### PR TITLE
feat: publish GitHub Action from main repo with v-prefixed tags

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -3,7 +3,7 @@ name: Builder 👷
 on:
   push:
     branches: [main]
-    tags: ["*.*.*"]
+    tags: ["v*.*.*"]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/tailor.yml
+++ b/.github/workflows/tailor.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6.0.1
 
       - name: Setup tailor
-        uses: wimpysworld/tailor-action@v0.1.0
+        uses: wimpysworld/tailor@v0
 
       - name: Alter swatches
         run: tailor alter

--- a/.github/workflows/update-action-tag.yml
+++ b/.github/workflows/update-action-tag.yml
@@ -1,0 +1,22 @@
+name: Update action tag 🏷️
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-tag:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update floating major version tag
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          major="${tag%%.*}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -fa "${major}" -m "Update ${major} tag to ${tag}"
+          git push origin "${major}" --force

--- a/.github/workflows/update-action-tag.yml
+++ b/.github/workflows/update-action-tag.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   update-tag:
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-slim
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup tailor
-        uses: wimpysworld/tailor-action@v1
+        uses: wimpysworld/tailor@v0
 
       - name: Alter swatches
         run: tailor alter
@@ -259,7 +259,7 @@ jobs:
           title: "chore: alter tailor swatches"
 ```
 
-The workflow itself is an `always` swatch, so it stays current as tailor releases update the template. [`wimpysworld/tailor-action`](https://github.com/wimpysworld/tailor-action) installs the binary into the runner.
+The workflow itself is an `always` swatch, so it stays current as tailor releases update the template. The `action.yml` at the repository root installs the binary into the runner.
 
 ### Token requirements
 
@@ -323,8 +323,8 @@ When a GitHub remote exists, `fit` queries the live repository configuration for
 Reads `.tailor.yml` in the current directory and applies repository settings, labels, licence, and swatches. Execution order: repository settings, then labels, then licence, then swatches.
 
 ```bash
-tailor alter              # Apply changes
-tailor alter --recut      # Overwrite regardless of mode
+tailor alter            # Apply changes
+tailor alter --recut    # Overwrite regardless of mode
 ```
 
 `--recut` overwrites all files including `first-fit` swatches. `LICENSE` is exempt (fetched content, not an embedded swatch). For `.tailor.yml`, `--recut` appends missing default swatch entries but never modifies existing entries.
@@ -338,12 +338,12 @@ tailor baste
 ```
 
 ```
-would set:                                      repository.has_wiki = false
-would copy:                                     LICENSE
-would overwrite:                                SECURITY.md
-no change:                                      .github/workflows/tailor.yml
-skipped (first-fit, exists):                    justfile
-would deploy (triggered: allow_auto_merge):     .github/workflows/tailor-automerge.yml
+     would set: repository.has_wiki = false
+    would copy: LICENSE
+ would overwrite: SECURITY.md
+     no change: .github/workflows/tailor.yml
+skipped (first-fit, exists): justfile
+would deploy (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml
 ```
 
 ### `docket`
@@ -363,16 +363,16 @@ tailor measure
 ```
 
 ```
-missing:        .github/FUNDING.yml
-warning:        LICENSE (contains unresolved placeholders)
-warning:        README.md (not managed by tailor)
-present:        CODE_OF_CONDUCT.md
+       missing: .github/FUNDING.yml
+       warning: LICENSE (contains unresolved placeholders)
+       warning: README.md (not managed by tailor)
+       present: CODE_OF_CONDUCT.md
 not-configured: .github/dependabot.yml
-mode-differs:   SECURITY.md          (config: first-fit, default: always)
+  mode-differs: SECURITY.md (config: first-fit, default: always)
 ```
 
 | Status | Meaning |
-|--------|---------|
+|--------|--------|
 | `missing` | Health file does not exist on disk |
 | `warning` | Health diagnostic needing attention (missing `README.md` or unresolved licence placeholders) |
 | `present` | Health file exists on disk |

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,48 @@
+name: "Setup Tailor"
+description: "Install the tailor CLI for managing project templates"
+branding:
+  icon: "scissors"
+  color: "purple"
+inputs:
+  version:
+    description: "Tailor version to install (e.g. 0.2.0). Defaults to the version matching this action release."
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Determine version
+      id: version
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.version }}" ]]; then
+          v="${{ inputs.version }}"
+          v="v${v#v}"
+        elif [[ "${{ github.action_ref }}" =~ ^v[0-9]+\.[0-9]+ ]]; then
+          v="${{ github.action_ref }}"
+        else
+          v=$(gh api "repos/${{ github.action_repository }}/releases/latest" --jq '.tag_name')
+        fi
+        echo "tag=${v}" >> "$GITHUB_OUTPUT"
+        echo "version=${v#v}" >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ github.token }}
+
+    - name: Install tailor
+      shell: bash
+      run: |
+        case "${{ runner.os }}-${{ runner.arch }}" in
+          Linux-X64)    os="linux";  arch="amd64" ;;
+          Linux-ARM64)  os="linux";  arch="arm64" ;;
+          macOS-X64)    os="darwin"; arch="amd64" ;;
+          macOS-ARM64)  os="darwin"; arch="arm64" ;;
+          *)
+            echo "::error::Unsupported platform: ${{ runner.os }}-${{ runner.arch }}"
+            exit 1
+            ;;
+        esac
+
+        url="https://github.com/${{ github.action_repository }}/releases/download/${{ steps.version.outputs.tag }}/tailor-${os}-${arch}"
+        curl -fsSL "${url}" -o "${RUNNER_TEMP}/tailor"
+        chmod +x "${RUNNER_TEMP}/tailor"
+        echo "${RUNNER_TEMP}" >> "$GITHUB_PATH"
+        echo "Installed tailor ${{ steps.version.outputs.version }} for ${os}/${arch}"

--- a/action.yml
+++ b/action.yml
@@ -14,18 +14,29 @@ runs:
       id: version
       shell: bash
       run: |
-        if [[ -n "${{ inputs.version }}" ]]; then
-          v="${{ inputs.version }}"
+        if [[ -n "${INPUT_VERSION}" ]]; then
+          v="${INPUT_VERSION}"
           v="v${v#v}"
-        elif [[ "${{ github.action_ref }}" =~ ^v[0-9]+\.[0-9]+ ]]; then
-          v="${{ github.action_ref }}"
+        elif [[ "${ACTION_REF}" =~ ^v[0-9]+\.[0-9]+ ]]; then
+          v="${ACTION_REF}"
+        elif [[ "${ACTION_REF}" =~ ^v([0-9]+)$ ]]; then
+          major="${BASH_REMATCH[1]}"
+          v=$(gh api "repos/${ACTION_REPO}/releases" --paginate --jq \
+            "[.[] | select(.prerelease == false) | .tag_name | select(startswith(\"v${major}.\"))] | first")
+          if [[ -z "${v}" ]]; then
+            echo "::error::No stable release found for major version v${major}"
+            exit 1
+          fi
         else
-          v=$(gh api "repos/${{ github.action_repository }}/releases/latest" --jq '.tag_name')
+          v=$(gh api "repos/${ACTION_REPO}/releases/latest" --jq '.tag_name')
         fi
         echo "tag=${v}" >> "$GITHUB_OUTPUT"
         echo "version=${v#v}" >> "$GITHUB_OUTPUT"
       env:
         GH_TOKEN: ${{ github.token }}
+        INPUT_VERSION: ${{ inputs.version }}
+        ACTION_REF: ${{ github.action_ref }}
+        ACTION_REPO: ${{ github.action_repository }}
 
     - name: Install tailor
       shell: bash
@@ -41,8 +52,10 @@ runs:
             ;;
         esac
 
-        url="https://github.com/${{ github.action_repository }}/releases/download/${{ steps.version.outputs.tag }}/tailor-${os}-${arch}"
+        url="https://github.com/${ACTION_REPO}/releases/download/${{ steps.version.outputs.tag }}/tailor-${os}-${arch}"
         curl -fsSL "${url}" -o "${RUNNER_TEMP}/tailor"
         chmod +x "${RUNNER_TEMP}/tailor"
         echo "${RUNNER_TEMP}" >> "$GITHUB_PATH"
         echo "Installed tailor ${{ steps.version.outputs.version }} for ${os}/${arch}"
+      env:
+        ACTION_REPO: ${{ github.action_repository }}

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
           major="${BASH_REMATCH[1]}"
           v=$(gh api "repos/${ACTION_REPO}/releases" --paginate --jq \
             "[.[] | select(.prerelease == false) | .tag_name | select(startswith(\"v${major}.\"))] | first")
-          if [[ -z "${v}" ]]; then
+          if [[ -z "${v}" || "${v}" == "null" ]]; then
             echo "::error::No stable release found for major version v${major}"
             exit 1
           fi

--- a/swatches/.github/workflows/tailor.yml
+++ b/swatches/.github/workflows/tailor.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6.0.1
 
       - name: Setup tailor
-        uses: wimpysworld/tailor-action@v0.1.0
+        uses: wimpysworld/tailor@v0
 
       - name: Alter swatches
         run: tailor alter


### PR DESCRIPTION
## Summary

Publish the GitHub Action directly from the main tailor repo instead of a separate `tailor-action` repository. Switch to `v`-prefixed release tags to follow Go module and GitHub Actions conventions.

## Changes

### New files

| File | Purpose |
|------|---------|
| `action.yml` | Composite action at repo root - installs the tailor binary matching the release version |
| `.github/workflows/update-action-tag.yml` | Moves floating major version tag (e.g. `v0`) on each release |

### Modified files

| File | Change |
|------|--------|
| `.github/workflows/builder.yml` | Tag pattern `["*.*.*"]` → `["v*.*.*"]` |
| `.github/workflows/tailor.yml` | `wimpysworld/tailor-action@v0.1.0` → `wimpysworld/tailor@v0` |
| `swatches/.github/workflows/tailor.yml` | Same change (embedded swatch template) |
| `README.md` | Updated action references and removed `tailor-action` repo link |

### How it works

- **Action versioning**: the action version moves in lockstep with CLI releases. Tag `v0.2.0` and the action at that ref installs tailor `0.2.0`.
- **Floating tags**: `update-action-tag.yml` fires on each release and force-pushes the floating major tag (e.g. `v0` → `v0.2.0`). Users reference `wimpysworld/tailor@v0`.
- **Version resolution**: when referenced via the floating tag, the action resolves the latest release via the GitHub API. When referenced via a full semver tag, it downloads directly.
- **goreleaser**: no changes needed. goreleaser natively expects `v`-prefixed tags and strips the prefix for `{{ .Version }}` in templates.

### Release process change

Tag the next release as `v0.2.0` instead of `0.2.0`. The existing `0.1.0` tag stays as-is.

## Remaining

`docs/SPECIFICATION.md` needs two changes (file is 58KB, not safe to reproduce in full via API):

1. Replace:
   ```
   `wimpysworld/tailor-action@v1` is a separate GitHub Actions action maintained alongside tailor that installs the tailor binary into the workflow runner. It is a separate deliverable from the tailor CLI itself.
   ```
   With:
   ```
   The `action.yml` at the repository root is a composite GitHub Action that installs the tailor binary into the workflow runner. The action version moves in lockstep with CLI releases via floating major version tags (e.g. `v0`).
   ```

2. In the swatch content YAML example, replace:
   ```
   uses: wimpysworld/tailor-action@v1
   ```
   With:
   ```
   uses: wimpysworld/tailor@v0
   ```
