### PR TITLE
fix(ci): add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -8,6 +8,8 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -16,6 +18,8 @@ jobs:
   lint-code:
     name: Code Linter 🧹
     runs-on: ubuntu-slim
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -40,6 +44,8 @@ jobs:
   coverage:
     name: Coverage 📊
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -69,6 +75,8 @@ jobs:
             arch: arm64
             runner: macos-15
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -81,6 +89,9 @@ jobs:
     name: Security 🔒
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/dependency-review-action@v4
@@ -95,6 +106,7 @@ jobs:
     needs: [lint-code, lint-actions, coverage, test, security]
     if: always()
     runs-on: ubuntu-slim
+    permissions: {}
     steps:
       - name: Check results
         run: |

--- a/.github/workflows/update-action-tag.yml
+++ b/.github/workflows/update-action-tag.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   update-tag:
     if: ${{ !github.event.release.prerelease }}


### PR DESCRIPTION
- Add top-level deny-all permissions block to builder and update-action-tag
- Define explicit job-level permissions for lint-code, coverage, test, security, and sentinel jobs
- Grant pull-requests: write only to security job for PR comment creation

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions
