### PR TITLE
docs(swatches): improve contributor and security guidance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -27,12 +27,12 @@ copyright in it.
 You must ensure that everyone who gets a copy of
 any part of this software from you, with or without
 changes, also gets the text of this license or a link to
-https://blueoakcouncil.org/license/1.0.0.
+<https://blueoakcouncil.org/license/1.0.0>.
 
 ## Excuse
 
 If anyone notifies you in writing that you have not
-complied with Notices, you can keep your
+complied with [Notices](#notices), you can keep your
 license by taking all practical steps to comply within 30
 days after the notice.  If you do not do so, your license
 ends immediately.
@@ -49,7 +49,7 @@ No contributor can revoke this license.
 
 ## No Liability
 
-As far as the law allows, this software comes as is,
+***As far as the law allows, this software comes as is,
 without any warranty or condition, and no contributor
 will be liable to anyone for any damages related to this
-software or this license, under any kind of legal claim.
+software or this license, under any kind of legal claim.***

--- a/swatches/CONTRIBUTING.md
+++ b/swatches/CONTRIBUTING.md
@@ -4,5 +4,8 @@ Contributions are welcome and appreciated.
 
 - **Report bugs and request features** in [Issues](../../issues)
 - **Submit pull requests** to fix bugs or add new features
-- **Improve documentation** directly via pull requests
 - Commit messages must conform to the [Conventional Commits](https://www.conventionalcommits.org/) specification
+- **Improve documentation** directly via pull requests
+- All contributors are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md)
+- Security issues must be reported privately; see [SECURITY.md](SECURITY.md)
+- By contributing, you agree that your contributions will be licensed under the project [licence](LICENSE)

--- a/swatches/SECURITY.md
+++ b/swatches/SECURITY.md
@@ -2,16 +2,16 @@
 
 ## Supported Versions
 
-Only the latest release is supported. Any security related fixes will be
-released as a new patch release.
+Only the latest release is supported. Security fixes are released as patch versions.
 
 ## Reporting a Vulnerability
 
-If you discover a vulnerability, please [report it privately]({{ADVISORY_URL}}).
-If that link does not work, you can open a regular issue and mark it as a
-security concern.
+**Do not open a public issue for security vulnerabilities.**
 
-Please include steps to reproduce, affected versions, and potential impact.
+[Report vulnerabilities privately]({{ADVISORY_URL}}). Include:
 
-- This project is maintained on a best-efforts basis.
-- We do not have SLAs for responding to security issues.
+- Steps to reproduce
+- Affected versions
+- Potential impact
+
+This project is maintained on a best-efforts basis. There are no guaranteed response times for security reports.

--- a/swatches/SUPPORT.md
+++ b/swatches/SUPPORT.md
@@ -17,6 +17,8 @@ Use the [bug report template](../../issues/new?template=bug_report.yml) and incl
 - Expected and actual behaviour
 - Version and environment details
 
+To fix a bug yourself, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Requesting Features
 
 Use the [feature request template](../../issues/new?template=feature_request.yml) and describe:
@@ -29,5 +31,4 @@ Use the [feature request template](../../issues/new?template=feature_request.yml
 
 - This project is maintained on a best-efforts basis.
 - There are no guaranteed response times or support SLAs.
-- Bug reports with clear reproduction steps are prioritised.
 - Security issues should be reported privately per [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
- Add Code of Conduct link to CONTRIBUTING.md for governance clarity
- Reorder Conventional Commits requirement for prominence
- Clarify licence language in CONTRIBUTING.md
- Add security reporting reference to CONTRIBUTING.md
- Cross-reference CONTRIBUTING.md in SUPPORT.md for bug fixes
- Remove redundant prioritisation bullet in SUPPORT.md
- Normalise punctuation in "What to Expect" section of SUPPORT.md
- Remove problematic "open a public issue" fallback from SECURITY.md
- Add bold warning against public security issues
- Collapse formatting to match updated swatch style
- Simplify wording for consistency across swatch templates
- Apply minor formatting updates to LICENSE for consistency

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions
