### PR TITLE
feat(nix): integrate wimpysworld/nix-packages as external Nix registry

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -254,3 +254,28 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -fa "${major}" -m "Update ${major} tag to ${tag}"
           git push origin "${major}" --force
+
+  update-nix-packages:
+    name: Update nix-packages 📦
+    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v28
+        with:
+          inputs: nix-packages
+          branch: update_flake_lock_nix-packages
+          commit-msg: "flake.lock: update nix-packages"
+          pr-title: "chore(flake): update nix-packages input"
+          pr-body: |
+            Automated `flake.lock` update after a new Tailor release.
+
+            Updates the `nix-packages` flake input to pick up the latest Nix derivation published by GoReleaser.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -114,8 +114,8 @@ nix:
   - name: tailor
     repository:
       owner: wimpysworld
-      name: tailor
-      token: "{{ .Env.GITHUB_TOKEN }}"
+      name: nix-packages
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     path: pkgs/tailor/default.nix
     description: "Ready-to-wear project templates for GitHub repositories."
     homepage: https://github.com/wimpysworld/tailor

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "nix-packages": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773271276,
+        "narHash": "sha256-g/XVxKewZWss4YfCEGmVG3r08EetyYrx/GBu3m9Vof4=",
+        "owner": "wimpysworld",
+        "repo": "nix-packages",
+        "rev": "a823592c91ad88068f1048d86a9073c4ac792f01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wimpysworld",
+        "repo": "nix-packages",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1772963539,
@@ -18,6 +38,7 @@
     },
     "root": {
       "inputs": {
+        "nix-packages": "nix-packages",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,16 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nix-packages.url = "github:wimpysworld/nix-packages";
+    nix-packages.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
-    { nixpkgs, ... }:
+    {
+      nixpkgs,
+      nix-packages,
+      ...
+    }:
     let
       supportedSystems = [
         "x86_64-linux"
@@ -37,23 +43,19 @@
           };
         }
       );
-    }
-    // (
-      if builtins.pathExists ./pkgs/tailor/default.nix then
-        {
-          packages = forAllSystems (
-            system:
-            let
-              pkgs = import nixpkgs { inherit system; };
-              tailor = pkgs.callPackage ./pkgs/tailor/default.nix { };
-            in
-            {
-              tailor = tailor;
-              default = tailor;
-            }
-          );
-        }
-      else
-        { }
-    );
+
+      packages = forAllSystems (
+        system:
+        let
+          tailorPkgs = nix-packages.packages.${system} or { };
+        in
+        if tailorPkgs ? tailor then
+          {
+            tailor = tailorPkgs.tailor;
+            default = tailorPkgs.tailor;
+          }
+        else
+          { }
+      );
+    };
 }


### PR DESCRIPTION
- Update GoReleaser nix publisher to target wimpysworld/nix-packages instead of tailor repo; use TAP_GITHUB_TOKEN for auth
- Add nix-packages as flake input with nixpkgs follow relationship
- Simplify flake.nix package output to consume tailor from nix-packages rather than local pkgs/tailor
- Add update-nix-packages CI job to builder workflow for automated flake.lock updates after releases

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions
