### PR TITLE
feat(action): add gated inputs to run tailor commands

### DIFF
--- a/.github/workflows/tailor-automerge.yml
+++ b/.github/workflows/tailor-automerge.yml
@@ -38,6 +38,19 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  automerge-flake-lock:
+    runs-on: ubuntu-slim
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.pull_request.user.login == 'github-actions[bot]'
+      && startsWith(github.event.pull_request.head.ref, 'update_flake_lock')
+    steps:
+      - name: Automerge flake.lock update
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   automerge-existing:
     runs-on: ubuntu-slim
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/tailor.yml
+++ b/.github/workflows/tailor.yml
@@ -18,14 +18,35 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.1
 
-      - name: Setup tailor
+      - name: Tailor
         uses: wimpysworld/tailor@v0
-
-      - name: Alter swatches
-        run: tailor alter
+        with:
+          alter: true
 
       - name: Create PR
         uses: peter-evans/create-pull-request@v8.1.0
         with:
           branch: tailor-alter
           title: "chore: alter tailor swatches"
+
+  update-flake-lock:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Check for flake.lock
+        id: check
+        run: test -f flake.lock && echo "found=true" >> "$GITHUB_OUTPUT" || echo "found=false" >> "$GITHUB_OUTPUT"
+
+      - name: Install Nix
+        if: steps.check.outputs.found == 'true'
+        uses: DeterminateSystems/determinate-nix-action@v3.17.0
+
+      - name: Update flake.lock
+        if: steps.check.outputs.found == 'true'
+        uses: DeterminateSystems/update-flake-lock@v28
+        with:
+          pr-title: "chore: update flake.lock"

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: "Setup Tailor"
-description: "Install the tailor CLI for managing project templates"
+name: "Tailor"
+description: "Install and run the tailor CLI for managing project templates"
 branding:
   icon: "scissors"
   color: "purple"
@@ -7,6 +7,26 @@ inputs:
   version:
     description: "Tailor version to install (e.g. 0.2.0). Defaults to the version matching this action release."
     required: false
+  fit:
+    description: "Run tailor fit to bootstrap a new project. Requires GH_TOKEN in the job env."
+    required: false
+    default: "false"
+  alter:
+    description: "Run tailor alter to apply swatches and repository settings. Requires GH_TOKEN in the job env."
+    required: false
+    default: "false"
+  baste:
+    description: "Run tailor baste to preview what alter would change. Requires GH_TOKEN in the job env."
+    required: false
+    default: "false"
+  measure:
+    description: "Run tailor measure to check community health files and configuration alignment."
+    required: false
+    default: "false"
+  docket:
+    description: "Run tailor docket to display authentication state and repository context."
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -59,3 +79,28 @@ runs:
         echo "Installed tailor ${{ steps.version.outputs.version }} for ${os}/${arch}"
       env:
         ACTION_REPO: ${{ github.action_repository }}
+
+    - name: Run tailor fit
+      if: inputs.fit == 'true'
+      shell: bash
+      run: tailor fit .
+
+    - name: Run tailor alter
+      if: inputs.alter == 'true'
+      shell: bash
+      run: tailor alter
+
+    - name: Run tailor baste
+      if: inputs.baste == 'true'
+      shell: bash
+      run: tailor baste
+
+    - name: Run tailor measure
+      if: inputs.measure == 'true'
+      shell: bash
+      run: tailor measure
+
+    - name: Run tailor docket
+      if: inputs.docket == 'true'
+      shell: bash
+      run: tailor docket

--- a/swatches/.github/workflows/tailor.yml
+++ b/swatches/.github/workflows/tailor.yml
@@ -18,11 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.1
 
-      - name: Setup tailor
+      - name: Tailor
         uses: wimpysworld/tailor@v0
-
-      - name: Alter swatches
-        run: tailor alter
+        with:
+          alter: true
 
       - name: Create PR
         uses: peter-evans/create-pull-request@v8.1.0


### PR DESCRIPTION
- Add five boolean inputs (fit, alter, baste, measure, docket) to invoke tailor commands directly via the action
- Refactor action name and description to reflect expanded capability
- Add conditional steps for each command, gated by input values
- Update tailor.yml swatch to use action input instead of separate step

Enables callers to compose workflows using the action for any tailor operation without requiring separate run steps.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions
