### PR TITLE
feat: migrate to Blue Oak Model License 1.0.0

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: moderate
-          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MIT, MPL-2.0, 0BSD, BlueOak-1.0.0, Unlicense
+          allow-licenses: 0BSD, AFL-2.0, AFL-2.1, AFL-3.0, ANTLR-PD, ANTLR-PD-fallback, Apache-1.0, Apache-1.1, Apache-2.0, Artistic-2.0, BlueOak-1.0.0, BSD-1-Clause, BSD-2-Clause, BSD-2-Clause-FreeBSD, BSD-2-Clause-NetBSD, BSD-2-Clause-Patent, BSD-2-Clause-Views, BSD-3-Clause, BSD-3-Clause-Attribution, BSD-3-Clause-Clear, BSD-3-Clause-HP, BSD-3-Clause-LBNL, BSD-3-Clause-Modification, BSD-3-Clause-No-Nuclear-License-2014, BSD-3-Clause-No-Nuclear-Warranty, BSD-3-Clause-Open-MPI, BSD-3-Clause-Sun, BSD-4-Clause, BSD-4-Clause-Shortened, BSD-4-Clause-UC, BSD-Source-Code, BSL-1.0, bzip2-1.0.5, bzip2-1.0.6, CC0-1.0, CNRI-Python, CNRI-Python-GPL-Compatible, curl, ECL-2.0, FTL, HPND-Fenneberg-Livingston, HPND-sell-regexpr, HTMLTIDY, ICU, ImageMagick, Info-ZIP, Intel, Intel-ACPI, ISC, JasPer-2.0, Libpng, libpng-2.0, libtiff, Linux-OpenIB, LZMA-SDK-9.22, MIT, MIT-0, MIT-advertising, MIT-CMU, MIT-Modern-Variant, MIT-open-group, MITNFA, MS-PL, MulanPSL-1.0, MulanPSL-2.0, Multics, NCSA, Net-SNMP, NetCDF, NIST-Software, NTP, OLDAP-2.7, OLDAP-2.8, OpenSSL, PostgreSQL, PSF-2.0, SGI-B-2.0, SHL-0.5, Spencer-99, SunPro, TCL, TCP-wrappers, UCAR, Unicode-DFS-2015, Unicode-DFS-2016, UnixCrypt, Unlicense, UPL-1.0, W3C, X11, XFree86-1.1, Xnet, Zlib, zlib-acknowledgement, ZPL-2.0, ZPL-2.1
           fail-on-scopes: runtime
           comment-summary-in-pr: on-failure
 

--- a/.tailor.yml
+++ b/.tailor.yml
@@ -1,5 +1,5 @@
 # Refitted by tailor on 2026-03-07
-license: MIT
+license: BlueOak-1.0.0
 
 repository:
   description: Ready-to-wear project templates for GitHub repositories 👔

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,55 @@
-MIT License
+# Blue Oak Model License
 
-Copyright (c) [year] [fullname]
+Version 1.0.0
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+## Purpose
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+This license gives everyone as much permission to work with
+this software as possible, while protecting contributors
+from liability.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+## Acceptance
+
+In order to receive this license, you must agree to its
+rules.  The rules of this license are both obligations
+under that agreement and conditions to your license.
+You must not do anything with this software that triggers
+a rule that you cannot or will not follow.
+
+## Copyright
+
+Each contributor licenses you to do everything with this
+software that would otherwise infringe that contributor's
+copyright in it.
+
+## Notices
+
+You must ensure that everyone who gets a copy of
+any part of this software from you, with or without
+changes, also gets the text of this license or a link to
+https://blueoakcouncil.org/license/1.0.0.
+
+## Excuse
+
+If anyone notifies you in writing that you have not
+complied with Notices, you can keep your
+license by taking all practical steps to comply within 30
+days after the notice.  If you do not do so, your license
+ends immediately.
+
+## Patent
+
+Each contributor licenses you to do everything with this
+software that would otherwise infringe any patent claims
+they can license or become able to license.
+
+## Reliability
+
+No contributor can revoke this license.
+
+## No Liability
+
+As far as the law allows, this software comes as is,
+without any warranty or condition, and no contributor
+will be liable to anyone for any damages related to this
+software or this license, under any kind of legal claim.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd my-project
 tailor alter
 ```
 
-`fit` creates the directory and writes `.tailor.yml` with the full default swatch set. `alter` copies the files and applies repository settings. The default licence is MIT.
+`fit` creates the directory and writes `.tailor.yml` with the full default swatch set. `alter` copies the files and applies repository settings. The default licence is BlueOak-1.0.0.
 
 ```bash
 tailor fit ./my-project --license=Apache-2.0
@@ -97,7 +97,7 @@ All state lives in `.tailor.yml` with four sections: `license`, `repository`, `l
 
 ```yaml
 # Initially fitted by tailor on 2026-03-04
-license: MIT
+license: BlueOak-1.0.0
 
 repository:
   topics:

--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -31,7 +31,7 @@ var cli struct {
 // FitCmd creates a new project directory with a default .tailor.yml.
 type FitCmd struct {
 	Path        string `arg:"" help:"Project directory to create."`
-	License     string `help:"Licence identifier." default:"MIT"`
+	License     string `help:"Licence identifier." default:"BlueOak-1.0.0"`
 	Description string `help:"Repository description."`
 }
 

--- a/cmd/tailor/main_test.go
+++ b/cmd/tailor/main_test.go
@@ -18,7 +18,7 @@ func TestFitNewDirectoryDefaultConfig(t *testing.T) {
 
 	dir := filepath.Join(t.TempDir(), "new-project")
 
-	cmd := FitCmd{Path: dir, License: "MIT"}
+	cmd := FitCmd{Path: dir, License: "BlueOak-1.0.0"}
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Run() error: %v", err)
 	}
@@ -31,8 +31,8 @@ func TestFitNewDirectoryDefaultConfig(t *testing.T) {
 	content := string(data)
 
 	// Verify license.
-	if !strings.Contains(content, "license: MIT") {
-		t.Error("config missing 'license: MIT'")
+	if !strings.Contains(content, "license: BlueOak-1.0.0") {
+		t.Error("config missing 'license: BlueOak-1.0.0'")
 	}
 
 	// Verify 17 swatches are present (count "- path:" occurrences).
@@ -79,7 +79,7 @@ func TestFitExistingDirectoryWithoutConfig(t *testing.T) {
 
 	dir := t.TempDir()
 
-	cmd := FitCmd{Path: dir, License: "MIT"}
+	cmd := FitCmd{Path: dir, License: "BlueOak-1.0.0"}
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Run() error: %v", err)
 	}
@@ -97,11 +97,11 @@ func TestFitExistingDirectoryWithConfigError(t *testing.T) {
 	dir := t.TempDir()
 
 	// Pre-create .tailor.yml.
-	if err := os.WriteFile(filepath.Join(dir, ".tailor.yml"), []byte("license: MIT\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ".tailor.yml"), []byte("license: BlueOak-1.0.0\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	cmd := FitCmd{Path: dir, License: "MIT"}
+	cmd := FitCmd{Path: dir, License: "BlueOak-1.0.0"}
 	err := cmd.Run()
 	if err == nil {
 		t.Fatal("Run() expected error, got nil")
@@ -143,7 +143,7 @@ func TestFitDescriptionNoRepoContext(t *testing.T) {
 
 	dir := filepath.Join(t.TempDir(), "with-desc")
 
-	cmd := FitCmd{Path: dir, License: "MIT", Description: "My project description"}
+	cmd := FitCmd{Path: dir, License: "BlueOak-1.0.0", Description: "My project description"}
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Run() error: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestFitNoRepoContextUsesDefaults(t *testing.T) {
 
 	dir := filepath.Join(t.TempDir(), "defaults")
 
-	cmd := FitCmd{Path: dir, License: "MIT"}
+	cmd := FitCmd{Path: dir, License: "BlueOak-1.0.0"}
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Run() error: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestFitAuthFailure(t *testing.T) {
 
 	dir := filepath.Join(t.TempDir(), "auth-fail")
 
-	cmd := FitCmd{Path: dir, License: "MIT"}
+	cmd := FitCmd{Path: dir, License: "BlueOak-1.0.0"}
 	err := cmd.Run()
 	if err == nil {
 		t.Fatal("Run() expected error, got nil")

--- a/docs/BLUEOAK-LICENSE.md
+++ b/docs/BLUEOAK-LICENSE.md
@@ -1,0 +1,34 @@
+# Blue Oak 1.0.0
+
+`tailor` is licensed under [Blue Oak 1.0.0](https://blueoakcouncil.org/license/1.0.0) (`BlueOak-1.0.0`).
+
+## What Blue Oak Is
+
+Blue Oak 1.0.0 is a permissive open-source licence published in 2019 by the [Blue Oak Council](https://blueoakcouncil.org/), a group of lawyers and technologists who set out to write the clearest permissive licence possible. It carries OSI approval, an SPDX identifier (`BlueOak-1.0.0`), and full recognition by GitHub's licence detector.
+
+It grants the same core freedoms as MIT and BSD: use, copy, modify, merge, publish, distribute, sublicence, and sell. The difference is in the precision and readability of those grants.
+
+## Why Blue Oak Over MIT or BSD
+
+| Dimension | MIT | BSD-2-Clause / BSD-3-Clause | Blue Oak 1.0.0 |
+|---|---|---|---|
+| Patent grant | Implied at best | Implied at best | Explicit |
+| Irrevocability | Not stated | Not stated | Explicit |
+| Cure period | None | None | 30 days to remedy a notice violation before termination |
+| Notice requirement | Full licence text in every copy | Full licence text in every copy | Licence text or link to canonical URL |
+| Language | Archaic legal boilerplate | Archaic legal boilerplate | Plain, readable English |
+
+MIT and BSD have served the open-source ecosystem well for decades, but their texts were written before modern software distribution patterns and carry ambiguities that have required decades of case law and community interpretation to manage. Blue Oak addresses these gaps directly in the licence text itself.
+
+The explicit patent grant closes the gap that has always existed in MIT and BSD: contributors cannot grant a copyright licence and then assert a patent claim over the same code. The explicit irrevocability clause means contributors cannot later withdraw permission. The 30-day cure period protects users who make an honest mistake with attribution from immediate licence termination. The notice requirement acknowledges that embedding a full licence file is often impractical and accepts a URL as sufficient.
+
+## What This Means for Users
+
+Nothing changes in practice. Blue Oak 1.0.0 is a permissive licence. You can use `tailor` in proprietary software, modify it, redistribute it, and sublicence it. The only obligations are attribution and preserving the licence notice - identical in substance to what MIT and BSD require, and easier to satisfy.
+
+## Further Reading
+
+- [Blue Oak 1.0.0 licence text](https://blueoakcouncil.org/license/1.0.0)
+- [Blue Oak Council permissive licence list](https://blueoakcouncil.org/list)
+- [OSI approval record](https://opensource.org/licenses/BlueOak-1.0.0)
+- [Choose a Licence entry](https://choosealicense.com/licenses/blueoak-1.0.0/)

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -19,7 +19,7 @@ The `fit`, `alter`, and `baste` commands verify that a valid authentication toke
 
 ### New project
 
-`fit` creates the project directory and writes `.tailor.yml` with the full default swatch set in one command, with a `license: MIT` default. Use `--license=<id>` to select a different licence or `--license=none` to opt out. Change into `<path>`, then run `alter` to copy the swatch files, including the `.github/workflows/tailor.yml` workflow that handles weekly automated maintenance. The action opens a pull request whenever swatch content changes, keeping files current without manual intervention.
+`fit` creates the project directory and writes `.tailor.yml` with the full default swatch set in one command, with a `license: BlueOak-1.0.0` default. Use `--license=<id>` to select a different licence or `--license=none` to opt out. Change into `<path>`, then run `alter` to copy the swatch files, including the `.github/workflows/tailor.yml` workflow that handles weekly automated maintenance. The action opens a pull request whenever swatch content changes, keeping files current without manual intervention.
 
 ### Existing project
 
@@ -191,9 +191,9 @@ The default swatch set embedded in the binary is:
 - `.envrc`
 - `.tailor.yml`
 
-A `license` key is included in `.tailor.yml` by default (`license: MIT`). Use `--license=<id>` to select a different licence or `--license=none` to opt out entirely.
+A `license` key is included in `.tailor.yml` by default (`license: BlueOak-1.0.0`). Use `--license=<id>` to select a different licence or `--license=none` to opt out entirely.
 
-`--license=<id>` records the licence identifier in `.tailor.yml`. Defaults to `MIT` if not specified. `--license=none` records `license: none`, opting out of licence creation. The identifier is used to fetch licence text via the GitHub REST API (`GET /licenses/{id}`) at `alter` time; any licence supported by the GitHub API is valid. `fit` does not validate the identifier - validation is deferred to `alter`.
+`--license=<id>` records the licence identifier in `.tailor.yml`. Defaults to `BlueOak-1.0.0` if not specified. `--license=none` records `license: none`, opting out of licence creation. The identifier is used to fetch licence text via the GitHub REST API (`GET /licenses/{id}`) at `alter` time; any licence supported by the GitHub API is valid. `fit` does not validate the identifier - validation is deferred to `alter`.
 
 `--description=<text>` sets the `description` field in the `repository` section of `.tailor.yml`, overriding any value from GitHub. `fit` does not apply the description - it is applied at `alter` time.
 
@@ -202,7 +202,7 @@ A `license` key is included in `.tailor.yml` by default (`license: MIT`). Use `-
 When repository context exists, `fit` queries the live repository configuration via `GET /repos/{owner}/{repo}` and the separate endpoints for private vulnerability reporting, vulnerability alerts, automated security fixes, and Actions workflow permissions to populate the `repository` section with the project's current settings. This ensures that enabling tailor on an existing project does not inadvertently change features that are already configured (e.g. disabling wiki or discussions that are currently enabled). The `--description` flag takes precedence over the value from GitHub. `description` and `homepage` are omitted if empty. When no repository context exists (e.g. a brand-new project with no remote), the built-in defaults from the embedded swatch are used, with `description` and `homepage` normalised to nil by `DefaultConfig` so they are omitted from the generated config.
 
 ```bash
-# Default licence (MIT)
+# Default licence (BlueOak-1.0.0)
 tailor fit ./my-project
 
 # Explicit licence selection
@@ -250,7 +250,7 @@ Behaviour:
 - For `.github/ISSUE_TEMPLATE/config.yml`: substitutes `{{SUPPORT_URL}}` before writing. `{{SUPPORT_URL}}` is constructed at `alter` time as `https://github.com/<owner>/<name>/blob/HEAD/SUPPORT.md` from the repository context (owner/name). If no GitHub repository context exists, `{{SUPPORT_URL}}` is left unsubstituted in the written file.
 - For `.tailor.yml`: substitutes `{{HOMEPAGE_URL}}` before writing. `{{HOMEPAGE_URL}}` is constructed at `alter` time as `https://github.com/<owner>/<name>` from the repository context (owner/name). If no GitHub repository context exists, `{{HOMEPAGE_URL}}` is left unsubstituted in the written file.
 - With `--recut`: overwrites regardless of mode or existence, including `first-fit` swatches - `--recut` will overwrite a `first-fit` swatch file even if it exists and has been locally modified. Use with care. The licence file is exempt from `--recut` and is never overwritten regardless, because it is fetched content not an embedded swatch. For `.tailor.yml`, `--recut` overrides `first-fit` to `always` semantics like any other swatch - this means missing default swatches are appended, but existing entries are never modified or overwritten, because `always` for `.tailor.yml` means "append missing entries". When `--recut` writes a substituted swatch (e.g. `.github/FUNDING.yml`, `SECURITY.md`, `.github/ISSUE_TEMPLATE/config.yml`, `.tailor.yml`, `.github/workflows/tailor-automerge.yml`), the full token resolution pipeline runs and fresh values are substituted before writing.
-- If no `license` key is present in `.tailor.yml` (or its value is `none`) and no `LICENSE` file exists in the project root, emits a warning: "No licence file found and no licence configured. Add `license: MIT` (or another identifier) to `.tailor.yml` and run `tailor alter`." Warning only; does not block execution.
+- If no `license` key is present in `.tailor.yml` (or its value is `none`) and no `LICENSE` file exists in the project root, emits a warning: "No licence file found and no licence configured. Add `license: BlueOak-1.0.0` (or another identifier) to `.tailor.yml` and run `tailor alter`." Warning only; does not block execution.
 - Creates intermediate directories as needed before writing any swatch whose destination path requires directories that do not yet exist.
 - Never touches files not listed in `.tailor.yml`
 - Modifies files only; does not commit or push
@@ -431,11 +431,11 @@ Behaviour:
 
 `.tailor.yml` has four top-level sections: `license` (a string), `repository` (a map of GitHub repository settings), `labels` (a list of label entries with name, colour, and description), and `swatches` (a list of swatch entries). `path` values use the full path relative to `swatches/`, including the file extension where one exists. Extensionless files (e.g. `justfile`) are referenced as-is. The `repository` and `labels` sections are optional; if absent, their respective management is skipped.
 
-Default (with `--license=MIT`). The `license` key varies by flag (`MIT`, `Apache-2.0`, `none`, etc.) - the rest of the generated file is identical regardless of licence choice:
+Default (with `--license=BlueOak-1.0.0`). The `license` key varies by flag (`MIT`, `Apache-2.0`, `none`, etc.) - the rest of the generated file is identical regardless of licence choice:
 
 ```yaml
 # Initially fitted by tailor on 2026-03-02
-license: MIT
+license: BlueOak-1.0.0
 
 repository:
   description: ""

--- a/internal/alter/licence.go
+++ b/internal/alter/licence.go
@@ -22,7 +22,7 @@ func ProcessLicence(cfg *config.Config, dir string, mode ApplyMode, client *api.
 
 	if cfg.License == "" || cfg.License == "none" {
 		if !exists {
-			fmt.Fprintln(os.Stderr, "No licence file found and no licence configured. Add 'license: MIT' (or another identifier) to '.tailor.yml' and run 'tailor alter'.")
+			fmt.Fprintln(os.Stderr, "No licence file found and no licence configured. Add 'license: BlueOak-1.0.0' (or another identifier) to '.tailor.yml' and run 'tailor alter'.")
 		}
 		return nil, nil
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,7 +14,7 @@ import (
 
 // specYAML is the exact config body from the specification, minus the leading
 // comment which is not part of the data model.
-const specYAML = `license: MIT
+const specYAML = `license: BlueOak-1.0.0
 
 repository:
   has_wiki: false
@@ -91,8 +91,8 @@ func TestUnmarshalSpecYAML(t *testing.T) {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
-	if cfg.License != "MIT" {
-		t.Errorf("License = %q, want %q", cfg.License, "MIT")
+	if cfg.License != "BlueOak-1.0.0" {
+		t.Errorf("License = %q, want %q", cfg.License, "BlueOak-1.0.0")
 	}
 
 	if cfg.Repository == nil {

--- a/internal/config/generate_test.go
+++ b/internal/config/generate_test.go
@@ -25,14 +25,14 @@ func TestDefaultConfigMatchesEmbedded(t *testing.T) {
 		t.Fatalf("unmarshalling embedded config: %v", err)
 	}
 
-	got, err := DefaultConfig("MIT")
+	got, err := DefaultConfig("BlueOak-1.0.0")
 	if err != nil {
 		t.Fatalf("DefaultConfig() error: %v", err)
 	}
 
 	// License should be the value we passed, not the embedded one.
-	if got.License != "MIT" {
-		t.Errorf("License = %q, want %q", got.License, "MIT")
+	if got.License != "BlueOak-1.0.0" {
+		t.Errorf("License = %q, want %q", got.License, "BlueOak-1.0.0")
 	}
 
 	// Repository settings should match the embedded config exactly.
@@ -112,7 +112,7 @@ func TestDefaultConfigMatchesEmbedded(t *testing.T) {
 }
 
 func TestDefaultConfigSwatchCount(t *testing.T) {
-	cfg, err := DefaultConfig("MIT")
+	cfg, err := DefaultConfig("BlueOak-1.0.0")
 	if err != nil {
 		t.Fatalf("DefaultConfig() error: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestDefaultConfigSwatchCount(t *testing.T) {
 }
 
 func TestDefaultConfigSwatchOrder(t *testing.T) {
-	cfg, err := DefaultConfig("MIT")
+	cfg, err := DefaultConfig("BlueOak-1.0.0")
 	if err != nil {
 		t.Fatalf("DefaultConfig() error: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestMergeRepoSettings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &Config{
-				License: "MIT",
+				License: "BlueOak-1.0.0",
 				Repository: &model.RepositorySettings{
 					HasWiki:   ptr.Ptr(false),
 					HasIssues: ptr.Ptr(true),
@@ -264,7 +264,7 @@ func TestMergeRepoSettingsPreservesMergeCommitFields(t *testing.T) {
 		MergeCommitMessage: &mergeMessage,
 	}
 
-	cfg := &Config{License: "MIT"}
+	cfg := &Config{License: "BlueOak-1.0.0"}
 	MergeRepoSettings(cfg, live, "")
 
 	testutil.AssertStringPtr(t, cfg.Repository.MergeCommitTitle, false, "PR_TITLE", "merge_commit_title")
@@ -276,7 +276,7 @@ func TestDefaultConfigLicenseValues(t *testing.T) {
 		name    string
 		license string
 	}{
-		{name: "MIT", license: "MIT"},
+		{name: "BlueOak-1.0.0", license: "BlueOak-1.0.0"},
 		{name: "Apache-2.0", license: "Apache-2.0"},
 		{name: "none", license: "none"},
 	}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -18,8 +18,8 @@ func TestLoadValidConfig(t *testing.T) {
 		t.Fatalf("Load() error: %v", err)
 	}
 
-	if cfg.License != "MIT" {
-		t.Errorf("License = %q, want %q", cfg.License, "MIT")
+	if cfg.License != "BlueOak-1.0.0" {
+		t.Errorf("License = %q, want %q", cfg.License, "BlueOak-1.0.0")
 	}
 	if cfg.Repository == nil {
 		t.Fatal("Repository is nil")
@@ -55,7 +55,7 @@ func TestLoadMalformedYAML(t *testing.T) {
 
 func TestLoadTriggeredAlterationMode(t *testing.T) {
 	dir := t.TempDir()
-	testutil.WriteConfig(t, dir, `license: MIT
+	testutil.WriteConfig(t, dir, `license: BlueOak-1.0.0
 swatches:
   - path: justfile
     alteration: triggered
@@ -72,7 +72,7 @@ swatches:
 
 func TestLoadNeverAlterationMode(t *testing.T) {
 	dir := t.TempDir()
-	testutil.WriteConfig(t, dir, `license: MIT
+	testutil.WriteConfig(t, dir, `license: BlueOak-1.0.0
 swatches:
   - path: justfile
     alteration: never
@@ -89,7 +89,7 @@ swatches:
 
 func TestLoadInvalidAlterationMode(t *testing.T) {
 	dir := t.TempDir()
-	testutil.WriteConfig(t, dir, `license: MIT
+	testutil.WriteConfig(t, dir, `license: BlueOak-1.0.0
 swatches:
   - path: justfile
     alteration: sometimes
@@ -106,7 +106,7 @@ swatches:
 
 func TestLoadEmptyPath(t *testing.T) {
 	dir := t.TempDir()
-	testutil.WriteConfig(t, dir, `license: MIT
+	testutil.WriteConfig(t, dir, `license: BlueOak-1.0.0
 swatches:
   - path: ""
     alteration: always
@@ -123,7 +123,7 @@ swatches:
 
 func TestLoadLabelsAbsent(t *testing.T) {
 	dir := t.TempDir()
-	testutil.WriteConfig(t, dir, `license: MIT
+	testutil.WriteConfig(t, dir, `license: BlueOak-1.0.0
 swatches: []
 `)
 
@@ -138,7 +138,7 @@ swatches: []
 
 func TestLoadLabelsEmpty(t *testing.T) {
 	dir := t.TempDir()
-	testutil.WriteConfig(t, dir, `license: MIT
+	testutil.WriteConfig(t, dir, `license: BlueOak-1.0.0
 labels: []
 swatches: []
 `)
@@ -157,7 +157,7 @@ swatches: []
 
 func TestLoadLabelsPopulated(t *testing.T) {
 	dir := t.TempDir()
-	testutil.WriteConfig(t, dir, `license: MIT
+	testutil.WriteConfig(t, dir, `license: BlueOak-1.0.0
 labels:
   - name: bug
     color: d73a4a
@@ -179,7 +179,7 @@ swatches: []
 
 func TestLoadRejectsInvalidLabel(t *testing.T) {
 	dir := t.TempDir()
-	testutil.WriteConfig(t, dir, `license: MIT
+	testutil.WriteConfig(t, dir, `license: BlueOak-1.0.0
 labels:
   - name: bug
     color: zzzzzz
@@ -198,7 +198,7 @@ swatches: []
 
 func TestExistsTrue(t *testing.T) {
 	dir := t.TempDir()
-	testutil.WriteConfig(t, dir, "license: MIT\nswatches: []\n")
+	testutil.WriteConfig(t, dir, "license: BlueOak-1.0.0\nswatches: []\n")
 
 	if !Exists(dir) {
 		t.Error("Exists() = false, want true")
@@ -260,7 +260,7 @@ swatches:
 
 func TestLoadEmptySwatchesList(t *testing.T) {
 	dir := t.TempDir()
-	testutil.WriteConfig(t, dir, `license: MIT
+	testutil.WriteConfig(t, dir, `license: BlueOak-1.0.0
 swatches: []
 `)
 

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 // wantSpecOutput is the exact byte-for-byte expected output from the
-// specification when writing DefaultConfig("MIT") with date 2026-03-02.
+// specification when writing DefaultConfig("BlueOak-1.0.0") with date 2026-03-02.
 const wantSpecOutput = `# Initially fitted by tailor on 2026-03-02
-license: MIT
+license: BlueOak-1.0.0
 
 repository:
   has_wiki: false
@@ -141,7 +141,7 @@ swatches:
 `
 
 func TestWriteDefaultConfigMatchesSpec(t *testing.T) {
-	cfg, err := DefaultConfig("MIT")
+	cfg, err := DefaultConfig("BlueOak-1.0.0")
 	if err != nil {
 		t.Fatalf("DefaultConfig: %v", err)
 	}

--- a/internal/measure/measure_test.go
+++ b/internal/measure/measure_test.go
@@ -15,7 +15,7 @@ import (
 // swatches at their default alteration modes.
 func buildDefaultConfigYAML() string {
 	var b strings.Builder
-	b.WriteString("license: MIT\n")
+	b.WriteString("license: BlueOak-1.0.0\n")
 	b.WriteString("swatches:\n")
 	for _, s := range swatch.All() {
 		b.WriteString("  - path: " + s.Path + "\n")
@@ -154,7 +154,7 @@ func TestIntegrationConfigWithAllDiffCategories(t *testing.T) {
 	// - changes SECURITY.md alteration from always to first-fit (mode-differs)
 	// All other defaults are present at their default modes.
 	var b strings.Builder
-	b.WriteString("license: MIT\n")
+	b.WriteString("license: BlueOak-1.0.0\n")
 	b.WriteString("swatches:\n")
 	for _, s := range swatch.All() {
 		// Skip .github/dependabot.yml to produce not-configured.
@@ -223,7 +223,7 @@ func TestIntegrationOutputOrderAndPadding(t *testing.T) {
 	// Config with all three diff categories, multiple entries per category
 	// to verify lexicographic sorting.
 	var b strings.Builder
-	b.WriteString("license: MIT\n")
+	b.WriteString("license: BlueOak-1.0.0\n")
 	b.WriteString("swatches:\n")
 	for _, s := range swatch.All() {
 		// Omit two defaults to produce two not-configured entries.

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestWriteConfigCreatesFile(t *testing.T) {
 	dir := t.TempDir()
-	content := "license: MIT\nswatches: []\n"
+	content := "license: BlueOak-1.0.0\nswatches: []\n"
 
 	WriteConfig(t, dir, content)
 

--- a/swatches/.tailor.yml
+++ b/swatches/.tailor.yml
@@ -1,4 +1,4 @@
-license: MIT
+license: BlueOak-1.0.0
 
 repository:
   description: ""


### PR DESCRIPTION
# Description

Replace MIT licence with Blue Oak Model License 1.0.0 across the project:

- Update LICENSE file with full Blue Oak 1.0.0 text and legal framework
- Set BlueOak-1.0.0 as default in .tailor.yml and swatches/.tailor.yml
- Update CLI flag default in cmd/tailor/main.go
- Update licence warning string in internal/alter/licence.go
- Update all test fixtures to use BlueOak-1.0.0 where testing default paths
- Update documentation to reflect new default licence
- Update CI workflow allow-licenses list to include Blue Oak Starter Policy with Go ecosystem filtering

## Additional Context

Blue Oak provides more comprehensive legal coverage than MIT, including explicit grant of patent rights, clearer liability limitations, and improved compliance with modern open source governance standards.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions
