### PR TITLE
ci(workflows): refactor release workflow to fix GitHub Actions trigger bug

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -231,7 +231,7 @@ jobs:
           AUR_KEY: ${{ matrix.mode == 'release' && secrets.AUR_KEY || '' }}
 
       - name: Update floating major version tag
-        if: steps.guard.outputs.run == 'true' && matrix.mode == 'release'
+        if: steps.guard.outputs.run == 'true' && matrix.mode == 'release' && !contains(github.ref_name, '-')
         run: |
           tag="${{ github.ref_name }}"
           major="${tag%%.*}"
@@ -241,7 +241,7 @@ jobs:
           git push origin "${major}" --force
 
       - name: Update flake.lock
-        if: steps.guard.outputs.run == 'true' && matrix.mode == 'release'
+        if: steps.guard.outputs.run == 'true' && matrix.mode == 'release' && !contains(github.ref_name, '-')
         uses: DeterminateSystems/update-flake-lock@v28
         with:
           inputs: nix-packages

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -6,8 +6,6 @@ on:
     tags: ["v*.*.*"]
   pull_request:
     branches: [main]
-  release:
-    types: [published]
   schedule:
     - cron: "0 9 * * 0" # Weekly
   workflow_dispatch:
@@ -21,7 +19,6 @@ concurrency:
 jobs:
   lint-code:
     name: Code Linter 🧹
-    if: github.event_name != 'release'
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -43,7 +40,6 @@ jobs:
 
   lint-actions:
     name: Workflow Linter 📋
-    if: github.event_name != 'release'
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -57,7 +53,6 @@ jobs:
 
   coverage:
     name: Coverage 📊
-    if: github.event_name != 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -73,7 +68,6 @@ jobs:
 
   test:
     name: Test 🧪
-    if: github.event_name != 'release'
     strategy:
       fail-fast: false
       matrix:
@@ -103,7 +97,6 @@ jobs:
 
   security:
     name: Security 🔒
-    if: github.event_name != 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -136,7 +129,7 @@ jobs:
   sentinel:
     name: Sentinel 👁️
     needs: [lint-code, lint-actions, coverage, test, security]
-    if: always() && github.event_name != 'release'
+    if: always()
     runs-on: ubuntu-slim
     permissions: {}
     steps:
@@ -176,13 +169,13 @@ jobs:
       always()
       && needs.sentinel.result == 'success'
       && github.repository_owner == 'wimpysworld'
-      && github.event_name != 'release'
       && github.event_name != 'schedule'
       && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || github.event_name == 'pull_request')
     runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
+      pull-requests: write
       id-token: write
     steps:
       - name: Check variant applies
@@ -237,38 +230,18 @@ jobs:
           TAP_GITHUB_TOKEN: ${{ matrix.mode == 'release' && secrets.TAP_GITHUB_TOKEN || '' }}
           AUR_KEY: ${{ matrix.mode == 'release' && secrets.AUR_KEY || '' }}
 
-  update-tag:
-    name: Update Tag 🏷️
-    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
-    runs-on: ubuntu-slim
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-
       - name: Update floating major version tag
+        if: steps.guard.outputs.run == 'true' && matrix.mode == 'release'
         run: |
-          tag="${{ github.event.release.tag_name }}"
+          tag="${{ github.ref_name }}"
           major="${tag%%.*}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -fa "${major}" -m "Update ${major} tag to ${tag}"
           git push origin "${major}" --force
 
-  update-nix-lock:
-    name: Update lock ❄️
-    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Nix
-        uses: DeterminateSystems/determinate-nix-action@v3
-
       - name: Update flake.lock
+        if: steps.guard.outputs.run == 'true' && matrix.mode == 'release'
         uses: DeterminateSystems/update-flake-lock@v28
         with:
           inputs: nix-packages

--- a/README.md
+++ b/README.md
@@ -28,11 +28,33 @@ brew install wimpysworld/tap/tailor
 ### Nix
 
 ```bash
-nix run github:wimpysworld/tailor -- --version
-nix profile install github:wimpysworld/tailor
+nix run github:wimpysworld/nix-packages#tailor -- --version
+nix profile install github:wimpysworld/nix-packages#tailor
 ```
 
-Or add the flake as an input in your own configuration. The package is available for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.
+To use tailor in a flake configuration, add `nix-packages` as an input:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    wimpysworld-nix-packages = {
+      url = "github:wimpysworld/nix-packages";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+}
+```
+
+Then reference tailor in your packages:
+
+```nix
+environment.systemPackages = [
+  inputs.wimpysworld-nix-packages.packages.${system}.tailor
+];
+```
+
+Available for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.
 
 ### Docker
 

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773271276,
-        "narHash": "sha256-g/XVxKewZWss4YfCEGmVG3r08EetyYrx/GBu3m9Vof4=",
+        "lastModified": 1773272365,
+        "narHash": "sha256-fenjpTIyJVUY5P2ZuyS6kKHURvBwWQLgROV9xoQOALA=",
         "owner": "wimpysworld",
         "repo": "nix-packages",
-        "rev": "a823592c91ad88068f1048d86a9073c4ac792f01",
+        "rev": "67179c119816ba42473f86138e5c3bad7cc2b42b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -26,20 +26,24 @@
         system:
         let
           pkgs = import nixpkgs { inherit system; };
+          tailorPkgs = nix-packages.packages.${system} or { };
         in
         {
           default = pkgs.mkShell {
-            packages = with pkgs; [
-              actionlint
-              cosign
-              gh
-              go
-              gocyclo
-              golangci-lint
-              goreleaser
-              ineffassign
-              just
-            ];
+            packages =
+              with pkgs;
+              [
+                actionlint
+                cosign
+                gh
+                go
+                gocyclo
+                golangci-lint
+                goreleaser
+                ineffassign
+                just
+              ]
+              ++ (if tailorPkgs ? tailor then [ tailorPkgs.tailor ] else [ ]);
           };
         }
       );


### PR DESCRIPTION
- Remove `release: types: [published]` trigger (doesn't fire with GITHUB_TOKEN)
- Consolidate `update-tag` and `update-nix-packages` jobs as post-GoReleaser steps
- Execute tag and flake.lock updates inline with matrix.mode == 'release' guard
- Add `pull-requests: write` permission to release job
- Remove obsolete `if: github.event_name != 'release'` guards from lint/test jobs

Tag updates and flake.lock syncs now run reliably after each release, regardless of token type.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions
