### PR TITLE
feat(measure): implement phase 1 health classification for README and LICENSE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,8 @@ tailor/
 - Test swatch embedding and config parsing without network access
 - Commands that call `gh` should have their external calls abstracted behind interfaces for testability
 - `measure` is purely local and needs no mocking
+- `measure` emits `warning` results for two local health diagnostics: missing `README.md` (not managed by tailor) and `LICENSE` files containing unresolved placeholder tokens (e.g. `[year]`, `[fullname]`)
+- `README.md` is checked by exact path at the project root; it is a local diagnostic, not a swatch or config-diff item
 
 ## Key implementation details
 
@@ -78,6 +80,7 @@ tailor/
 - `labels` is a top-level config section with its own API layer (`internal/gh/labels.go`) and alter layer (`internal/alter/labels.go`), separate from repository settings
 - `validate.go` includes enum validation for `default_workflow_permissions` ("read"|"write"), topic format validation (lowercase alphanumeric start, max 50 chars, lowercase alphanumerics and hyphens only), and label validation (name length, hex colour, description length, duplicate detection)
 - Dry-run output uses dynamically computed label width for `baste` (accommodates trigger annotations) and fixed 16 chars for `measure`
+- `measure` output order: `missing`, `warning`, `present`, then config-diff categories (`not-configured`, `config-only`, `mode-differs`)
 - Triggered swatch output includes annotation, e.g. `would deploy (triggered: allow_auto_merge):`
 - Branch protection (classic rules and rulesets) is out of scope: it requires `Administration: write`, which `GITHUB_TOKEN` cannot hold, and branch protection rarely drifts for the solo-dev and small-team audience Tailor targets
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ tailor fit .                  # Create .tailor.yml
 tailor alter                  # Apply swatches and settings
 ```
 
-`measure` checks which community health files are present or missing. `fit .` works in an existing directory without error. If the project has a GitHub remote, `fit` reads the live repository settings so it preserves anything already configured.
+`measure` checks which community health files are present, missing, or need attention. It warns when `README.md` is absent or when `LICENSE` contains unresolved placeholders. `fit .` works in an existing directory without error. If the project has a GitHub remote, `fit` reads the live repository settings so it preserves anything already configured.
 
 Edit `.tailor.yml` to add swatches or change alteration modes, then run `alter`. Set `alteration: never` on any swatch you want tailor to skip.
 
@@ -325,6 +325,8 @@ tailor measure
 
 ```
 missing:        .github/FUNDING.yml
+warning:        LICENSE (contains unresolved placeholders)
+warning:        README.md (not managed by tailor)
 present:        CODE_OF_CONDUCT.md
 not-configured: .github/dependabot.yml
 mode-differs:   SECURITY.md          (config: first-fit, default: always)
@@ -333,6 +335,7 @@ mode-differs:   SECURITY.md          (config: first-fit, default: always)
 | Status | Meaning |
 |--------|---------|
 | `missing` | Health file does not exist on disk |
+| `warning` | Health diagnostic needing attention (missing `README.md` or unresolved licence placeholders) |
 | `present` | Health file exists on disk |
 | `not-configured` | Default swatch not in `.tailor.yml` |
 | `config-only` | Swatch in `.tailor.yml` not in the built-in default set |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -324,8 +324,9 @@ missing:        .github/dependabot.yml
 missing:        .github/pull_request_template.md
 missing:        CONTRIBUTING.md
 missing:        SUPPORT.md
+warning:        LICENSE (contains unresolved placeholders)
+warning:        README.md (not managed by tailor)
 present:        CODE_OF_CONDUCT.md
-present:        LICENSE
 present:        SECURITY.md
 
 No .tailor.yml found. Run `tailor fit <path>` to initialise, or create `.tailor.yml` manually to enable configuration alignment checks.
@@ -335,7 +336,7 @@ No .tailor.yml found. Run `tailor fit <path>` to initialise, or create `.tailor.
 
 ```
 missing:        CONTRIBUTING.md
-present:        LICENSE
+warning:        LICENSE (contains unresolved placeholders)
 present:        SECURITY.md
 not-configured: .github/dependabot.yml
 config-only:    some-custom-swatch.yml
@@ -344,14 +345,17 @@ mode-differs:   SECURITY.md          (config: first-fit, default: always)
 
 Category definitions:
 - `missing` - health file does not exist on disk
+- `warning` - health diagnostic that requires attention but is not a missing swatch. Two cases are recognised: `LICENSE` exists but contains unresolved placeholder tokens (e.g. `[year]`, `[fullname]`, `{project}`), and `README.md` is absent from the project root. A warned path appears once in the output and does not also appear as `present`
 - `present` - health file exists on disk
 - `not-configured` - default swatch whose destination is not covered by any entry in `.tailor.yml`; the default swatch will not be applied until added
 - `config-only` - swatch in `.tailor.yml` whose destination is not covered by any entry in the built-in default set. This arises when a swatch is removed from the built-in defaults in a newer tailor release but the project's `.tailor.yml` still references it. `alter` will reject unrecognised swatch paths, so this category serves as a diagnostic hint that `.tailor.yml` needs updating
 - `mode-differs` - swatch whose destination appears in both `.tailor.yml` and the default set, but with a different alteration mode; the inline annotation shows both values
 
-Output order: `missing`, `present`, `not-configured`, `config-only`, `mode-differs`. Within each category, entries are sorted lexicographically by destination path. The category label is padded to a fixed width of 16 characters (the length of `not-configured: `) for consistent column alignment. For `mode-differs` entries, the annotation (e.g. `(config: first-fit, default: always)`) is separated from the destination path by a single space; no additional fixed column alignment is applied to the annotation. Health file checks are always performed and reported regardless of whether `.tailor.yml` is present; config-diff categories (`not-configured`, `config-only`, `mode-differs`) are shown only when `.tailor.yml` is present.
+Output order: `missing`, `warning`, `present`, `not-configured`, `config-only`, `mode-differs`. Within each category, entries are sorted lexicographically by destination path. The category label is padded to a fixed width of 16 characters (the length of `not-configured: `) for consistent column alignment. For `warning` entries, the detail annotation (e.g. `(contains unresolved placeholders)`) is separated from the path by a single space, following the same annotation style as `mode-differs`. For `mode-differs` entries, the annotation (e.g. `(config: first-fit, default: always)`) is separated from the destination path by a single space; no additional fixed column alignment is applied to the annotation. Health file checks are always performed and reported regardless of whether `.tailor.yml` is present; config-diff categories (`not-configured`, `config-only`, `mode-differs`) are shown only when `.tailor.yml` is present.
 
-The `present`/`missing` check covers health swatches only. The config-diff check (`config-only`, `not-configured`, `mode-differs`) compares against the full default swatch set (both health and development swatches), since `.tailor.yml` covers all swatches.
+`README.md` is a local health diagnostic, not a swatch or config-diff item. It is checked by exact path at the project root only. `README`, `README.rst`, and other variants do not satisfy the check. The `README.md` warning is not emitted when the file exists. Licence placeholder detection scans for `\[[^\]]+\]` and `\{[^}]+\}` patterns, covering GitHub licence template tokens such as `[year]`, `[fullname]`, `[yyyy]`, `[name of copyright owner]`, and `{project}`. The check runs only when `LICENSE` exists on disk; an absent `LICENSE` stays in the `missing` category.
+
+The `present`/`missing`/`warning` check covers health swatches, `LICENSE`, and `README.md`. The config-diff check (`config-only`, `not-configured`, `mode-differs`) compares against the full default swatch set (both health and development swatches), since `.tailor.yml` covers all swatches.
 
 ### `docket`
 

--- a/internal/measure/format.go
+++ b/internal/measure/format.go
@@ -18,7 +18,11 @@ func FormatOutput(health []HealthResult, diff []DiffResult, hasConfig bool) stri
 	var b strings.Builder
 
 	for _, r := range health {
-		fmt.Fprintf(&b, "%-*s%s\n", labelWidth, r.Status.Label(), r.Path)
+		line := r.Path
+		if r.Detail != "" {
+			line += " " + r.Detail
+		}
+		fmt.Fprintf(&b, "%-*s%s\n", labelWidth, r.Status.Label(), line)
 	}
 
 	for _, r := range diff {

--- a/internal/measure/format_test.go
+++ b/internal/measure/format_test.go
@@ -14,8 +14,9 @@ func TestFormatOutputWithoutConfig(t *testing.T) {
 		{Path: ".github/pull_request_template.md", Status: Missing},
 		{Path: "CONTRIBUTING.md", Status: Missing},
 		{Path: "SUPPORT.md", Status: Missing},
+		{Path: "LICENSE", Status: Warning, Detail: "(contains unresolved placeholders)"},
+		{Path: "README.md", Status: Warning, Detail: "(not managed by tailor)"},
 		{Path: "CODE_OF_CONDUCT.md", Status: Present},
-		{Path: "LICENSE", Status: Present},
 		{Path: "SECURITY.md", Status: Present},
 	}
 
@@ -28,8 +29,9 @@ func TestFormatOutputWithoutConfig(t *testing.T) {
 		"missing:        .github/pull_request_template.md\n" +
 		"missing:        CONTRIBUTING.md\n" +
 		"missing:        SUPPORT.md\n" +
+		"warning:        LICENSE (contains unresolved placeholders)\n" +
+		"warning:        README.md (not managed by tailor)\n" +
 		"present:        CODE_OF_CONDUCT.md\n" +
-		"present:        LICENSE\n" +
 		"present:        SECURITY.md\n" +
 		"\n" +
 		"No .tailor.yml found. Run `tailor fit <path>` to initialise, or create `.tailor.yml` manually to enable configuration alignment checks.\n"
@@ -73,6 +75,7 @@ func TestFormatOutputPaddingWidth(t *testing.T) {
 		width int
 	}{
 		{"missing:", 16},
+		{"warning:", 16},
 		{"present:", 16},
 		{"not-configured:", 16},
 		{"config-only:", 16},

--- a/internal/measure/health.go
+++ b/internal/measure/health.go
@@ -2,7 +2,9 @@ package measure
 
 import (
 	"cmp"
+	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 
 	"github.com/wimpysworld/tailor/internal/fsutil"
@@ -14,21 +16,38 @@ type HealthStatus string
 
 const (
 	Missing HealthStatus = "missing"
+	Warning HealthStatus = "warning"
 	Present HealthStatus = "present"
 )
 
 // Label returns the status string with a trailing colon, suitable for formatted output.
 func (s HealthStatus) Label() string { return string(s) + ":" }
 
-// HealthResult pairs a path with its on-disk status.
+// HealthResult pairs a path with its on-disk status and optional detail.
 type HealthResult struct {
 	Path   string
 	Status HealthStatus
+	Detail string
 }
 
-// CheckHealth checks whether each health swatch path and the LICENSE file
-// exist in dir. Returns results sorted lexicographically by path within each
-// status group (missing first, then present).
+// placeholderRe matches unresolved bracket or brace tokens in licence templates,
+// such as [year], [fullname], [yyyy], [name of copyright owner], or {project}.
+var placeholderRe = regexp.MustCompile(`\[[^\]]+\]|\{[^}]+\}`)
+
+// hasUnresolvedPlaceholders reports whether data contains any bracket or brace
+// tokens typical of GitHub licence templates.
+func hasUnresolvedPlaceholders(data []byte) bool {
+	return placeholderRe.Match(data)
+}
+
+// readmeFile is the exact filename checked as a local health diagnostic.
+const readmeFile = "README.md"
+
+// CheckHealth checks whether each health swatch path, the LICENSE file, and
+// README.md exist in dir. LICENSE files containing unresolved placeholder
+// tokens are reported as warnings rather than present. A missing README.md
+// is reported as a warning. Returns results sorted lexicographically by path
+// within each status group (missing, warning, present).
 func CheckHealth(dir string) []HealthResult {
 	healthSwatches := swatch.HealthSwatches()
 	paths := make([]string, 0, len(healthSwatches)+1)
@@ -37,22 +56,46 @@ func CheckHealth(dir string) []HealthResult {
 	}
 	paths = append(paths, swatch.LicenseDestination)
 
-	var missing, present []HealthResult
+	var missing, warning, present []HealthResult
 	for _, p := range paths {
 		fullPath := filepath.Join(dir, p)
-		if fsutil.FileExists(fullPath) {
-			present = append(present, HealthResult{Path: p, Status: Present})
-		} else {
+		if !fsutil.FileExists(fullPath) {
 			missing = append(missing, HealthResult{Path: p, Status: Missing})
+			continue
 		}
+		if p == swatch.LicenseDestination {
+			data, err := os.ReadFile(fullPath)
+			if err == nil && hasUnresolvedPlaceholders(data) {
+				warning = append(warning, HealthResult{
+					Path:   p,
+					Status: Warning,
+					Detail: "(contains unresolved placeholders)",
+				})
+				continue
+			}
+		}
+		present = append(present, HealthResult{Path: p, Status: Present})
 	}
 
-	slices.SortFunc(missing, func(a, b HealthResult) int {
-		return cmp.Compare(a.Path, b.Path)
-	})
-	slices.SortFunc(present, func(a, b HealthResult) int {
-		return cmp.Compare(a.Path, b.Path)
-	})
+	// README.md is a local diagnostic, not a swatch. Warn when absent.
+	if !fsutil.FileExists(filepath.Join(dir, readmeFile)) {
+		warning = append(warning, HealthResult{
+			Path:   readmeFile,
+			Status: Warning,
+			Detail: "(not managed by tailor)",
+		})
+	}
 
-	return append(missing, present...)
+	sortByPath := func(a, b HealthResult) int {
+		return cmp.Compare(a.Path, b.Path)
+	}
+	slices.SortFunc(missing, sortByPath)
+	slices.SortFunc(warning, sortByPath)
+	slices.SortFunc(present, sortByPath)
+
+	results := make([]HealthResult, 0, len(missing)+len(warning)+len(present))
+	results = append(results, missing...)
+	results = append(results, warning...)
+	results = append(results, present...)
+	return results
 }

--- a/internal/measure/health_test.go
+++ b/internal/measure/health_test.go
@@ -12,11 +12,18 @@ func TestCheckHealthEmptyDir(t *testing.T) {
 	dir := t.TempDir()
 	results := CheckHealth(dir)
 
-	if len(results) != 11 {
-		t.Fatalf("CheckHealth() returned %d results, want 11", len(results))
+	// 10 health swatches + LICENSE = 11 missing, plus 1 README.md warning = 12
+	if len(results) != 12 {
+		t.Fatalf("CheckHealth() returned %d results, want 12", len(results))
 	}
 
 	for _, r := range results {
+		if r.Path == "README.md" {
+			if r.Status != Warning {
+				t.Errorf("README.md: status = %q, want %q", r.Status, Warning)
+			}
+			continue
+		}
 		if r.Status != Missing {
 			t.Errorf("destination %q: status = %q, want %q", r.Path, r.Status, Missing)
 		}
@@ -26,11 +33,12 @@ func TestCheckHealthEmptyDir(t *testing.T) {
 func TestCheckHealthAllPresent(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create all 11 health check files.
+	// Create all 11 health check files plus README.md.
 	files := []string{
 		"CODE_OF_CONDUCT.md",
 		"CONTRIBUTING.md",
 		"LICENSE",
+		"README.md",
 		"SECURITY.md",
 		"SUPPORT.md",
 		".github/FUNDING.yml",
@@ -46,6 +54,7 @@ func TestCheckHealthAllPresent(t *testing.T) {
 
 	results := CheckHealth(dir)
 
+	// 11 present, no README.md warning because it exists
 	if len(results) != 11 {
 		t.Fatalf("CheckHealth() returned %d results, want 11", len(results))
 	}
@@ -67,16 +76,20 @@ func TestCheckHealthMixedPresence(t *testing.T) {
 
 	results := CheckHealth(dir)
 
-	if len(results) != 11 {
-		t.Fatalf("CheckHealth() returned %d results, want 11", len(results))
+	// 8 missing + 1 warning (README.md) + 3 present = 12
+	if len(results) != 12 {
+		t.Fatalf("CheckHealth() returned %d results, want 12", len(results))
 	}
 
 	missing := 0
+	warning := 0
 	present := 0
 	for _, r := range results {
 		switch r.Status {
 		case Missing:
 			missing++
+		case Warning:
+			warning++
 		case Present:
 			present++
 		default:
@@ -87,6 +100,9 @@ func TestCheckHealthMixedPresence(t *testing.T) {
 	if missing != 8 {
 		t.Errorf("missing count = %d, want 8", missing)
 	}
+	if warning != 1 {
+		t.Errorf("warning count = %d, want 1", warning)
+	}
 	if present != 3 {
 		t.Errorf("present count = %d, want 3", present)
 	}
@@ -95,28 +111,33 @@ func TestCheckHealthMixedPresence(t *testing.T) {
 func TestCheckHealthSortOrder(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create just LICENSE so we get a mix.
+	// Create just LICENSE so we get a mix of missing, warning, and present.
 	testutil.CreateFile(t, dir, "LICENSE")
 
 	results := CheckHealth(dir)
 
-	// All missing entries come first, then all present entries.
-	seenPresent := false
+	// Verify group order: all missing, then all warning, then all present.
+	statusOrder := map[HealthStatus]int{Missing: 0, Warning: 1, Present: 2}
+	maxSeen := 0
 	for _, r := range results {
-		if r.Status == Present {
-			seenPresent = true
+		order := statusOrder[r.Status]
+		if order < maxSeen {
+			t.Errorf("entry %q (%s) appeared after a later status group", r.Path, r.Status)
 		}
-		if r.Status == Missing && seenPresent {
-			t.Errorf("missing entry %q appeared after present entries", r.Path)
+		if order > maxSeen {
+			maxSeen = order
 		}
 	}
 
 	// Within each group, destinations are sorted lexicographically.
-	var missingDests, presentDests []string
+	var missingDests, warningDests, presentDests []string
 	for _, r := range results {
-		if r.Status == Missing {
+		switch r.Status {
+		case Missing:
 			missingDests = append(missingDests, r.Path)
-		} else {
+		case Warning:
+			warningDests = append(warningDests, r.Path)
+		case Present:
 			presentDests = append(presentDests, r.Path)
 		}
 	}
@@ -124,6 +145,11 @@ func TestCheckHealthSortOrder(t *testing.T) {
 	for i := 1; i < len(missingDests); i++ {
 		if missingDests[i] < missingDests[i-1] {
 			t.Errorf("missing entries not sorted: %q before %q", missingDests[i-1], missingDests[i])
+		}
+	}
+	for i := 1; i < len(warningDests); i++ {
+		if warningDests[i] < warningDests[i-1] {
+			t.Errorf("warning entries not sorted: %q before %q", warningDests[i-1], warningDests[i])
 		}
 	}
 	for i := 1; i < len(presentDests); i++ {
@@ -152,4 +178,131 @@ func TestCheckHealthDirectoryNotCountedAsFile(t *testing.T) {
 		}
 	}
 	t.Error("LICENSE not found in results")
+}
+
+func TestCheckHealthLicenseWithPlaceholders(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a LICENSE with unresolved placeholders.
+	content := "MIT License\n\nCopyright (c) [year] [fullname]\n"
+	if err := os.WriteFile(filepath.Join(dir, "LICENSE"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	results := CheckHealth(dir)
+
+	for _, r := range results {
+		if r.Path == "LICENSE" {
+			if r.Status != Warning {
+				t.Errorf("LICENSE with placeholders: status = %q, want %q", r.Status, Warning)
+			}
+			if r.Detail != "(contains unresolved placeholders)" {
+				t.Errorf("LICENSE detail = %q, want %q", r.Detail, "(contains unresolved placeholders)")
+			}
+			return
+		}
+	}
+	t.Error("LICENSE not found in results")
+}
+
+func TestCheckHealthLicenseResolved(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a LICENSE without placeholders.
+	content := "MIT License\n\nCopyright (c) 2024 Jane Smith\n"
+	if err := os.WriteFile(filepath.Join(dir, "LICENSE"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	results := CheckHealth(dir)
+
+	for _, r := range results {
+		if r.Path == "LICENSE" {
+			if r.Status != Present {
+				t.Errorf("resolved LICENSE: status = %q, want %q", r.Status, Present)
+			}
+			if r.Detail != "" {
+				t.Errorf("resolved LICENSE: detail = %q, want empty", r.Detail)
+			}
+			return
+		}
+	}
+	t.Error("LICENSE not found in results")
+}
+
+func TestCheckHealthLicenseWithBracePlaceholders(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a LICENSE with curly-brace placeholders.
+	content := "Apache License 2.0\n\nCopyright {project}\n"
+	if err := os.WriteFile(filepath.Join(dir, "LICENSE"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	results := CheckHealth(dir)
+
+	for _, r := range results {
+		if r.Path == "LICENSE" {
+			if r.Status != Warning {
+				t.Errorf("LICENSE with brace placeholders: status = %q, want %q", r.Status, Warning)
+			}
+			return
+		}
+	}
+	t.Error("LICENSE not found in results")
+}
+
+func TestCheckHealthReadmeMissing(t *testing.T) {
+	dir := t.TempDir()
+
+	results := CheckHealth(dir)
+
+	for _, r := range results {
+		if r.Path == "README.md" {
+			if r.Status != Warning {
+				t.Errorf("missing README.md: status = %q, want %q", r.Status, Warning)
+			}
+			if r.Detail != "(not managed by tailor)" {
+				t.Errorf("README.md detail = %q, want %q", r.Detail, "(not managed by tailor)")
+			}
+			return
+		}
+	}
+	t.Error("README.md not found in results")
+}
+
+func TestCheckHealthReadmePresent(t *testing.T) {
+	dir := t.TempDir()
+	testutil.CreateFile(t, dir, "README.md")
+
+	results := CheckHealth(dir)
+
+	for _, r := range results {
+		if r.Path == "README.md" {
+			t.Errorf("README.md should not appear in results when present, got status %q", r.Status)
+		}
+	}
+}
+
+func TestCheckHealthSingleResultPerPath(t *testing.T) {
+	dir := t.TempDir()
+
+	// LICENSE with placeholders should appear once as warning, not also as present.
+	content := "MIT License\n\nCopyright (c) [year] [fullname]\n"
+	if err := os.WriteFile(filepath.Join(dir, "LICENSE"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	results := CheckHealth(dir)
+
+	pathCount := make(map[string]int)
+	for _, r := range results {
+		pathCount[r.Path]++
+	}
+
+	for path, count := range pathCount {
+		if count > 1 {
+			t.Errorf("path %q appears %d times, want 1", path, count)
+		}
+	}
 }

--- a/internal/measure/measure_test.go
+++ b/internal/measure/measure_test.go
@@ -1,6 +1,8 @@
 package measure
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -23,8 +25,8 @@ func buildDefaultConfigYAML() string {
 }
 
 // TestIntegrationEmptyDirNoConfig exercises the full measure pipeline against
-// an empty directory with no config file. All 11 health files are missing and
-// the advisory message is printed after a blank line.
+// an empty directory with no config file. All 11 health files are missing,
+// README.md appears as a warning, and the advisory message is printed.
 func TestIntegrationEmptyDirNoConfig(t *testing.T) {
 	dir := t.TempDir()
 
@@ -46,6 +48,7 @@ func TestIntegrationEmptyDirNoConfig(t *testing.T) {
 		"missing:        LICENSE\n" +
 		"missing:        SECURITY.md\n" +
 		"missing:        SUPPORT.md\n" +
+		"warning:        README.md (not managed by tailor)\n" +
 		"\n" +
 		"No .tailor.yml found. Run `tailor fit <path>` to initialise, or create `.tailor.yml` manually to enable configuration alignment checks.\n"
 
@@ -59,7 +62,7 @@ func TestIntegrationEmptyDirNoConfig(t *testing.T) {
 func TestIntegrationSomeHealthFilesNoConfig(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create three health files matching the spec example (lines 258-270).
+	// Create three health files.
 	testutil.CreateFile(t, dir, "CODE_OF_CONDUCT.md")
 	testutil.CreateFile(t, dir, "LICENSE")
 	testutil.CreateFile(t, dir, "SECURITY.md")
@@ -79,6 +82,7 @@ func TestIntegrationSomeHealthFilesNoConfig(t *testing.T) {
 		"missing:        .github/pull_request_template.md\n" +
 		"missing:        CONTRIBUTING.md\n" +
 		"missing:        SUPPORT.md\n" +
+		"warning:        README.md (not managed by tailor)\n" +
 		"present:        CODE_OF_CONDUCT.md\n" +
 		"present:        LICENSE\n" +
 		"present:        SECURITY.md\n" +
@@ -125,6 +129,7 @@ func TestIntegrationConfigMatchesDefaults(t *testing.T) {
 		"missing:        CODE_OF_CONDUCT.md\n" +
 		"missing:        CONTRIBUTING.md\n" +
 		"missing:        SUPPORT.md\n" +
+		"warning:        README.md (not managed by tailor)\n" +
 		"present:        LICENSE\n" +
 		"present:        SECURITY.md\n"
 
@@ -134,8 +139,8 @@ func TestIntegrationConfigMatchesDefaults(t *testing.T) {
 }
 
 // TestIntegrationConfigWithAllDiffCategories exercises the full pipeline with
-// a config that produces entries in all five output categories: missing,
-// present, not-configured, config-only, and mode-differs.
+// a config that produces entries in all six output categories: missing,
+// warning, present, not-configured, config-only, and mode-differs.
 func TestIntegrationConfigWithAllDiffCategories(t *testing.T) {
 	dir := t.TempDir()
 
@@ -181,8 +186,6 @@ func TestIntegrationConfigWithAllDiffCategories(t *testing.T) {
 
 	got := FormatOutput(health, diff, hasConfig)
 
-	// This output matches the spec example format (lines 275-281) adapted
-	// to the specific files present in our temp directory.
 	want := "" +
 		"missing:        .github/FUNDING.yml\n" +
 		"missing:        .github/ISSUE_TEMPLATE/bug_report.yml\n" +
@@ -193,6 +196,7 @@ func TestIntegrationConfigWithAllDiffCategories(t *testing.T) {
 		"missing:        CODE_OF_CONDUCT.md\n" +
 		"missing:        CONTRIBUTING.md\n" +
 		"missing:        SUPPORT.md\n" +
+		"warning:        README.md (not managed by tailor)\n" +
 		"present:        LICENSE\n" +
 		"present:        SECURITY.md\n" +
 		"not-configured: .github/dependabot.yml\n" +
@@ -205,9 +209,9 @@ func TestIntegrationConfigWithAllDiffCategories(t *testing.T) {
 }
 
 // TestIntegrationOutputOrderAndPadding verifies that entries appear in the
-// correct category order (missing, present, not-configured, config-only,
-// mode-differs), that labels are padded to exactly 16 characters, and that
-// entries within each category are sorted lexicographically by destination.
+// correct category order (missing, warning, present, not-configured,
+// config-only, mode-differs), that labels are padded to exactly 16 characters,
+// and that entries within each category are sorted lexicographically.
 func TestIntegrationOutputOrderAndPadding(t *testing.T) {
 	dir := t.TempDir()
 
@@ -256,10 +260,6 @@ func TestIntegrationOutputOrderAndPadding(t *testing.T) {
 
 	got := FormatOutput(health, diff, hasConfig)
 
-	// Build expected output verifying:
-	// 1. Category order: missing, present, not-configured, config-only, mode-differs
-	// 2. Lexicographic sort within each category
-	// 3. 16-char fixed-width label padding
 	want := "" +
 		// missing (sorted lexicographically)
 		"missing:        .github/FUNDING.yml\n" +
@@ -270,6 +270,8 @@ func TestIntegrationOutputOrderAndPadding(t *testing.T) {
 		"missing:        .github/pull_request_template.md\n" +
 		"missing:        CODE_OF_CONDUCT.md\n" +
 		"missing:        SUPPORT.md\n" +
+		// warning (sorted lexicographically)
+		"warning:        README.md (not managed by tailor)\n" +
 		// present (sorted lexicographically)
 		"present:        CONTRIBUTING.md\n" +
 		"present:        LICENSE\n" +
@@ -303,5 +305,42 @@ func TestIntegrationOutputOrderAndPadding(t *testing.T) {
 		if lastLabelChar != ' ' && lastLabelChar != ':' {
 			t.Errorf("label padding violated, expected space or colon at position 15: %q", line)
 		}
+	}
+}
+
+// TestIntegrationLicenseWithPlaceholders verifies that a LICENSE containing
+// unresolved placeholders appears as warning, not present.
+func TestIntegrationLicenseWithPlaceholders(t *testing.T) {
+	dir := t.TempDir()
+
+	content := "MIT License\n\nCopyright (c) [year] [fullname]\n"
+	if err := os.WriteFile(filepath.Join(dir, "LICENSE"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	testutil.CreateFile(t, dir, "README.md")
+
+	health := CheckHealth(dir)
+	got := FormatOutput(health, nil, false)
+
+	if !strings.Contains(got, "warning:        LICENSE (contains unresolved placeholders)") {
+		t.Errorf("expected LICENSE warning line in output:\n%s", got)
+	}
+	if strings.Contains(got, "present:        LICENSE") {
+		t.Errorf("LICENSE with placeholders should not appear as present:\n%s", got)
+	}
+}
+
+// TestIntegrationReadmePresent verifies that no README.md warning appears
+// when README.md exists.
+func TestIntegrationReadmePresent(t *testing.T) {
+	dir := t.TempDir()
+
+	testutil.CreateFile(t, dir, "README.md")
+
+	health := CheckHealth(dir)
+	got := FormatOutput(health, nil, false)
+
+	if strings.Contains(got, "README.md") {
+		t.Errorf("README.md should not appear in output when present:\n%s", got)
 	}
 }


### PR DESCRIPTION
# Description

- Add health classification based on README and LICENSE presence
- Implement detection logic and warnings in health package
- Extend format output to include health check results
- Add comprehensive test coverage for health checks and formatting

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions