### PR TITLE
ci(release): install Nix to provide nix-hash for GoReleaser

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -138,6 +138,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v21
+
       - name: Install cosign
         if: startsWith(github.ref, 'refs/tags/')
         uses: sigstore/cosign-installer@v4.1.0


### PR DESCRIPTION
- Add DeterminateSystems/nix-installer-action@v21 before cosign setup
- Enables GoReleaser's nix publisher to compute hashes and commit pkgs/tailor/default.nix on tagged releases

Fixes #0.1.0 release where pkgs/tailor/default.nix was unpublished due to missing nix-hash

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have tested my changes and confirmed there are no regressions
