### PR TITLE
fix(alter,swatch): align swatch output and recut behaviour with spec

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -132,11 +132,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: nick-fields/retry@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          timeout_seconds: 30
+          max_attempts: 3
+          retry_wait_seconds: 10
+          retry_on: error
+          command: |
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v21

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -133,6 +133,10 @@ dockers_v2:
     platforms:
       - linux/amd64
       - linux/arm64
+    retry:
+      attempts: 5
+      delay: 10s
+      max_delay: 2m
     labels:
       "org.opencontainers.image.title": "{{ .ProjectName }}"
       "org.opencontainers.image.description": "Ready-to-wear project templates for GitHub repositories."

--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -54,7 +54,10 @@ func (f *FitCmd) Run() error {
 		return err
 	}
 
-	owner, name, ok := gh.RepoContext()
+	owner, name, ok, err := gh.RepoContextAt(f.Path)
+	if err != nil {
+		return err
+	}
 
 	if ok {
 		client, err := api.DefaultRESTClient()

--- a/internal/alter/alter_integration_test.go
+++ b/internal/alter/alter_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -736,8 +737,7 @@ swatches:
 	requireContains(t, output, "SECURITY.md")
 
 	// Must not show "no change" for SECURITY.md.
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
+	for line := range strings.SplitSeq(output, "\n") {
 		if strings.Contains(line, "SECURITY.md") && strings.Contains(line, "no change") {
 			t.Errorf("substituted swatch SECURITY.md should not show 'no change', got: %s", line)
 		}
@@ -851,7 +851,7 @@ swatches:
 	}
 
 	// Classify each line as actionable or informational.
-	actionableLabels := []string{"would set:", "would copy:", "would overwrite:"}
+	actionableLabels := []string{"would set:", "would copy:", "would overwrite:", "would deploy:"}
 	informationalLabels := []string{"no change:", "skipped (first-fit, exists):"}
 
 	isActionable := func(line string) bool {
@@ -956,14 +956,7 @@ swatches:
 		labelPart := line[:expectedWidth]
 		trimmed := strings.TrimRight(labelPart, " ")
 
-		found := false
-		for _, label := range knownLabels {
-			if trimmed == label {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(knownLabels, trimmed) {
 			t.Errorf("label portion %q does not match any known label", trimmed)
 		}
 	}
@@ -1286,7 +1279,7 @@ swatches:
 	}
 
 	// Verify the body contains expected settings.
-	var body map[string]interface{}
+	var body map[string]any
 	if err := json.Unmarshal([]byte(patchCall.Body), &body); err != nil {
 		t.Fatalf("failed to parse PATCH body as JSON: %v", err)
 	}
@@ -1706,7 +1699,7 @@ swatches:
 
 	// DryRun: output should indicate the swatch would be deployed.
 	dryOutput := captureAlterRun(t, cfg, tc.Dir, alter.DryRun, tc.Client)
-	requireContains(t, dryOutput, "would copy")
+	requireContains(t, dryOutput, "would deploy")
 	requireContains(t, dryOutput, "tailor-automerge.yml")
 	requireContains(t, dryOutput, "triggered: allow_auto_merge")
 
@@ -1758,8 +1751,9 @@ swatches:
 		output := captureAlterRun(t, cfg, tc.Dir, alter.DryRun, tc.Client)
 		requireNotContains(t, output, "would copy")
 		requireNotContains(t, output, "would overwrite")
+		requireNotContains(t, output, "would deploy")
 		// The swatch should not appear in actionable output.
-		// It may appear as "skipped (never)" or be silently ignored.
+		// It may appear as "skip (never)" or be silently ignored.
 		requireNotContains(t, output, "would remove")
 	})
 
@@ -1804,12 +1798,13 @@ swatches:
 
 	cfg := loadTestConfig(t, tc.Dir)
 
-	// DryRun: output should show "skipped (never)", not any deploy/copy action.
+	// DryRun: output should show "skip (never)", not any deploy/copy action.
 	output := captureAlterRun(t, cfg, tc.Dir, alter.DryRun, tc.Client)
-	requireContains(t, output, "skipped (never):")
+	requireContains(t, output, "skip (never):")
 	requireContains(t, output, "tailor-automerge.yml")
 	requireNotContains(t, output, "would copy")
 	requireNotContains(t, output, "would overwrite")
+	requireNotContains(t, output, "would deploy")
 
 	// Apply: file should not be written.
 	_ = captureAlterRun(t, cfg, tc.Dir, alter.Apply, tc.Client)

--- a/internal/alter/format.go
+++ b/internal/alter/format.go
@@ -80,7 +80,7 @@ func labelResultLabel(r LabelResult) string {
 }
 
 // swatchLabel returns the formatted label for a swatch result, including any
-// trigger annotation. For example: "would copy (triggered: allow_auto_merge):".
+// trigger annotation. For example: "would deploy (triggered: allow_auto_merge):".
 func swatchLabel(r SwatchResult) string {
 	if r.Annotation != "" {
 		return string(r.Category) + " (" + r.Annotation + "):"
@@ -202,17 +202,19 @@ func swatchOrder(c SwatchCategory) int {
 		return 0
 	case WouldOverwrite:
 		return 1
-	case WouldRemove:
+	case WouldDeploy:
 		return 2
-	case Removed:
+	case WouldRemove:
 		return 3
-	case NoChange:
+	case Removed:
 		return 4
-	case SkippedFirstFit:
+	case NoChange:
 		return 5
-	case SkippedNever:
+	case SkippedFirstFit:
 		return 6
-	default:
+	case SkippedNever:
 		return 7
+	default:
+		return 8
 	}
 }

--- a/internal/alter/format_test.go
+++ b/internal/alter/format_test.go
@@ -123,11 +123,12 @@ func TestFormatOutputColumnAlignment(t *testing.T) {
 	labels := []string{
 		"would copy:",
 		"would overwrite:",
+		"would deploy:",
 		"would remove:",
 		"removed:",
 		"no change:",
 		"skipped (first-fit, exists):",
-		"skipped (never):",
+		"skip (never):",
 		"would set:",
 		"would skip (insufficient scope):",
 		"would skip (insufficient role):",
@@ -206,7 +207,7 @@ func TestFormatOutputNewCategories(t *testing.T) {
 	want := "would copy:                          copied.md\n" +
 		"would remove:                        would-remove.yml\n" +
 		"removed:                             removed.yml\n" +
-		"skipped (never):                     ignored.yml\n"
+		"skip (never):                        ignored.yml\n"
 
 	if got != want {
 		t.Errorf("FormatOutput new categories:\ngot:\n%s\nwant:\n%s", got, want)
@@ -233,7 +234,7 @@ func TestFormatOutputNewCategorySorting(t *testing.T) {
 		"removed:                             a-removed.yml\n" +
 		"no change:                           d-no-change.md\n" +
 		"skipped (first-fit, exists):         c-skipped.md\n" +
-		"skipped (never):                     z-ignored.yml\n"
+		"skip (never):                        z-ignored.yml\n"
 
 	if got != want {
 		t.Errorf("FormatOutput new category sorting:\ngot:\n%s\nwant:\n%s", got, want)
@@ -281,15 +282,15 @@ func TestFormatOutputSkipSorting(t *testing.T) {
 
 func TestFormatOutputAnnotations(t *testing.T) {
 	swatches := []SwatchResult{
-		{Path: ".github/workflows/tailor-automerge.yml", Category: WouldCopy, Annotation: "triggered: allow_auto_merge"},
+		{Path: ".github/workflows/tailor-automerge.yml", Category: WouldDeploy, Annotation: "triggered: allow_auto_merge"},
 		{Path: "LICENSE", Category: NoChange},
 	}
 
 	got := FormatOutput(nil, nil, swatches)
-	// Annotated label "would copy (triggered: allow_auto_merge):" is 41 chars,
-	// plus 1 space = 42 column width.
-	want := "would copy (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n" +
-		"no change:                                LICENSE\n"
+	// Annotated label "would deploy (triggered: allow_auto_merge):" is 43 chars,
+	// plus 1 space = 44 column width.
+	want := "would deploy (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n" +
+		"no change:                                  LICENSE\n"
 
 	if got != want {
 		t.Errorf("FormatOutput annotations:\ngot:\n%s\nwant:\n%s", got, want)
@@ -316,9 +317,9 @@ func TestFormatOutputAnnotationSkippedNever(t *testing.T) {
 	}
 
 	got := FormatOutput(nil, nil, swatches)
-	// "skipped (never) (triggered: allow_auto_merge):" = 46 chars + 1 space = 47 width
-	want := "would copy:                                    CONTRIBUTING.md\n" +
-		"skipped (never) (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n"
+	// "skip (never) (triggered: allow_auto_merge):" = 43 chars + 1 space = 44 width
+	want := "would copy:                                 CONTRIBUTING.md\n" +
+		"skip (never) (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n"
 
 	if got != want {
 		t.Errorf("FormatOutput annotation ignored:\ngot:\n%s\nwant:\n%s", got, want)
@@ -330,13 +331,13 @@ func TestFormatOutputAnnotationMixedWithRepo(t *testing.T) {
 		{Field: "allow_auto_merge", Category: WouldSet, Value: "true"},
 	}
 	swatches := []SwatchResult{
-		{Path: ".github/workflows/tailor-automerge.yml", Category: WouldCopy, Annotation: "triggered: allow_auto_merge"},
+		{Path: ".github/workflows/tailor-automerge.yml", Category: WouldDeploy, Annotation: "triggered: allow_auto_merge"},
 	}
 
 	got := FormatOutput(repos, nil, swatches)
-	// Column width widens to 42 to fit the annotated swatch label.
-	want := "would set:                                repository.allow_auto_merge = true\n" +
-		"would copy (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n"
+	// Column width widens to 44 to fit the annotated swatch label.
+	want := "would set:                                  repository.allow_auto_merge = true\n" +
+		"would deploy (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n"
 
 	if got != want {
 		t.Errorf("FormatOutput annotation mixed with repo:\ngot:\n%s\nwant:\n%s", got, want)

--- a/internal/alter/settings.go
+++ b/internal/alter/settings.go
@@ -55,6 +55,15 @@ func ProcessRepoSettings(cfg *config.Config, mode ApplyMode, client *api.RESTCli
 	// field names so the corresponding WouldSet entries can be suppressed.
 	skipResults, skippedFields := readWarningsToResults(warnings, cfg.Repository)
 
+	// Warn when the config wants automated security fixes but alerts are
+	// currently disabled on GitHub - the API will reject the enable call.
+	if cfg.Repository.AutomatedSecurityFixesEnabled != nil &&
+		*cfg.Repository.AutomatedSecurityFixesEnabled &&
+		live.VulnerabilityAlertsEnabled != nil &&
+		!*live.VulnerabilityAlertsEnabled {
+		fmt.Fprintln(os.Stderr, "warning: automated_security_fixes_enabled is true but vulnerability alerts are disabled on GitHub; enable vulnerability_alerts_enabled first")
+	}
+
 	results := compareSettings(cfg.Repository, live)
 
 	// Remove false-positive WouldSet entries for fields whose live value is
@@ -120,7 +129,7 @@ func compareSettings(declared, live *model.RepositorySettings) []RepoSettingResu
 		key, _, _ := strings.Cut(tag, ",")
 
 		dfv := dv.Field(i)
-		if dfv.Kind() != reflect.Ptr || dfv.IsNil() {
+		if dfv.Kind() != reflect.Pointer || dfv.IsNil() {
 			continue
 		}
 
@@ -231,7 +240,7 @@ func declaredFieldNames(s *model.RepositorySettings) map[string]bool {
 		}
 		key, _, _ := strings.Cut(tag, ",")
 		fv := rv.Field(i)
-		if fv.Kind() == reflect.Ptr && !fv.IsNil() {
+		if fv.Kind() == reflect.Pointer && !fv.IsNil() {
 			names[key] = true
 		}
 	}

--- a/internal/alter/settings_test.go
+++ b/internal/alter/settings_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -1185,5 +1186,61 @@ func TestProcessRepoSettingsCanApprovePullRequestReviewsWouldSet(t *testing.T) {
 	}
 	if results[0].Category != alter.WouldSet {
 		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldSet)
+	}
+}
+
+func TestProcessRepoSettingsWarnsASFWithAlertsDisabled(t *testing.T) {
+	ghfake.FakeRepo(t, "testowner", "testrepo")
+
+	// Server where vulnerability-alerts returns 404 (disabled).
+	live := repoJSON{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+
+		switch {
+		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(live)
+
+		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/private-vulnerability-reporting":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"enabled":false}`)
+
+		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/automated-security-fixes":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"enabled":false}`)
+
+		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/vulnerability-alerts":
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"message":"Not Found"}`)
+
+		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/actions/permissions/workflow":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintf(w, `{"message":"Not Found: %s %s"}`, r.Method, path) //nolint:gosec
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := testutil.NewTestClient(t, server)
+
+	cfg := &config.Config{
+		Repository: &model.RepositorySettings{
+			AutomatedSecurityFixesEnabled: ptr.Ptr(true),
+		},
+	}
+
+	stderr := captureStderr(t, func() {
+		_, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	want := "automated_security_fixes_enabled is true but vulnerability alerts are disabled"
+	if !strings.Contains(stderr, want) {
+		t.Errorf("stderr = %q, want substring %q", stderr, want)
 	}
 }

--- a/internal/alter/swatch.go
+++ b/internal/alter/swatch.go
@@ -88,7 +88,19 @@ func processSwatch(cfg *config.Config, entry config.SwatchEntry, content []byte,
 		if entry.Alteration == swatch.Triggered && !swatch.EvaluateTrigger(entry.Path, cfg.Repository) {
 			return processTriggered(cfg, entry, content, dest, exists, Apply)
 		}
-		return processRecut(entry, content, dest, exists)
+		result, err := processRecut(entry, content, dest, exists)
+		if err != nil {
+			return result, err
+		}
+		// Triggered swatches use "would deploy" with annotation even
+		// under --recut, per spec.
+		if entry.Alteration == swatch.Triggered {
+			if result.Category == WouldCopy || result.Category == WouldOverwrite {
+				result.Category = WouldDeploy
+			}
+			result.Annotation = triggerAnnotation(entry.Path)
+		}
+		return result, nil
 	}
 
 	switch entry.Alteration {

--- a/internal/alter/swatch.go
+++ b/internal/alter/swatch.go
@@ -19,11 +19,12 @@ type SwatchCategory string
 const (
 	WouldCopy       SwatchCategory = "would copy"
 	WouldOverwrite  SwatchCategory = "would overwrite"
+	WouldDeploy     SwatchCategory = "would deploy"
 	WouldRemove     SwatchCategory = "would remove"
 	Removed         SwatchCategory = "removed"
 	NoChange        SwatchCategory = "no change"
 	SkippedFirstFit SwatchCategory = "skipped (first-fit, exists)"
-	SkippedNever    SwatchCategory = "skipped (never)"
+	SkippedNever    SwatchCategory = "skip (never)"
 )
 
 // SwatchResult records the path and categorised outcome for one swatch entry.
@@ -82,6 +83,11 @@ func processSwatch(cfg *config.Config, entry config.SwatchEntry, content []byte,
 	exists := fsutil.FileExists(dest)
 
 	if mode == Recut {
+		// Triggered swatches are never overwritten by --recut when the
+		// trigger condition is false.
+		if entry.Alteration == swatch.Triggered && !swatch.EvaluateTrigger(entry.Path, cfg.Repository) {
+			return processTriggered(cfg, entry, content, dest, exists, Apply)
+		}
 		return processRecut(entry, content, dest, exists)
 	}
 
@@ -143,6 +149,11 @@ func processTriggered(cfg *config.Config, entry config.SwatchEntry, content []by
 		result, err := processAlways(entry, content, dest, exists, mode)
 		if err != nil {
 			return result, err
+		}
+		// Triggered swatches use "would deploy" instead of "would copy" or
+		// "would overwrite" per spec.
+		if result.Category == WouldCopy || result.Category == WouldOverwrite {
+			result.Category = WouldDeploy
 		}
 		result.Annotation = annotation
 		return result, nil

--- a/internal/alter/swatch_test.go
+++ b/internal/alter/swatch_test.go
@@ -316,7 +316,7 @@ func TestNeverSkipsRegardlessOfFileExistence(t *testing.T) {
 // triggeredSource is the swatch path that has a trigger condition.
 const triggeredSource = ".github/workflows/tailor-automerge.yml"
 
-func TestTriggeredMetFileAbsentWouldCopy(t *testing.T) {
+func TestTriggeredMetFileAbsentWouldDeploy(t *testing.T) {
 	dir := t.TempDir()
 
 	cfg := newConfig(entry(triggeredSource, swatch.Triggered))
@@ -326,8 +326,8 @@ func TestTriggeredMetFileAbsentWouldCopy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if results[0].Category != alter.WouldCopy {
-		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldCopy)
+	if results[0].Category != alter.WouldDeploy {
+		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldDeploy)
 	}
 }
 
@@ -342,8 +342,8 @@ func TestTriggeredMetFileExistsDifferentContent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if results[0].Category != alter.WouldOverwrite {
-		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldOverwrite)
+	if results[0].Category != alter.WouldDeploy {
+		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldDeploy)
 	}
 }
 
@@ -419,6 +419,68 @@ func TestTriggeredNotMetFileAbsent(t *testing.T) {
 	}
 	if results[0].Category != alter.SkippedNever {
 		t.Errorf("category = %q, want %q", results[0].Category, alter.SkippedNever)
+	}
+}
+
+func TestRecutTriggeredConditionFalseSkips(t *testing.T) {
+	dir := t.TempDir()
+	writeOnDisk(t, dir, triggeredSource, []byte("existing content"))
+
+	cfg := newConfig(entry(triggeredSource, swatch.Triggered))
+	cfg.Repository = &model.RepositorySettings{AllowAutoMerge: ptr.Ptr(false)}
+
+	results, err := alter.ProcessSwatches(cfg, dir, alter.Recut, &alter.TokenContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	// When condition is false and file exists, recut should remove (like normal alter).
+	if results[0].Category != alter.Removed {
+		t.Errorf("category = %q, want %q", results[0].Category, alter.Removed)
+	}
+	// File should be removed.
+	if _, err := os.Stat(filepath.Join(dir, triggeredSource)); err == nil {
+		t.Error("recut with false trigger did not remove file")
+	}
+}
+
+func TestRecutTriggeredConditionFalseAbsentSkips(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := newConfig(entry(triggeredSource, swatch.Triggered))
+	cfg.Repository = &model.RepositorySettings{AllowAutoMerge: ptr.Ptr(false)}
+
+	results, err := alter.ProcessSwatches(cfg, dir, alter.Recut, &alter.TokenContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	// When condition is false and file absent, skip.
+	if results[0].Category != alter.SkippedNever {
+		t.Errorf("category = %q, want %q", results[0].Category, alter.SkippedNever)
+	}
+}
+
+func TestRecutTriggeredConditionTrueOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	writeOnDisk(t, dir, triggeredSource, []byte("old content"))
+
+	cfg := newConfig(entry(triggeredSource, swatch.Triggered))
+	cfg.Repository = &model.RepositorySettings{AllowAutoMerge: ptr.Ptr(true)}
+
+	results, err := alter.ProcessSwatches(cfg, dir, alter.Recut, &alter.TokenContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Category != alter.WouldOverwrite {
+		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldOverwrite)
 	}
 }
 

--- a/internal/alter/swatch_test.go
+++ b/internal/alter/swatch_test.go
@@ -479,8 +479,11 @@ func TestRecutTriggeredConditionTrueOverwrites(t *testing.T) {
 	if len(results) != 1 {
 		t.Fatalf("got %d results, want 1", len(results))
 	}
-	if results[0].Category != alter.WouldOverwrite {
-		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldOverwrite)
+	if results[0].Category != alter.WouldDeploy {
+		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldDeploy)
+	}
+	if results[0].Annotation == "" {
+		t.Error("expected trigger annotation, got empty string")
 	}
 }
 

--- a/internal/gh/repo.go
+++ b/internal/gh/repo.go
@@ -1,6 +1,9 @@
 package gh
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/cli/go-gh/v2/pkg/repository"
 )
 
@@ -16,4 +19,25 @@ func RepoContext() (owner string, name string, ok bool) {
 		return "", "", false
 	}
 	return repo.Owner, repo.Name, true
+}
+
+// RepoContextAt detects the GitHub repository for the given directory.
+// It temporarily changes the working directory to dir before querying
+// git remotes, then restores the original directory. Returns the owner
+// and name if a GitHub remote is found; ok=false otherwise.
+func RepoContextAt(dir string) (owner string, name string, ok bool, err error) {
+	orig, err := os.Getwd()
+	if err != nil {
+		return "", "", false, fmt.Errorf("getting working directory: %w", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		return "", "", false, fmt.Errorf("changing to directory %q: %w", dir, err)
+	}
+	defer os.Chdir(orig) //nolint:errcheck
+
+	repo, repoErr := currentRepo()
+	if repoErr != nil {
+		return "", "", false, nil
+	}
+	return repo.Owner, repo.Name, true, nil
 }

--- a/internal/gh/repo_test.go
+++ b/internal/gh/repo_test.go
@@ -2,6 +2,7 @@ package gh
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/cli/go-gh/v2/pkg/repository"
@@ -52,5 +53,58 @@ func TestRepoContext(t *testing.T) {
 				t.Errorf("RepoContext() ok = %v, want %v", ok, tt.wantOK)
 			}
 		})
+	}
+}
+
+func TestRepoContextAt(t *testing.T) {
+	restore := SetCurrentRepoFunc(func() (repository.Repository, error) {
+		return repository.Repository{Host: "github.com", Owner: "testowner", Name: "testrepo"}, nil
+	})
+	t.Cleanup(restore)
+
+	dir := t.TempDir()
+
+	owner, name, ok, err := RepoContextAt(dir)
+	if err != nil {
+		t.Fatalf("RepoContextAt() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("RepoContextAt() ok = false, want true")
+	}
+	if owner != "testowner" {
+		t.Errorf("RepoContextAt() owner = %q, want %q", owner, "testowner")
+	}
+	if name != "testrepo" {
+		t.Errorf("RepoContextAt() name = %q, want %q", name, "testrepo")
+	}
+
+	// Verify working directory is restored.
+	cwd, _ := os.Getwd()
+	if cwd == dir {
+		t.Error("RepoContextAt() did not restore working directory")
+	}
+}
+
+func TestRepoContextAtNoRepo(t *testing.T) {
+	restore := SetCurrentRepoFunc(func() (repository.Repository, error) {
+		return repository.Repository{}, errors.New("no repo")
+	})
+	t.Cleanup(restore)
+
+	dir := t.TempDir()
+
+	_, _, ok, err := RepoContextAt(dir)
+	if err != nil {
+		t.Fatalf("RepoContextAt() error = %v", err)
+	}
+	if ok {
+		t.Error("RepoContextAt() ok = true, want false")
+	}
+}
+
+func TestRepoContextAtBadDir(t *testing.T) {
+	_, _, _, err := RepoContextAt("/nonexistent/path/that/does/not/exist")
+	if err == nil {
+		t.Fatal("RepoContextAt() expected error for non-existent dir, got nil")
 	}
 }


### PR DESCRIPTION
- Use "would deploy" label for triggered swatches instead of "would copy" or "would overwrite"
- Add annotation support to "would deploy" for clarity (e.g. "would deploy (triggered: allow_auto_merge):")
- Change "skipped (never)" label to "skip (never)" for consistency
- Prevent --recut from overwriting triggered swatches when their condition is false
- Fix fit command to detect repo context from <path> instead of the current working directory
- Add warning when automated_security_fixes_enabled is true, but vulnerability alerts are disabled on GitHub
- Modernise code: SplitSeq, slices.Contains, reflect.Pointer, any type

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions
