### PR TITLE
ci(automerge): grant actions write permission to automerge workflows

### DIFF
--- a/.github/workflows/tailor-automerge.yml
+++ b/.github/workflows/tailor-automerge.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 

--- a/swatches/.github/workflows/tailor-automerge.yml
+++ b/swatches/.github/workflows/tailor-automerge.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
- Add 'actions: write' permission to:
  - .github/workflows/tailor-automerge.yml
  - swatches/.github/workflows/tailor-automerge.yml
- Allow automerge workflow steps that require write access to actions

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 📦 Packaging (updates the packaging)

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have tested my changes and confirmed there are no regressions
- [ ] I have confirmed my changes generate no new warnings or errors