### PR TITLE
refactor(settings): remove admin-only repository fields from model

### DIFF
--- a/.tailor.yml
+++ b/.tailor.yml
@@ -17,9 +17,6 @@ repository:
   allow_update_branch: true
   allow_auto_merge: true
   web_commit_signoff_required: false
-  private_vulnerability_reporting_enabled: true
-  vulnerability_alerts_enabled: true
-  automated_security_fixes_enabled: true
   default_workflow_permissions: read
   can_approve_pull_request_reviews: true
   topics:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ tailor/
 - `--recut` overwrites everything except `LICENSE`; for `.tailor.yml`, recut overrides `first-fit` to `always` (append-only: missing default entries added, existing entries never modified)
 - Token substitution: `{{GITHUB_USERNAME}}`, `{{ADVISORY_URL}}`, `{{SUPPORT_URL}}`, `{{HOMEPAGE_URL}}`, `{{MERGE_STRATEGY}}`
 - Licences fetched via GitHub REST API (`GET /licenses/{id}`), not embedded
-- Several repository settings use separate API endpoints rather than the main repo PATCH: `private_vulnerability_reporting_enabled`, `vulnerability_alerts_enabled`, `automated_security_fixes_enabled`, `topics`, `default_workflow_permissions`, and `can_approve_pull_request_reviews`; see `internal/gh/settings.go` for implementation
+- Several repository settings use separate API endpoints rather than the main repo PATCH: `topics`, `default_workflow_permissions`, and `can_approve_pull_request_reviews`; see `internal/gh/settings.go` for implementation
 - `labels` is a top-level config section with its own API layer (`internal/gh/labels.go`) and alter layer (`internal/alter/labels.go`), separate from repository settings
 - `validate.go` includes enum validation for `default_workflow_permissions` ("read"|"write"), topic format validation (lowercase alphanumeric start, max 50 chars, lowercase alphanumerics and hyphens only), and label validation (name length, hex colour, description length, duplicate detection)
 - Dry-run output uses dynamically computed label width for `baste` (accommodates trigger annotations) and fixed 16 chars for `measure`
@@ -83,18 +83,6 @@ tailor/
 
 - [Conventional Commits](https://www.conventionalcommits.org/) specification
 - Common prefixes: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`
-
-## CI token requirements
-
-`GITHUB_TOKEN` covers all Tailor operations on the workflow's own repository except three settings that require admin role:
-
-- `vulnerability_alerts_enabled`
-- `automated_security_fixes_enabled`
-- `private_vulnerability_reporting_enabled`
-
-`GITHUB_TOKEN` never holds `administration` permission regardless of `permissions:` in the workflow - this is a GitHub platform constraint. When these settings appear in `.tailor.yml`, Tailor skips them with a warning. To manage them from CI, set `GH_TOKEN: ${{ secrets.TAILOR_PAT }}` on the workflow step, where `TAILOR_PAT` is a classic PAT with `repo` scope (or fine-grained with `Administration: write`, `Contents: write`, `Issues: write`, `Metadata: read`, `Actions: write`) stored as a repository secret.
-
-See `docs/TOKENS.md` for the full GitHub API endpoint permission matrix.
 
 ## Security considerations
 

--- a/README.md
+++ b/README.md
@@ -204,8 +204,6 @@ repository:
   allow_squash_merge: true
   delete_branch_on_merge: true
   allow_auto_merge: true
-  vulnerability_alerts_enabled: true
-  automated_security_fixes_enabled: true
   default_workflow_permissions: read
   can_approve_pull_request_reviews: false
 
@@ -249,9 +247,6 @@ The `repository` section manages GitHub repository settings declaratively. Field
 | `allow_update_branch` | bool | Allow updating PR branches |
 | `allow_auto_merge` | bool | Allow auto-merge |
 | `web_commit_signoff_required` | bool | Require sign-off on web commits |
-| `private_vulnerability_reporting_enabled` | bool | Enable private vulnerability reporting |
-| `vulnerability_alerts_enabled` | bool | Enable Dependabot vulnerability alerts |
-| `automated_security_fixes_enabled` | bool | Enable Dependabot security update PRs |
 | `topics` | string[] | Repository topics for discoverability |
 | `default_workflow_permissions` | string | `GITHUB_TOKEN` default permissions: `read` or `write` |
 | `can_approve_pull_request_reviews` | bool | Allow workflows to approve PRs |
@@ -316,25 +311,6 @@ jobs:
 ```
 
 The workflow itself is an `always` swatch, so it stays current as tailor releases update the template. The `action.yml` at the repository root installs the binary into the runner.
-
-### Token requirements
-
-`GITHUB_TOKEN` covers all Tailor operations on the workflow's own repository. Three settings require admin role on the repository and cannot be managed via `GITHUB_TOKEN` regardless of how `permissions:` is set in the workflow - this is a GitHub platform constraint:
-
-- `vulnerability_alerts_enabled`
-- `automated_security_fixes_enabled`
-- `private_vulnerability_reporting_enabled`
-
-When these settings appear in `.tailor.yml` and `GITHUB_TOKEN` is used, Tailor logs a warning per skipped setting and continues. The run does not fail.
-
-To manage these settings from CI, create a classic PAT with `repo` scope (or a fine-grained PAT with `Administration: write`), store it as a repository secret, and override `GH_TOKEN` in the workflow step:
-
-```yaml
-- name: Alter swatches
-  env:
-    GH_TOKEN: ${{ secrets.TAILOR_PAT }}
-  run: tailor alter
-```
 
 ### Branch protection
 

--- a/cmd/tailor/main_test.go
+++ b/cmd/tailor/main_test.go
@@ -40,7 +40,7 @@ func TestFitNewDirectoryDefaultConfig(t *testing.T) {
 		t.Errorf("swatch count = %d, want 17", count)
 	}
 
-	// Verify the 14 default repo settings are present.
+	// Verify the 13 default repo settings are present.
 	wantSettings := []string{
 		"has_wiki:",
 		"has_discussions:",
@@ -55,7 +55,6 @@ func TestFitNewDirectoryDefaultConfig(t *testing.T) {
 		"allow_update_branch:",
 		"allow_auto_merge:",
 		"web_commit_signoff_required:",
-		"private_vulnerability_reporting_enabled:",
 	}
 	for _, s := range wantSettings {
 		if !strings.Contains(content, s) {

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -80,9 +80,6 @@ Supported repository settings:
 | `allow_update_branch` | bool | Allow updating PR branches |
 | `allow_auto_merge` | bool | Allow auto-merge |
 | `web_commit_signoff_required` | bool | Require sign-off on web commits |
-| `private_vulnerability_reporting_enabled` | bool | Allow users to privately report potential security vulnerabilities |
-| `vulnerability_alerts_enabled` | bool | Enable Dependabot vulnerability alerts |
-| `automated_security_fixes_enabled` | bool | Enable Dependabot automated security fix PRs |
 | `topics` | string array | Repository topics for discoverability (replace-all semantics) |
 | `default_workflow_permissions` | string | Default GITHUB_TOKEN permissions (`read` or `write`) |
 | `can_approve_pull_request_reviews` | bool | Allow GitHub Actions to approve pull requests |
@@ -91,15 +88,8 @@ Several fields use separate API endpoints rather than the repository PATCH call.
 
 | Field | Read | Write |
 |---|---|---|
-| `private_vulnerability_reporting_enabled` | `GET /repos/{owner}/{repo}/private-vulnerability-reporting` | `PUT`/`DELETE /repos/{owner}/{repo}/private-vulnerability-reporting` |
-| `vulnerability_alerts_enabled` | `GET /repos/{owner}/{repo}/vulnerability-alerts` (204=enabled, 404=disabled) | `PUT`/`DELETE /repos/{owner}/{repo}/vulnerability-alerts` |
-| `automated_security_fixes_enabled` | `GET /repos/{owner}/{repo}/automated-security-fixes` (JSON `{"enabled": bool}`) | `PUT`/`DELETE /repos/{owner}/{repo}/automated-security-fixes` |
 | `topics` | Read from `GET /repos/{owner}/{repo}` response (no extra call) | `PUT /repos/{owner}/{repo}/topics` with `{"names": [...]}` |
 | `default_workflow_permissions`, `can_approve_pull_request_reviews` | `GET /repos/{owner}/{repo}/actions/permissions/workflow` | `PUT /repos/{owner}/{repo}/actions/permissions/workflow` (both fields atomically) |
-
-**Admin role required**: `vulnerability_alerts_enabled`, `automated_security_fixes_enabled`, and `private_vulnerability_reporting_enabled` require the caller to hold admin role (or security manager role for PVR) on the repository. `GITHUB_TOKEN` never holds `administration` permission regardless of `permissions:` in the workflow - this is a GitHub platform constraint. When `GITHUB_TOKEN` is used and these fields appear in `.tailor.yml`, Tailor skips them with a warning and continues. To manage them from CI, supply a PAT via `GH_TOKEN: ${{ secrets.TAILOR_PAT }}` - see README.md for the workaround.
-
-**Ordering constraint**: `automated_security_fixes_enabled` requires `vulnerability_alerts_enabled` to be active. When enabling both, alerts are enabled first, then security fixes. When disabling both, security fixes are disabled first, then alerts. If `automated_security_fixes_enabled: true` is declared but alerts are disabled on GitHub, a warning is emitted.
 
 **Topics**: The PUT endpoint replaces the entire topics list. The config declares the complete desired set; omitted topics are removed on apply. Topics are project-specific and not included in the default config template. Topic names must start with a lowercase letter or number, contain only lowercase alphanumerics and hyphens, and be 50 characters or fewer. The `topics` field uses `*[]string` semantics: nil (absent) means skip, empty list means clear all topics.
 
@@ -199,7 +189,7 @@ A `license` key is included in `.tailor.yml` by default (`license: BlueOak-1.0.0
 
 **Repository settings resolution at `fit` time**: `fit` detects repository context by querying GitHub remotes in `<path>`. If a GitHub remote exists, the project has repository context. If no remote is found, no repository context exists. Repository context detection reads git remotes (via `go-gh`), so `git` must be present when a GitHub remote exists - which is always the case in practice, since the remote implies a git repository.
 
-When repository context exists, `fit` queries the live repository configuration via `GET /repos/{owner}/{repo}` and the separate endpoints for private vulnerability reporting, vulnerability alerts, automated security fixes, and Actions workflow permissions to populate the `repository` section with the project's current settings. This ensures that enabling tailor on an existing project does not inadvertently change features that are already configured (e.g. disabling wiki or discussions that are currently enabled). The `--description` flag takes precedence over the value from GitHub. `description` and `homepage` are omitted if empty. When no repository context exists (e.g. a brand-new project with no remote), the built-in defaults from the embedded swatch are used, with `description` and `homepage` normalised to nil by `DefaultConfig` so they are omitted from the generated config.
+When repository context exists, `fit` queries the live repository configuration via `GET /repos/{owner}/{repo}` and the separate endpoint for Actions workflow permissions to populate the `repository` section with the project's current settings. This ensures that enabling tailor on an existing project does not inadvertently change features that are already configured (e.g. disabling wiki or discussions that are currently enabled). The `--description` flag takes precedence over the value from GitHub. `description` and `homepage` are omitted if empty. When no repository context exists (e.g. a brand-new project with no remote), the built-in defaults from the embedded swatch are used, with `description` and `homepage` normalised to nil by `DefaultConfig` so they are omitted from the generated config.
 
 ```bash
 # Default licence (BlueOak-1.0.0)
@@ -277,16 +267,12 @@ Repository settings output uses the following categories:
 would set:                                    repository.has_wiki = false
 would set:                                    repository.delete_branch_on_merge = true
 no change:                                    repository.allow_squash_merge (already true)
-would skip (insufficient scope: <detail>):    vulnerability_alerts_enabled
-would skip (insufficient role: <detail>):     private_vulnerability_reporting_enabled
 ```
 
 `would set` - declared value differs from the live repository setting.
 `no change` - declared value matches the live repository setting.
-`would skip (insufficient scope: <detail>)` - field could not be read or applied because the token lacks the required scope. The detail annotation embeds the error message.
-`would skip (insufficient role: <detail>)` - field could not be read or applied because the authenticated user lacks the required repository role (admin). The detail annotation embeds the error message.
 
-Repository settings entries are sorted lexicographically by field name within each category: `would set` first, then `no change`, then `would skip` variants.
+Repository settings entries are sorted lexicographically by field name within each category: `would set` first, then `no change`.
 
 Label output uses the following categories:
 
@@ -328,7 +314,7 @@ skip (never):                              .github/workflows/tailor-automerge.ym
 
 `baste` and `alter` use the same output format. The categories above apply to both commands; the only category exclusive to `alter` is `removed`.
 
-Output order: actionable items first (`would set`, `would copy`, `would overwrite`, `would deploy`, `would remove`), then informational (`no change`, `skipped (first-fit, exists)`, `skip (never)`), then skip variants (`would skip`). Within each category, entries are sorted lexicographically by path or field name. The category label width is computed dynamically from the longest label in the output, with a minimum of 37 characters to accommodate `would skip (insufficient scope):` labels.
+Output order: actionable items first (`would set`, `would copy`, `would overwrite`, `would deploy`, `would remove`), then informational (`no change`, `skipped (first-fit, exists)`, `skip (never)`). Within each category, entries are sorted lexicographically by path or field name. The category label width is computed dynamically from the longest label in the output, with a minimum of 37 characters to accommodate `would skip (insufficient scope):` labels.
 
 ### `measure`
 
@@ -477,9 +463,6 @@ repository:
   allow_update_branch: true
   allow_auto_merge: true
   web_commit_signoff_required: false
-  private_vulnerability_reporting_enabled: true
-  vulnerability_alerts_enabled: true
-  automated_security_fixes_enabled: true
   default_workflow_permissions: read
   can_approve_pull_request_reviews: false
 
@@ -749,4 +732,4 @@ measure:
 5. **No project registry**: Tailor has no awareness of its consumers. Projects pull from tailor, tailor does not track projects.
 6. **Authentication via `go-gh`**: All project metadata, user metadata, licence content, and repository settings are resolved via `go-gh` (`github.com/cli/go-gh/v2`), the official Go library for GitHub CLI extensions. Token resolution follows the `go-gh` precedence order: `GH_TOKEN` environment variable, `GITHUB_TOKEN` environment variable, `gh` config file, `gh` keyring (via the `gh` binary). When `GH_TOKEN` or `GITHUB_TOKEN` is set, the `gh` binary is not required. The `gh` binary is needed only for `gh auth login` (establishing credentials) and as a fallback for keyring-based token access when no environment variable is set. Repository context detection reads git remotes via `go-gh`, so `git` must be present when a GitHub remote exists - but any directory with a GitHub remote already has `git` installed. If no valid token can be resolved, `fit`, `alter`, and `baste` exit immediately with an error.
 7. **CLI parsing**: [Kong](https://github.com/alecthomas/kong) is used as the command line parser.
-8. **Repository settings via API**: Repository settings are applied via `PATCH /repos/{owner}/{repo}` with a JSON body constructed from the `repository` section of `.tailor.yml`, plus separate API calls for fields with dedicated endpoints (private vulnerability reporting, vulnerability alerts, automated security fixes, topics, Actions workflow permissions). Field names map directly to the GitHub REST API without translation. Current settings are read via `GET /repos/{owner}/{repo}` and the relevant separate endpoints for `baste` comparison. All API calls use `go-gh`'s pre-authenticated REST client. The `alter` execution order is: repository settings, then labels, then licence, then swatches.
+8. **Repository settings via API**: Repository settings are applied via `PATCH /repos/{owner}/{repo}` with a JSON body constructed from the `repository` section of `.tailor.yml`, plus separate API calls for fields with dedicated endpoints (topics, Actions workflow permissions). Field names map directly to the GitHub REST API without translation. Current settings are read via `GET /repos/{owner}/{repo}` and the relevant separate endpoints for `baste` comparison. All API calls use `go-gh`'s pre-authenticated REST client. The `alter` execution order is: repository settings, then labels, then licence, then swatches.

--- a/docs/TOKENS.md
+++ b/docs/TOKENS.md
@@ -9,9 +9,6 @@
 | Repo settings PATCH | `PATCH /repos/{owner}/{repo}` | `repo` | Yes | Yes (contents:write) | Standard settings work with repo write access, admin-only fields use separate endpoints |
 | Topics | `PUT /repos/{owner}/{repo}/topics` | `repo` | Yes | Yes (contents:write) | Fine-grained: Metadata write |
 | Labels | `GET/POST/PATCH/DELETE /repos/{owner}/{repo}/labels` | `repo` | Yes | Yes (issues:write for writes) | Labels sit under issues permissions in fine-grained |
-| Private vulnerability reporting | `PUT/DELETE /repos/{owner}/{repo}/private-vulnerability-reporting` | `repo` | Yes | No | Requires repo admin or security manager role |
-| Vulnerability alerts | `PUT/DELETE /repos/{owner}/{repo}/vulnerability-alerts` | `repo` | Yes | No | Requires admin role; fine-grained needs security-events:write |
-| Automated security fixes | `PUT/DELETE /repos/{owner}/{repo}/automated-security-fixes` | `repo` | Yes | No | Same constraints as vulnerability alerts |
 | Actions workflow permissions | `GET/PUT /repos/{owner}/{repo}/actions/permissions/workflow` | `repo` | Yes | Yes (actions:write) | Repo-level only; org-level requires admin:org |
 | Licence fetch | `GET /licenses/{id}`, `GET /repos/{owner}/{repo}/license` | none (public) | Yes | Yes | Public endpoint; `repo` scope needed for private repos |
 | File contents read/write | `GET/PUT /repos/{owner}/{repo}/contents/{path}` | `repo` (write) | Yes | Yes (contents:read/write) | Public read needs no auth; write always requires repo scope |
@@ -30,4 +27,3 @@
 | 403 | Insufficient scope or insufficient role |
 | 404 | Returned instead of 403 for private resources to avoid leaking existence |
 
-Security feature endpoints (e.g. `GET /repos/{owner}/{repo}/vulnerability-alerts`) return 404 when the feature is disabled - not a scope error in the read path.

--- a/internal/alter/alter_integration_test.go
+++ b/internal/alter/alter_integration_test.go
@@ -78,7 +78,6 @@ type alterServerConfig struct {
 	owner        string
 	repo         string
 	repoJSON     repoJSON
-	pvrEnabled   bool
 	licenceID    string
 	licenceBody  string
 	labels       []model.LabelEntry // labels returned by GET /repos/{owner}/{repo}/labels
@@ -104,11 +103,6 @@ func WithRepo(owner, repo string) testOption {
 // WithRepoSettings sets the live repo settings returned by GET /repos/{owner}/{repo}.
 func WithRepoSettings(r repoJSON) testOption {
 	return func(c *alterServerConfig) { c.repoJSON = r }
-}
-
-// WithPVR sets the private vulnerability reporting status.
-func WithPVR(enabled bool) testOption {
-	return func(c *alterServerConfig) { c.pvrEnabled = enabled }
 }
 
 // WithLicence sets the licence ID and body for GET /licenses/{id}.
@@ -199,17 +193,6 @@ func setupAlterTest(t *testing.T, configYAML string, opts ...testOption) *alterT
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(sc.repoJSON)
 
-		case r.Method == http.MethodGet && path == repoPath+"/private-vulnerability-reporting":
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"enabled":%t}`, sc.pvrEnabled)
-
-		case r.Method == http.MethodGet && path == repoPath+"/automated-security-fixes":
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"enabled":false}`)
-
-		case r.Method == http.MethodGet && path == repoPath+"/vulnerability-alerts":
-			w.WriteHeader(http.StatusNoContent)
-
 		case r.Method == http.MethodGet && path == repoPath+"/actions/permissions/workflow":
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprint(w, `{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`)
@@ -233,25 +216,7 @@ func setupAlterTest(t *testing.T, configYAML string, opts ...testOption) *alterT
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprint(w, `{}`)
 
-		case r.Method == http.MethodPut && path == repoPath+"/private-vulnerability-reporting":
-			w.WriteHeader(http.StatusNoContent)
-
-		case r.Method == http.MethodDelete && path == repoPath+"/private-vulnerability-reporting":
-			w.WriteHeader(http.StatusNoContent)
-
 		case r.Method == http.MethodPut && path == repoPath+"/actions/permissions/workflow":
-			w.WriteHeader(http.StatusNoContent)
-
-		case r.Method == http.MethodPut && path == repoPath+"/vulnerability-alerts":
-			w.WriteHeader(http.StatusNoContent)
-
-		case r.Method == http.MethodDelete && path == repoPath+"/vulnerability-alerts":
-			w.WriteHeader(http.StatusNoContent)
-
-		case r.Method == http.MethodPut && path == repoPath+"/automated-security-fixes":
-			w.WriteHeader(http.StatusNoContent)
-
-		case r.Method == http.MethodDelete && path == repoPath+"/automated-security-fixes":
 			w.WriteHeader(http.StatusNoContent)
 
 		case r.Method == http.MethodGet && path == repoPath+"/labels":
@@ -1892,15 +1857,6 @@ func allDefaultRepoSettingsYAML(t *testing.T) string {
 	if r.WebCommitSignoffRequired != nil {
 		fmt.Fprintf(&sb, "  web_commit_signoff_required: %t\n", *r.WebCommitSignoffRequired)
 	}
-	if r.PrivateVulnerabilityReportEnabled != nil {
-		fmt.Fprintf(&sb, "  private_vulnerability_reporting_enabled: %t\n", *r.PrivateVulnerabilityReportEnabled)
-	}
-	if r.VulnerabilityAlertsEnabled != nil {
-		fmt.Fprintf(&sb, "  vulnerability_alerts_enabled: %t\n", *r.VulnerabilityAlertsEnabled)
-	}
-	if r.AutomatedSecurityFixesEnabled != nil {
-		fmt.Fprintf(&sb, "  automated_security_fixes_enabled: %t\n", *r.AutomatedSecurityFixesEnabled)
-	}
 	if r.DefaultWorkflowPermissions != nil {
 		fmt.Fprintf(&sb, "  default_workflow_permissions: %s\n", *r.DefaultWorkflowPermissions)
 	}
@@ -2215,15 +2171,6 @@ func TestAlterRunMergeCompleteConfigNotRewritten(t *testing.T) {
 		}
 		if defaults.Repository.WebCommitSignoffRequired != nil {
 			fmt.Fprintf(&sb, "  web_commit_signoff_required: %t\n", *defaults.Repository.WebCommitSignoffRequired)
-		}
-		if defaults.Repository.PrivateVulnerabilityReportEnabled != nil {
-			fmt.Fprintf(&sb, "  private_vulnerability_reporting_enabled: %t\n", *defaults.Repository.PrivateVulnerabilityReportEnabled)
-		}
-		if defaults.Repository.VulnerabilityAlertsEnabled != nil {
-			fmt.Fprintf(&sb, "  vulnerability_alerts_enabled: %t\n", *defaults.Repository.VulnerabilityAlertsEnabled)
-		}
-		if defaults.Repository.AutomatedSecurityFixesEnabled != nil {
-			fmt.Fprintf(&sb, "  automated_security_fixes_enabled: %t\n", *defaults.Repository.AutomatedSecurityFixesEnabled)
 		}
 		if defaults.Repository.DefaultWorkflowPermissions != nil {
 			fmt.Fprintf(&sb, "  default_workflow_permissions: %s\n", *defaults.Repository.DefaultWorkflowPermissions)

--- a/internal/alter/format_test.go
+++ b/internal/alter/format_test.go
@@ -245,15 +245,15 @@ func TestFormatOutputSkipCategories(t *testing.T) {
 	repos := []RepoSettingResult{
 		{Field: "has_wiki", Category: WouldSet, Value: "false"},
 		{Field: "has_issues", Category: RepoNoChange, Value: "true"},
-		{Field: "enable private vulnerability reporting", Category: WouldSkipRole, Value: "insufficient role"},
+		{Field: "set workflow permissions", Category: WouldSkipRole, Value: "insufficient role"},
 		{Field: "patch repo settings", Category: WouldSkipScope, Value: "insufficient scope"},
 	}
 
 	got := FormatOutput(repos, nil, nil)
 	want := "would set:                           repository.has_wiki = false\n" +
 		"no change:                           repository.has_issues (already true)\n" +
-		"would skip (insufficient role):      enable private vulnerability reporting\n" +
-		"would skip (insufficient scope):     patch repo settings\n"
+		"would skip (insufficient scope):     patch repo settings\n" +
+		"would skip (insufficient role):      set workflow permissions\n"
 
 	if got != want {
 		t.Errorf("FormatOutput skip categories:\ngot:\n%s\nwant:\n%s", got, want)
@@ -262,7 +262,7 @@ func TestFormatOutputSkipCategories(t *testing.T) {
 
 func TestFormatOutputSkipSorting(t *testing.T) {
 	repos := []RepoSettingResult{
-		{Field: "enable private vulnerability reporting", Category: WouldSkipRole, Value: "role error"},
+		{Field: "set workflow permissions", Category: WouldSkipRole, Value: "role error"},
 		{Field: "has_wiki", Category: RepoNoChange, Value: "false"},
 		{Field: "description", Category: WouldSet, Value: "My project"},
 		{Field: "patch repo settings", Category: WouldSkipScope, Value: "scope error"},
@@ -272,8 +272,8 @@ func TestFormatOutputSkipSorting(t *testing.T) {
 	// Order: WouldSet (0), RepoNoChange (1), WouldSkipScope (2), WouldSkipRole (2) - alpha within same order.
 	want := "would set:                           repository.description = My project\n" +
 		"no change:                           repository.has_wiki (already false)\n" +
-		"would skip (insufficient role):      enable private vulnerability reporting\n" +
-		"would skip (insufficient scope):     patch repo settings\n"
+		"would skip (insufficient scope):     patch repo settings\n" +
+		"would skip (insufficient role):      set workflow permissions\n"
 
 	if got != want {
 		t.Errorf("FormatOutput skip sorting:\ngot:\n%s\nwant:\n%s", got, want)
@@ -346,12 +346,12 @@ func TestFormatOutputAnnotationMixedWithRepo(t *testing.T) {
 
 func TestFormatOutputSkipAnnotationScope(t *testing.T) {
 	repos := []RepoSettingResult{
-		{Field: "vulnerability_alerts_enabled", Category: WouldSkipScope, Annotation: "token missing required scope"},
+		{Field: "default_workflow_permissions", Category: WouldSkipScope, Annotation: "token missing required scope"},
 	}
 
 	got := FormatOutput(repos, nil, nil)
 	// "would skip (insufficient scope: token missing required scope):" = 62 chars + 1 space = 63 width.
-	want := "would skip (insufficient scope: token missing required scope): vulnerability_alerts_enabled\n"
+	want := "would skip (insufficient scope: token missing required scope): default_workflow_permissions\n"
 
 	if got != want {
 		t.Errorf("FormatOutput skip annotation scope:\ngot:\n%s\nwant:\n%s", got, want)
@@ -360,12 +360,12 @@ func TestFormatOutputSkipAnnotationScope(t *testing.T) {
 
 func TestFormatOutputSkipAnnotationRole(t *testing.T) {
 	repos := []RepoSettingResult{
-		{Field: "vulnerability_alerts_enabled", Category: WouldSkipRole, Annotation: "admin required"},
+		{Field: "default_workflow_permissions", Category: WouldSkipRole, Annotation: "admin required"},
 	}
 
 	got := FormatOutput(repos, nil, nil)
 	// "would skip (insufficient role: admin required):" = 48 chars + 1 space = 49 width.
-	want := "would skip (insufficient role: admin required): vulnerability_alerts_enabled\n"
+	want := "would skip (insufficient role: admin required): default_workflow_permissions\n"
 
 	if got != want {
 		t.Errorf("FormatOutput skip annotation role:\ngot:\n%s\nwant:\n%s", got, want)
@@ -376,16 +376,16 @@ func TestFormatOutputSkipAnnotationMixed(t *testing.T) {
 	repos := []RepoSettingResult{
 		{Field: "has_wiki", Category: WouldSet, Value: "false"},
 		{Field: "has_issues", Category: RepoNoChange, Value: "true"},
-		{Field: "vulnerability_alerts_enabled", Category: WouldSkipScope, Annotation: "token missing required scope"},
-		{Field: "private_vulnerability_reporting_enabled", Category: WouldSkipRole, Annotation: "admin required"},
+		{Field: "default_workflow_permissions", Category: WouldSkipScope, Annotation: "token missing required scope"},
+		{Field: "can_approve_pull_request_reviews", Category: WouldSkipRole, Annotation: "admin required"},
 	}
 
 	got := FormatOutput(repos, nil, nil)
 	// Widest label is "would skip (insufficient scope: token missing required scope):" = 62 chars + 1 = 63.
 	want := "would set:                                                     repository.has_wiki = false\n" +
 		"no change:                                                     repository.has_issues (already true)\n" +
-		"would skip (insufficient role: admin required):                private_vulnerability_reporting_enabled\n" +
-		"would skip (insufficient scope: token missing required scope): vulnerability_alerts_enabled\n"
+		"would skip (insufficient role: admin required):                can_approve_pull_request_reviews\n" +
+		"would skip (insufficient scope: token missing required scope): default_workflow_permissions\n"
 
 	if got != want {
 		t.Errorf("FormatOutput skip annotation mixed:\ngot:\n%s\nwant:\n%s", got, want)

--- a/internal/alter/settings.go
+++ b/internal/alter/settings.go
@@ -55,15 +55,6 @@ func ProcessRepoSettings(cfg *config.Config, mode ApplyMode, client *api.RESTCli
 	// field names so the corresponding WouldSet entries can be suppressed.
 	skipResults, skippedFields := readWarningsToResults(warnings, cfg.Repository)
 
-	// Warn when the config wants automated security fixes but alerts are
-	// currently disabled on GitHub - the API will reject the enable call.
-	if cfg.Repository.AutomatedSecurityFixesEnabled != nil &&
-		*cfg.Repository.AutomatedSecurityFixesEnabled &&
-		live.VulnerabilityAlertsEnabled != nil &&
-		!*live.VulnerabilityAlertsEnabled {
-		fmt.Fprintln(os.Stderr, "warning: automated_security_fixes_enabled is true but vulnerability alerts are disabled on GitHub; enable vulnerability_alerts_enabled first")
-	}
-
 	results := compareSettings(cfg.Repository, live)
 
 	// Remove false-positive WouldSet entries for fields whose live value is
@@ -174,10 +165,7 @@ func compareSettings(declared, live *model.RepositorySettings) []RepoSettingResu
 // ErrInsufficientScope/ErrInsufficientRole) to the config field names
 // (YAML tags) they affect. Workflow permissions covers two fields.
 var readWarningOperationFields = map[string][]string{
-	"fetch vulnerability alerts":            {"vulnerability_alerts_enabled"},
-	"fetch automated security fixes":        {"automated_security_fixes_enabled"},
-	"fetch private vulnerability reporting": {"private_vulnerability_reporting_enabled"},
-	"fetch workflow permissions":            {"default_workflow_permissions", "can_approve_pull_request_reviews"},
+	"fetch workflow permissions": {"default_workflow_permissions", "can_approve_pull_request_reviews"},
 }
 
 // readWarningsToResults converts read-path access-error warnings into

--- a/internal/alter/settings_test.go
+++ b/internal/alter/settings_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -43,7 +42,7 @@ type repoJSON struct {
 
 // settingsServer creates an httptest server that responds to repo settings
 // GET and PATCH requests. patchCalled is incremented when PATCH is received.
-func settingsServer(repo repoJSON, pvrEnabled bool, patchCalled *atomic.Int32) *httptest.Server {
+func settingsServer(repo repoJSON, patchCalled *atomic.Int32) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 
@@ -51,17 +50,6 @@ func settingsServer(repo repoJSON, pvrEnabled bool, patchCalled *atomic.Int32) *
 		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo":
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(repo)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/private-vulnerability-reporting":
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"enabled":%t}`, pvrEnabled)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/automated-security-fixes":
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"enabled":false}`)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/vulnerability-alerts":
-			w.WriteHeader(http.StatusNoContent)
 
 		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/actions/permissions/workflow":
 			w.Header().Set("Content-Type", "application/json")
@@ -74,18 +62,6 @@ func settingsServer(repo repoJSON, pvrEnabled bool, patchCalled *atomic.Int32) *
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprint(w, `{}`)
-
-		case r.Method == http.MethodPut && path == "/repos/testowner/testrepo/private-vulnerability-reporting":
-			if patchCalled != nil {
-				patchCalled.Add(1)
-			}
-			w.WriteHeader(http.StatusNoContent)
-
-		case r.Method == http.MethodDelete && path == "/repos/testowner/testrepo/private-vulnerability-reporting":
-			if patchCalled != nil {
-				patchCalled.Add(1)
-			}
-			w.WriteHeader(http.StatusNoContent)
 
 		case r.Method == http.MethodPut && path == "/repos/testowner/testrepo/actions/permissions/workflow":
 			if patchCalled != nil {
@@ -151,7 +127,7 @@ func TestProcessRepoSettingsWouldSetWhenDiffer(t *testing.T) {
 	ghfake.FakeRepo(t, "testowner", "testrepo")
 
 	live := repoJSON{HasWiki: true, HasIssues: true}
-	server := settingsServer(live, false, nil)
+	server := settingsServer(live, nil)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -183,7 +159,7 @@ func TestProcessRepoSettingsNoChangeWhenMatch(t *testing.T) {
 	ghfake.FakeRepo(t, "testowner", "testrepo")
 
 	live := repoJSON{HasWiki: false, HasIssues: true}
-	server := settingsServer(live, false, nil)
+	server := settingsServer(live, nil)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -216,7 +192,7 @@ func TestProcessRepoSettingsApplyCallsAPI(t *testing.T) {
 
 	var patchCalled atomic.Int32
 	live := repoJSON{HasWiki: true}
-	server := settingsServer(live, false, &patchCalled)
+	server := settingsServer(live, &patchCalled)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -240,7 +216,7 @@ func TestProcessRepoSettingsRecutCallsAPI(t *testing.T) {
 
 	var patchCalled atomic.Int32
 	live := repoJSON{HasWiki: true}
-	server := settingsServer(live, false, &patchCalled)
+	server := settingsServer(live, &patchCalled)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -264,7 +240,7 @@ func TestProcessRepoSettingsDryRunDoesNotCallAPI(t *testing.T) {
 
 	var patchCalled atomic.Int32
 	live := repoJSON{HasWiki: true}
-	server := settingsServer(live, false, &patchCalled)
+	server := settingsServer(live, &patchCalled)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -288,7 +264,7 @@ func TestProcessRepoSettingsNoApplyWhenAllMatch(t *testing.T) {
 
 	var patchCalled atomic.Int32
 	live := repoJSON{HasWiki: false, HasIssues: true}
-	server := settingsServer(live, false, &patchCalled)
+	server := settingsServer(live, &patchCalled)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -336,7 +312,7 @@ func TestProcessRepoSettingsMixedResults(t *testing.T) {
 		Description:         "My project",
 		DeleteBranchOnMerge: false,
 	}
-	server := settingsServer(live, true, nil)
+	server := settingsServer(live, nil)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -373,7 +349,7 @@ func TestProcessRepoSettingsStringFieldValues(t *testing.T) {
 	ghfake.FakeRepo(t, "testowner", "testrepo")
 
 	live := repoJSON{Description: "old", Homepage: "https://old.example.com"}
-	server := settingsServer(live, false, nil)
+	server := settingsServer(live, nil)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -414,166 +390,11 @@ func TestProcessRepoSettingsStringFieldValues(t *testing.T) {
 	}
 }
 
-func TestProcessRepoSettingsPrivateVulnerabilityReporting(t *testing.T) {
-	ghfake.FakeRepo(t, "testowner", "testrepo")
-
-	live := repoJSON{}
-	server := settingsServer(live, false, nil)
-	t.Cleanup(server.Close)
-	client := testutil.NewTestClient(t, server)
-
-	cfg := &config.Config{
-		Repository: &model.RepositorySettings{
-			PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-		},
-	}
-
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("got %d results, want 1", len(results))
-	}
-	if results[0].Field != "private_vulnerability_reporting_enabled" {
-		t.Errorf("field = %q, want %q", results[0].Field, "private_vulnerability_reporting_enabled")
-	}
-	if results[0].Category != alter.WouldSet {
-		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldSet)
-	}
-	if results[0].Value != "true" {
-		t.Errorf("value = %q, want %q", results[0].Value, "true")
-	}
-}
-
-func TestProcessRepoSettingsVulnerabilityAlertsNoChange(t *testing.T) {
-	ghfake.FakeRepo(t, "testowner", "testrepo")
-
-	live := repoJSON{}
-	// settingsServer returns 204 for vulnerability-alerts GET, meaning enabled=true
-	server := settingsServer(live, false, nil)
-	t.Cleanup(server.Close)
-	client := testutil.NewTestClient(t, server)
-
-	cfg := &config.Config{
-		Repository: &model.RepositorySettings{
-			VulnerabilityAlertsEnabled: ptr.Ptr(true),
-		},
-	}
-
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("got %d results, want 1", len(results))
-	}
-	if results[0].Field != "vulnerability_alerts_enabled" {
-		t.Errorf("field = %q, want %q", results[0].Field, "vulnerability_alerts_enabled")
-	}
-	if results[0].Category != alter.RepoNoChange {
-		t.Errorf("category = %q, want %q", results[0].Category, alter.RepoNoChange)
-	}
-	if results[0].Value != "true" {
-		t.Errorf("value = %q, want %q", results[0].Value, "true")
-	}
-}
-
-func TestProcessRepoSettingsVulnerabilityAlertsWouldSet(t *testing.T) {
-	ghfake.FakeRepo(t, "testowner", "testrepo")
-
-	live := repoJSON{}
-	// settingsServer returns 204 for vulnerability-alerts GET, meaning enabled=true
-	server := settingsServer(live, false, nil)
-	t.Cleanup(server.Close)
-	client := testutil.NewTestClient(t, server)
-
-	cfg := &config.Config{
-		Repository: &model.RepositorySettings{
-			VulnerabilityAlertsEnabled: ptr.Ptr(false),
-		},
-	}
-
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("got %d results, want 1", len(results))
-	}
-	if results[0].Field != "vulnerability_alerts_enabled" {
-		t.Errorf("field = %q, want %q", results[0].Field, "vulnerability_alerts_enabled")
-	}
-	if results[0].Category != alter.WouldSet {
-		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldSet)
-	}
-}
-
-func TestProcessRepoSettingsAutomatedSecurityFixesNoChange(t *testing.T) {
-	ghfake.FakeRepo(t, "testowner", "testrepo")
-
-	live := repoJSON{}
-	// settingsServer returns {"enabled":false} for automated-security-fixes GET
-	server := settingsServer(live, false, nil)
-	t.Cleanup(server.Close)
-	client := testutil.NewTestClient(t, server)
-
-	cfg := &config.Config{
-		Repository: &model.RepositorySettings{
-			AutomatedSecurityFixesEnabled: ptr.Ptr(false),
-		},
-	}
-
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("got %d results, want 1", len(results))
-	}
-	if results[0].Field != "automated_security_fixes_enabled" {
-		t.Errorf("field = %q, want %q", results[0].Field, "automated_security_fixes_enabled")
-	}
-	if results[0].Category != alter.RepoNoChange {
-		t.Errorf("category = %q, want %q", results[0].Category, alter.RepoNoChange)
-	}
-}
-
-func TestProcessRepoSettingsAutomatedSecurityFixesWouldSet(t *testing.T) {
-	ghfake.FakeRepo(t, "testowner", "testrepo")
-
-	live := repoJSON{}
-	// settingsServer returns {"enabled":false} for automated-security-fixes GET
-	server := settingsServer(live, false, nil)
-	t.Cleanup(server.Close)
-	client := testutil.NewTestClient(t, server)
-
-	cfg := &config.Config{
-		Repository: &model.RepositorySettings{
-			AutomatedSecurityFixesEnabled: ptr.Ptr(true),
-		},
-	}
-
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("got %d results, want 1", len(results))
-	}
-	if results[0].Field != "automated_security_fixes_enabled" {
-		t.Errorf("field = %q, want %q", results[0].Field, "automated_security_fixes_enabled")
-	}
-	if results[0].Category != alter.WouldSet {
-		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldSet)
-	}
-}
-
 func TestProcessRepoSettingsTopicsNoChange(t *testing.T) {
 	ghfake.FakeRepo(t, "testowner", "testrepo")
 
 	live := repoJSON{Topics: []string{"go", "cli"}}
-	server := settingsServer(live, false, nil)
+	server := settingsServer(live, nil)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -606,7 +427,7 @@ func TestProcessRepoSettingsTopicsWouldSet(t *testing.T) {
 	ghfake.FakeRepo(t, "testowner", "testrepo")
 
 	live := repoJSON{Topics: []string{"go", "cli"}}
-	server := settingsServer(live, false, nil)
+	server := settingsServer(live, nil)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -640,7 +461,7 @@ func TestProcessRepoSettingsTopicsEmptyVsNil(t *testing.T) {
 
 	// Live has no topics (nil from JSON unmarshalling)
 	live := repoJSON{}
-	server := settingsServer(live, false, nil)
+	server := settingsServer(live, nil)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -676,7 +497,7 @@ func TestProcessRepoSettingsTopicsEmptyMatchesEmpty(t *testing.T) {
 
 	// Live has empty topics from JSON
 	live := repoJSON{Topics: []string{}}
-	server := settingsServer(live, false, nil)
+	server := settingsServer(live, nil)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -704,7 +525,7 @@ func TestProcessRepoSettingsDefaultWorkflowPermissionsNoChange(t *testing.T) {
 
 	live := repoJSON{}
 	// settingsServer returns {"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}
-	server := settingsServer(live, false, nil)
+	server := settingsServer(live, nil)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -737,7 +558,7 @@ func TestProcessRepoSettingsDefaultWorkflowPermissionsWouldSet(t *testing.T) {
 
 	live := repoJSON{}
 	// settingsServer returns {"default_workflow_permissions":"read",...}
-	server := settingsServer(live, false, nil)
+	server := settingsServer(live, nil)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -770,7 +591,7 @@ func TestProcessRepoSettingsCanApprovePullRequestReviewsNoChange(t *testing.T) {
 
 	live := repoJSON{}
 	// settingsServer returns {"can_approve_pull_request_reviews":false}
-	server := settingsServer(live, false, nil)
+	server := settingsServer(live, nil)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -795,92 +616,7 @@ func TestProcessRepoSettingsCanApprovePullRequestReviewsNoChange(t *testing.T) {
 	}
 }
 
-func TestProcessRepoSettingsPVR403ProducesSkipResult(t *testing.T) {
-	ghfake.FakeRepo(t, "testowner", "testrepo")
-
-	// Server that returns 403 on PVR PUT (apply path), simulating insufficient role.
-	live := repoJSON{HasWiki: true}
-	var patchCalled atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
-
-		switch {
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo":
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(live)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/private-vulnerability-reporting":
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"enabled":false}`)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/automated-security-fixes":
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"enabled":false}`)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/vulnerability-alerts":
-			w.WriteHeader(http.StatusNoContent)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/actions/permissions/workflow":
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`)
-
-		case r.Method == http.MethodPatch && path == "/repos/testowner/testrepo":
-			patchCalled.Add(1)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, `{}`)
-
-		case r.Method == http.MethodPut && path == "/repos/testowner/testrepo/private-vulnerability-reporting":
-			// Return 403 to simulate insufficient role.
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusForbidden)
-			fmt.Fprint(w, `{"message":"Resource not accessible by personal access token"}`)
-
-		default:
-			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprintf(w, `{"message":"Not Found: %s %s"}`, r.Method, path) //nolint:gosec
-		}
-	}))
-	t.Cleanup(server.Close)
-	client := testutil.NewTestClient(t, server)
-
-	cfg := &config.Config{
-		Repository: &model.RepositorySettings{
-			HasWiki:                           ptr.Ptr(false),
-			PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-		},
-	}
-
-	results, err := alter.ProcessRepoSettings(cfg, alter.Apply, client, "testowner", "testrepo", true)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Should have: has_wiki (WouldSet), pvr (WouldSet from compare), plus a skip result from apply.
-	var skipCount int
-	for _, r := range results {
-		if r.Category == alter.WouldSkipRole || r.Category == alter.WouldSkipScope {
-			skipCount++
-		}
-	}
-	if skipCount == 0 {
-		t.Error("expected at least one WouldSkipRole or WouldSkipScope result, got none")
-	}
-
-	// Verify the skip is for PVR.
-	var foundPVRSkip bool
-	for _, r := range results {
-		if (r.Category == alter.WouldSkipRole || r.Category == alter.WouldSkipScope) &&
-			r.Field == "enable private vulnerability reporting" {
-			foundPVRSkip = true
-		}
-	}
-	if !foundPVRSkip {
-		t.Errorf("expected skip result for PVR, got results: %v", results)
-	}
-}
-
-func TestProcessRepoSettingsPVR403ScopeProducesSkipScope(t *testing.T) {
+func TestProcessRepoSettingsPatch403ScopeProducesSkipScope(t *testing.T) {
 	ghfake.FakeRepo(t, "testowner", "testrepo")
 
 	// Server that returns 403 on PATCH (simulating insufficient scope on the main settings call).
@@ -892,17 +628,6 @@ func TestProcessRepoSettingsPVR403ScopeProducesSkipScope(t *testing.T) {
 		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo":
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(live)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/private-vulnerability-reporting":
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"enabled":false}`)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/automated-security-fixes":
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"enabled":false}`)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/vulnerability-alerts":
-			w.WriteHeader(http.StatusNoContent)
 
 		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/actions/permissions/workflow":
 			w.Header().Set("Content-Type", "application/json")
@@ -946,9 +671,9 @@ func TestProcessRepoSettingsPVR403ScopeProducesSkipScope(t *testing.T) {
 	}
 }
 
-// forbiddenReadServer returns a test server where specific GET endpoints
-// return 403 to simulate insufficient role on the read path.
-func forbiddenReadServer(forbidPVR, forbidASF, forbidVA, forbidWF bool) *httptest.Server {
+// forbiddenReadServer returns a test server where the workflow permissions
+// GET endpoint returns 403 to simulate insufficient scope on the read path.
+func forbiddenReadServer(forbidWF bool) *httptest.Server {
 	repo := repoJSON{}
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
@@ -957,35 +682,6 @@ func forbiddenReadServer(forbidPVR, forbidASF, forbidVA, forbidWF bool) *httptes
 		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo":
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(repo)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/private-vulnerability-reporting":
-			if forbidPVR {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusForbidden)
-				fmt.Fprint(w, `{"message":"Resource not accessible by personal access token"}`)
-				return
-			}
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"enabled":false}`)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/automated-security-fixes":
-			if forbidASF {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusForbidden)
-				fmt.Fprint(w, `{"message":"Resource not accessible by personal access token"}`)
-				return
-			}
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"enabled":false}`)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/vulnerability-alerts":
-			if forbidVA {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusForbidden)
-				fmt.Fprint(w, `{"message":"Resource not accessible by personal access token"}`)
-				return
-			}
-			w.WriteHeader(http.StatusNoContent)
 
 		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/actions/permissions/workflow":
 			if forbidWF {
@@ -1006,94 +702,10 @@ func forbiddenReadServer(forbidPVR, forbidASF, forbidVA, forbidWF bool) *httptes
 	}))
 }
 
-func TestProcessRepoSettingsReadPath403PVRProducesSkipRole(t *testing.T) {
-	ghfake.FakeRepo(t, "testowner", "testrepo")
-
-	server := forbiddenReadServer(true, false, false, false)
-	t.Cleanup(server.Close)
-	client := testutil.NewTestClient(t, server)
-
-	cfg := &config.Config{
-		Repository: &model.RepositorySettings{
-			PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-		},
-	}
-
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("got %d results, want 1", len(results))
-	}
-	if results[0].Field != "private_vulnerability_reporting_enabled" {
-		t.Errorf("field = %q, want %q", results[0].Field, "private_vulnerability_reporting_enabled")
-	}
-	if results[0].Category != alter.WouldSkipRole {
-		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldSkipRole)
-	}
-}
-
-func TestProcessRepoSettingsReadPath403ASFProducesSkipRole(t *testing.T) {
-	ghfake.FakeRepo(t, "testowner", "testrepo")
-
-	server := forbiddenReadServer(false, true, false, false)
-	t.Cleanup(server.Close)
-	client := testutil.NewTestClient(t, server)
-
-	cfg := &config.Config{
-		Repository: &model.RepositorySettings{
-			AutomatedSecurityFixesEnabled: ptr.Ptr(true),
-		},
-	}
-
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("got %d results, want 1", len(results))
-	}
-	if results[0].Field != "automated_security_fixes_enabled" {
-		t.Errorf("field = %q, want %q", results[0].Field, "automated_security_fixes_enabled")
-	}
-	if results[0].Category != alter.WouldSkipRole {
-		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldSkipRole)
-	}
-}
-
-func TestProcessRepoSettingsReadPath403VAProducesSkipRole(t *testing.T) {
-	ghfake.FakeRepo(t, "testowner", "testrepo")
-
-	server := forbiddenReadServer(false, false, true, false)
-	t.Cleanup(server.Close)
-	client := testutil.NewTestClient(t, server)
-
-	cfg := &config.Config{
-		Repository: &model.RepositorySettings{
-			VulnerabilityAlertsEnabled: ptr.Ptr(true),
-		},
-	}
-
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("got %d results, want 1", len(results))
-	}
-	if results[0].Field != "vulnerability_alerts_enabled" {
-		t.Errorf("field = %q, want %q", results[0].Field, "vulnerability_alerts_enabled")
-	}
-	if results[0].Category != alter.WouldSkipRole {
-		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldSkipRole)
-	}
-}
-
 func TestProcessRepoSettingsReadPath403WorkflowProducesSkipScope(t *testing.T) {
 	ghfake.FakeRepo(t, "testowner", "testrepo")
 
-	server := forbiddenReadServer(false, false, false, true)
+	server := forbiddenReadServer(true)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -1121,18 +733,15 @@ func TestProcessRepoSettingsReadPath403WorkflowProducesSkipScope(t *testing.T) {
 func TestProcessRepoSettingsReadPath403DoesNotProduceWouldSet(t *testing.T) {
 	ghfake.FakeRepo(t, "testowner", "testrepo")
 
-	// All four sub-calls return 403.
-	server := forbiddenReadServer(true, true, true, true)
+	// Workflow permissions sub-call returns 403.
+	server := forbiddenReadServer(true)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-			AutomatedSecurityFixesEnabled:     ptr.Ptr(true),
-			VulnerabilityAlertsEnabled:        ptr.Ptr(true),
-			DefaultWorkflowPermissions:        ptr.Ptr("write"),
-			CanApprovePullRequestReviews:      ptr.Ptr(true),
+			DefaultWorkflowPermissions:   ptr.Ptr("write"),
+			CanApprovePullRequestReviews: ptr.Ptr(true),
 		},
 	}
 
@@ -1147,15 +756,15 @@ func TestProcessRepoSettingsReadPath403DoesNotProduceWouldSet(t *testing.T) {
 		}
 	}
 
-	// All five fields should have skip results.
+	// Both fields should have skip results.
 	skipCount := 0
 	for _, r := range results {
 		if r.Category == alter.WouldSkipRole || r.Category == alter.WouldSkipScope {
 			skipCount++
 		}
 	}
-	if skipCount != 5 {
-		t.Errorf("got %d skip results, want 5", skipCount)
+	if skipCount != 2 {
+		t.Errorf("got %d skip results, want 2", skipCount)
 	}
 }
 
@@ -1164,7 +773,7 @@ func TestProcessRepoSettingsCanApprovePullRequestReviewsWouldSet(t *testing.T) {
 
 	live := repoJSON{}
 	// settingsServer returns {"can_approve_pull_request_reviews":false}
-	server := settingsServer(live, false, nil)
+	server := settingsServer(live, nil)
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 
@@ -1186,61 +795,5 @@ func TestProcessRepoSettingsCanApprovePullRequestReviewsWouldSet(t *testing.T) {
 	}
 	if results[0].Category != alter.WouldSet {
 		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldSet)
-	}
-}
-
-func TestProcessRepoSettingsWarnsASFWithAlertsDisabled(t *testing.T) {
-	ghfake.FakeRepo(t, "testowner", "testrepo")
-
-	// Server where vulnerability-alerts returns 404 (disabled).
-	live := repoJSON{}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
-
-		switch {
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo":
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(live)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/private-vulnerability-reporting":
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"enabled":false}`)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/automated-security-fixes":
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"enabled":false}`)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/vulnerability-alerts":
-			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprint(w, `{"message":"Not Found"}`)
-
-		case r.Method == http.MethodGet && path == "/repos/testowner/testrepo/actions/permissions/workflow":
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`)
-
-		default:
-			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprintf(w, `{"message":"Not Found: %s %s"}`, r.Method, path) //nolint:gosec
-		}
-	}))
-	t.Cleanup(server.Close)
-	client := testutil.NewTestClient(t, server)
-
-	cfg := &config.Config{
-		Repository: &model.RepositorySettings{
-			AutomatedSecurityFixesEnabled: ptr.Ptr(true),
-		},
-	}
-
-	stderr := captureStderr(t, func() {
-		_, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	want := "automated_security_fixes_enabled is true but vulnerability alerts are disabled"
-	if !strings.Contains(stderr, want) {
-		t.Errorf("stderr = %q, want substring %q", stderr, want)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,7 +30,6 @@ repository:
   allow_update_branch: true
   allow_auto_merge: true
   web_commit_signoff_required: false
-  private_vulnerability_reporting_enabled: true
 
 swatches:
   - path: .github/workflows/tailor.yml
@@ -113,7 +112,6 @@ func TestUnmarshalSpecYAML(t *testing.T) {
 	testutil.AssertBoolPtr(t, r.AllowUpdateBranch, false, true, "allow_update_branch")
 	testutil.AssertBoolPtr(t, r.AllowAutoMerge, false, true, "allow_auto_merge")
 	testutil.AssertBoolPtr(t, r.WebCommitSignoffRequired, false, false, "web_commit_signoff_required")
-	testutil.AssertBoolPtr(t, r.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
 
 	if len(cfg.Swatches) != 17 {
 		t.Fatalf("Swatches count = %d, want 17", len(cfg.Swatches))
@@ -236,8 +234,6 @@ func TestOptionalRepositoryFieldsOmitted(t *testing.T) {
 func TestNewRepositoryFieldsParsing(t *testing.T) {
 	input := `license: MIT
 repository:
-  vulnerability_alerts_enabled: true
-  automated_security_fixes_enabled: false
   topics:
     - go
     - cli-tool
@@ -251,8 +247,6 @@ swatches: []
 	}
 
 	r := cfg.Repository
-	testutil.AssertBoolPtr(t, r.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertBoolPtr(t, r.AutomatedSecurityFixesEnabled, false, false, "automated_security_fixes_enabled")
 	testutil.AssertStringPtr(t, r.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
 	testutil.AssertBoolPtr(t, r.CanApprovePullRequestReviews, false, false, "can_approve_pull_request_reviews")
 
@@ -277,8 +271,6 @@ swatches: []
 	}
 
 	r := cfg.Repository
-	testutil.AssertBoolPtr(t, r.VulnerabilityAlertsEnabled, true, false, "vulnerability_alerts_enabled")
-	testutil.AssertBoolPtr(t, r.AutomatedSecurityFixesEnabled, true, false, "automated_security_fixes_enabled")
 	testutil.AssertStringPtr(t, r.DefaultWorkflowPermissions, true, "", "default_workflow_permissions")
 	testutil.AssertBoolPtr(t, r.CanApprovePullRequestReviews, true, false, "can_approve_pull_request_reviews")
 
@@ -312,11 +304,9 @@ func TestNewFieldsRoundTrip(t *testing.T) {
 	cfg := Config{
 		License: "MIT",
 		Repository: &model.RepositorySettings{
-			VulnerabilityAlertsEnabled:    ptr.Ptr(true),
-			AutomatedSecurityFixesEnabled: ptr.Ptr(false),
-			Topics:                        &topics,
-			DefaultWorkflowPermissions:    ptr.Ptr("write"),
-			CanApprovePullRequestReviews:  ptr.Ptr(true),
+			Topics:                       &topics,
+			DefaultWorkflowPermissions:   ptr.Ptr("write"),
+			CanApprovePullRequestReviews: ptr.Ptr(true),
 		},
 		Swatches: []SwatchEntry{
 			{Path: "justfile", Alteration: swatch.FirstFit},
@@ -334,8 +324,6 @@ func TestNewFieldsRoundTrip(t *testing.T) {
 	}
 
 	r := roundTripped.Repository
-	testutil.AssertBoolPtr(t, r.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertBoolPtr(t, r.AutomatedSecurityFixesEnabled, false, false, "automated_security_fixes_enabled")
 	testutil.AssertStringPtr(t, r.DefaultWorkflowPermissions, false, "write", "default_workflow_permissions")
 	testutil.AssertBoolPtr(t, r.CanApprovePullRequestReviews, false, true, "can_approve_pull_request_reviews")
 
@@ -366,8 +354,6 @@ func TestNewFieldsOmittedInMarshal(t *testing.T) {
 
 	s := string(out)
 	for _, field := range []string{
-		"vulnerability_alerts_enabled",
-		"automated_security_fixes_enabled",
 		"topics",
 		"default_workflow_permissions",
 		"can_approve_pull_request_reviews",

--- a/internal/config/generate_test.go
+++ b/internal/config/generate_test.go
@@ -52,9 +52,6 @@ func TestDefaultConfigMatchesEmbedded(t *testing.T) {
 	testutil.AssertBoolPtr(t, got.Repository.AllowUpdateBranch, false, true, "allow_update_branch")
 	testutil.AssertBoolPtr(t, got.Repository.AllowAutoMerge, false, true, "allow_auto_merge")
 	testutil.AssertBoolPtr(t, got.Repository.WebCommitSignoffRequired, false, false, "web_commit_signoff_required")
-	testutil.AssertBoolPtr(t, got.Repository.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertBoolPtr(t, got.Repository.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertBoolPtr(t, got.Repository.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
 	testutil.AssertStringPtr(t, got.Repository.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
 	testutil.AssertBoolPtr(t, got.Repository.CanApprovePullRequestReviews, false, true, "can_approve_pull_request_reviews")
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -127,7 +127,6 @@ func TestRepoSettingNamesContainsExpectedFields(t *testing.T) {
 		"allow_rebase_merge",
 		"allow_squash_merge",
 		"allow_update_branch",
-		"automated_security_fixes_enabled",
 		"can_approve_pull_request_reviews",
 		"default_workflow_permissions",
 		"delete_branch_on_merge",
@@ -139,11 +138,9 @@ func TestRepoSettingNamesContainsExpectedFields(t *testing.T) {
 		"homepage",
 		"merge_commit_message",
 		"merge_commit_title",
-		"private_vulnerability_reporting_enabled",
 		"squash_merge_commit_message",
 		"squash_merge_commit_title",
 		"topics",
-		"vulnerability_alerts_enabled",
 		"web_commit_signoff_required",
 	}
 	if len(names) != len(expected) {

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -126,15 +126,6 @@ repository:
 {{- if set .Repository.WebCommitSignoffRequired }}
   web_commit_signoff_required: {{ derefBool .Repository.WebCommitSignoffRequired }}
 {{- end }}
-{{- if set .Repository.PrivateVulnerabilityReportEnabled }}
-  private_vulnerability_reporting_enabled: {{ derefBool .Repository.PrivateVulnerabilityReportEnabled }}
-{{- end }}
-{{- if set .Repository.VulnerabilityAlertsEnabled }}
-  vulnerability_alerts_enabled: {{ derefBool .Repository.VulnerabilityAlertsEnabled }}
-{{- end }}
-{{- if set .Repository.AutomatedSecurityFixesEnabled }}
-  automated_security_fixes_enabled: {{ derefBool .Repository.AutomatedSecurityFixesEnabled }}
-{{- end }}
 {{- if set .Repository.DefaultWorkflowPermissions }}
   default_workflow_permissions: {{ deref .Repository.DefaultWorkflowPermissions }}
 {{- end }}

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -32,9 +32,6 @@ repository:
   allow_update_branch: true
   allow_auto_merge: true
   web_commit_signoff_required: false
-  private_vulnerability_reporting_enabled: true
-  vulnerability_alerts_enabled: true
-  automated_security_fixes_enabled: true
   default_workflow_permissions: read
   can_approve_pull_request_reviews: true
 
@@ -197,28 +194,25 @@ func TestWriteOptionalFieldsPresent(t *testing.T) {
 	cfg := &Config{
 		License: "Apache-2.0",
 		Repository: &model.RepositorySettings{
-			Description:                       ptr.Ptr("My project"),
-			Homepage:                          ptr.Ptr("https://example.com"),
-			HasWiki:                           ptr.Ptr(true),
-			HasDiscussions:                    ptr.Ptr(false),
-			HasProjects:                       ptr.Ptr(false),
-			HasIssues:                         ptr.Ptr(true),
-			AllowMergeCommit:                  ptr.Ptr(true),
-			AllowSquashMerge:                  ptr.Ptr(true),
-			AllowRebaseMerge:                  ptr.Ptr(false),
-			SquashMergeCommitTitle:            ptr.Ptr("PR_TITLE"),
-			SquashMergeCommitMessage:          ptr.Ptr("COMMIT_MESSAGES"),
-			MergeCommitTitle:                  ptr.Ptr("PR_TITLE"),
-			MergeCommitMessage:                ptr.Ptr("PR_BODY"),
-			DeleteBranchOnMerge:               ptr.Ptr(true),
-			AllowUpdateBranch:                 ptr.Ptr(true),
-			AllowAutoMerge:                    ptr.Ptr(false),
-			WebCommitSignoffRequired:          ptr.Ptr(true),
-			PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-			VulnerabilityAlertsEnabled:        ptr.Ptr(true),
-			AutomatedSecurityFixesEnabled:     ptr.Ptr(false),
-			DefaultWorkflowPermissions:        ptr.Ptr("write"),
-			CanApprovePullRequestReviews:      ptr.Ptr(true),
+			Description:                  ptr.Ptr("My project"),
+			Homepage:                     ptr.Ptr("https://example.com"),
+			HasWiki:                      ptr.Ptr(true),
+			HasDiscussions:               ptr.Ptr(false),
+			HasProjects:                  ptr.Ptr(false),
+			HasIssues:                    ptr.Ptr(true),
+			AllowMergeCommit:             ptr.Ptr(true),
+			AllowSquashMerge:             ptr.Ptr(true),
+			AllowRebaseMerge:             ptr.Ptr(false),
+			SquashMergeCommitTitle:       ptr.Ptr("PR_TITLE"),
+			SquashMergeCommitMessage:     ptr.Ptr("COMMIT_MESSAGES"),
+			MergeCommitTitle:             ptr.Ptr("PR_TITLE"),
+			MergeCommitMessage:           ptr.Ptr("PR_BODY"),
+			DeleteBranchOnMerge:          ptr.Ptr(true),
+			AllowUpdateBranch:            ptr.Ptr(true),
+			AllowAutoMerge:               ptr.Ptr(false),
+			WebCommitSignoffRequired:     ptr.Ptr(true),
+			DefaultWorkflowPermissions:   ptr.Ptr("write"),
+			CanApprovePullRequestReviews: ptr.Ptr(true),
 		},
 		Swatches: []SwatchEntry{
 			{Path: "justfile", Alteration: swatch.FirstFit},
@@ -246,9 +240,6 @@ repository:
   allow_update_branch: true
   allow_auto_merge: false
   web_commit_signoff_required: true
-  private_vulnerability_reporting_enabled: true
-  vulnerability_alerts_enabled: true
-  automated_security_fixes_enabled: false
   default_workflow_permissions: write
   can_approve_pull_request_reviews: true
 
@@ -277,24 +268,21 @@ func TestWriteOptionalFieldsOmitted(t *testing.T) {
 		License: "MIT",
 		Repository: &model.RepositorySettings{
 			// Description, Homepage, MergeCommitTitle, MergeCommitMessage are nil.
-			HasWiki:                           ptr.Ptr(false),
-			HasDiscussions:                    ptr.Ptr(false),
-			HasProjects:                       ptr.Ptr(false),
-			HasIssues:                         ptr.Ptr(true),
-			AllowMergeCommit:                  ptr.Ptr(false),
-			AllowSquashMerge:                  ptr.Ptr(true),
-			AllowRebaseMerge:                  ptr.Ptr(true),
-			SquashMergeCommitTitle:            ptr.Ptr("PR_TITLE"),
-			SquashMergeCommitMessage:          ptr.Ptr("PR_BODY"),
-			DeleteBranchOnMerge:               ptr.Ptr(true),
-			AllowUpdateBranch:                 ptr.Ptr(true),
-			AllowAutoMerge:                    ptr.Ptr(true),
-			WebCommitSignoffRequired:          ptr.Ptr(false),
-			PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-			VulnerabilityAlertsEnabled:        ptr.Ptr(true),
-			AutomatedSecurityFixesEnabled:     ptr.Ptr(true),
-			DefaultWorkflowPermissions:        ptr.Ptr("read"),
-			CanApprovePullRequestReviews:      ptr.Ptr(false),
+			HasWiki:                      ptr.Ptr(false),
+			HasDiscussions:               ptr.Ptr(false),
+			HasProjects:                  ptr.Ptr(false),
+			HasIssues:                    ptr.Ptr(true),
+			AllowMergeCommit:             ptr.Ptr(false),
+			AllowSquashMerge:             ptr.Ptr(true),
+			AllowRebaseMerge:             ptr.Ptr(true),
+			SquashMergeCommitTitle:       ptr.Ptr("PR_TITLE"),
+			SquashMergeCommitMessage:     ptr.Ptr("PR_BODY"),
+			DeleteBranchOnMerge:          ptr.Ptr(true),
+			AllowUpdateBranch:            ptr.Ptr(true),
+			AllowAutoMerge:               ptr.Ptr(true),
+			WebCommitSignoffRequired:     ptr.Ptr(false),
+			DefaultWorkflowPermissions:   ptr.Ptr("read"),
+			CanApprovePullRequestReviews: ptr.Ptr(false),
 		},
 		Swatches: []SwatchEntry{
 			{Path: "justfile", Alteration: swatch.FirstFit},
@@ -318,9 +306,6 @@ repository:
   allow_update_branch: true
   allow_auto_merge: true
   web_commit_signoff_required: false
-  private_vulnerability_reporting_enabled: true
-  vulnerability_alerts_enabled: true
-  automated_security_fixes_enabled: true
   default_workflow_permissions: read
   can_approve_pull_request_reviews: false
 

--- a/internal/gh/errors.go
+++ b/internal/gh/errors.go
@@ -49,17 +49,7 @@ func (e *ErrInsufficientRole) Error() string {
 // adminRoleOperations maps operation names to their required repository roles.
 // Operations in this set return 403 when the caller lacks the required role,
 // regardless of token scope.
-var adminRoleOperations = map[string]string{
-	"enable vulnerability alerts":             "admin",
-	"disable vulnerability alerts":            "admin",
-	"fetch vulnerability alerts":              "admin",
-	"enable automated security fixes":         "admin",
-	"disable automated security fixes":        "admin",
-	"fetch automated security fixes":          "admin",
-	"enable private vulnerability reporting":  "admin or security manager",
-	"disable private vulnerability reporting": "admin or security manager",
-	"fetch private vulnerability reporting":   "admin or security manager",
-}
+var adminRoleOperations = map[string]string{}
 
 // requiredRole returns the required role for an operation and whether the
 // operation is in the admin-role registry.

--- a/internal/gh/errors_test.go
+++ b/internal/gh/errors_test.go
@@ -153,34 +153,6 @@ func TestErrInsufficientRole_ErrorsAs(t *testing.T) {
 	}
 }
 
-// --- Task 1.3: admin-role registry tests ---
-
-func TestRequiredRole_AdminOperations(t *testing.T) {
-	tests := []struct {
-		operation string
-		wantRole  string
-	}{
-		{"enable vulnerability alerts", "admin"},
-		{"disable vulnerability alerts", "admin"},
-		{"enable automated security fixes", "admin"},
-		{"disable automated security fixes", "admin"},
-		{"enable private vulnerability reporting", "admin or security manager"},
-		{"disable private vulnerability reporting", "admin or security manager"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.operation, func(t *testing.T) {
-			role, ok := requiredRole(tt.operation)
-			if !ok {
-				t.Fatalf("requiredRole(%q) returned ok=false, want true", tt.operation)
-			}
-			if role != tt.wantRole {
-				t.Errorf("requiredRole(%q) = %q, want %q", tt.operation, role, tt.wantRole)
-			}
-		})
-	}
-}
-
 func TestRequiredRole_NonAdminOperation(t *testing.T) {
 	_, ok := requiredRole("update repository settings")
 	if ok {
@@ -255,60 +227,6 @@ func TestClassifyHTTPError_403ScopeError(t *testing.T) {
 	}
 }
 
-func TestClassifyHTTPError_403RoleError_VA(t *testing.T) {
-	headers := http.Header{}
-	headers.Set("X-OAuth-Scopes", "repo")
-	headers.Set("X-Accepted-OAuth-Scopes", "repo")
-	httpErr := newHTTPError(http.StatusForbidden, "Must have admin rights to Repository.", headers)
-
-	got := classifyHTTPError(httpErr, "enable vulnerability alerts")
-
-	var roleErr *ErrInsufficientRole
-	if !errors.As(got, &roleErr) {
-		t.Fatalf("expected *ErrInsufficientRole, got %T: %v", got, got)
-	}
-	if roleErr.StatusCode != http.StatusForbidden {
-		t.Errorf("StatusCode = %d, want %d", roleErr.StatusCode, http.StatusForbidden)
-	}
-	if roleErr.Operation != "enable vulnerability alerts" {
-		t.Errorf("Operation = %q, want %q", roleErr.Operation, "enable vulnerability alerts")
-	}
-	if roleErr.RequiredRole != "admin" {
-		t.Errorf("RequiredRole = %q, want %q", roleErr.RequiredRole, "admin")
-	}
-	if roleErr.Message != "Must have admin rights to Repository." {
-		t.Errorf("Message = %q, want %q", roleErr.Message, "Must have admin rights to Repository.")
-	}
-}
-
-func TestClassifyHTTPError_403RoleError_PVR(t *testing.T) {
-	httpErr := newHTTPError(http.StatusForbidden, "Resource not accessible by integration", http.Header{})
-
-	got := classifyHTTPError(httpErr, "enable private vulnerability reporting")
-
-	var roleErr *ErrInsufficientRole
-	if !errors.As(got, &roleErr) {
-		t.Fatalf("expected *ErrInsufficientRole, got %T: %v", got, got)
-	}
-	if roleErr.RequiredRole != "admin or security manager" {
-		t.Errorf("RequiredRole = %q, want %q", roleErr.RequiredRole, "admin or security manager")
-	}
-}
-
-func TestClassifyHTTPError_403RoleError_ASF(t *testing.T) {
-	httpErr := newHTTPError(http.StatusForbidden, "Resource not accessible by integration", http.Header{})
-
-	got := classifyHTTPError(httpErr, "disable automated security fixes")
-
-	var roleErr *ErrInsufficientRole
-	if !errors.As(got, &roleErr) {
-		t.Fatalf("expected *ErrInsufficientRole, got %T: %v", got, got)
-	}
-	if roleErr.RequiredRole != "admin" {
-		t.Errorf("RequiredRole = %q, want %q", roleErr.RequiredRole, "admin")
-	}
-}
-
 func TestClassifyHTTPError_404ClassifiedAsScopeError(t *testing.T) {
 	httpErr := newHTTPError(http.StatusNotFound, "Not Found", http.Header{})
 
@@ -320,20 +238,6 @@ func TestClassifyHTTPError_404ClassifiedAsScopeError(t *testing.T) {
 	}
 	if scopeErr.StatusCode != http.StatusNotFound {
 		t.Errorf("StatusCode = %d, want %d", scopeErr.StatusCode, http.StatusNotFound)
-	}
-}
-
-func TestClassifyHTTPError_404AdminRoleOperation(t *testing.T) {
-	httpErr := newHTTPError(http.StatusNotFound, "Not Found", http.Header{})
-
-	got := classifyHTTPError(httpErr, "enable vulnerability alerts")
-
-	var roleErr *ErrInsufficientRole
-	if !errors.As(got, &roleErr) {
-		t.Fatalf("expected *ErrInsufficientRole for 404 on admin-role op, got %T: %v", got, got)
-	}
-	if roleErr.StatusCode != http.StatusNotFound {
-		t.Errorf("StatusCode = %d, want %d", roleErr.StatusCode, http.StatusNotFound)
 	}
 }
 

--- a/internal/gh/settings.go
+++ b/internal/gh/settings.go
@@ -3,9 +3,7 @@ package gh
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"reflect"
 	"strings"
 
@@ -36,11 +34,6 @@ type repoResponse struct {
 	Topics                   []string `json:"topics"`
 }
 
-// vulnerabilityReportingResponse holds the private vulnerability reporting status.
-type vulnerabilityReportingResponse struct {
-	Enabled bool `json:"enabled"`
-}
-
 // workflowPermissionsResponse holds the Actions workflow permission settings.
 type workflowPermissionsResponse struct {
 	DefaultWorkflowPermissions   string `json:"default_workflow_permissions"`
@@ -49,8 +42,7 @@ type workflowPermissionsResponse struct {
 
 // ReadRepoSettings fetches repository settings from the GitHub API and returns
 // them as a model.RepositorySettings. It makes separate API calls for the
-// standard repository fields, private vulnerability reporting, automated
-// security fixes, vulnerability alerts, and Actions workflow permissions.
+// standard repository fields and Actions workflow permissions.
 //
 // The returned warnings slice contains classified access errors
 // (ErrInsufficientScope, ErrInsufficientRole) for sub-calls that returned 403.
@@ -88,42 +80,6 @@ func ReadRepoSettings(client *api.RESTClient, owner, name string) (*model.Reposi
 	// and the classified error is appended to warnings for the caller.
 	var warnings []error
 
-	pvrEnabled, pvrKnown, pvrErr := readSecurityFeatureEnabled(client, fmt.Sprintf("repos/%s/%s/private-vulnerability-reporting", owner, name))
-	if pvrKnown {
-		s.PrivateVulnerabilityReportEnabled = ptr.Ptr(pvrEnabled)
-	} else if pvrErr != nil {
-		classified := classifyHTTPError(pvrErr, "fetch private vulnerability reporting")
-		if isAccessError(classified) {
-			warnings = append(warnings, classified)
-		} else {
-			return nil, nil, fmt.Errorf("fetching private vulnerability reporting: %w", pvrErr)
-		}
-	}
-
-	asfEnabled, asfKnown, asfErr := readSecurityFeatureEnabled(client, fmt.Sprintf("repos/%s/%s/automated-security-fixes", owner, name))
-	if asfKnown {
-		s.AutomatedSecurityFixesEnabled = ptr.Ptr(asfEnabled)
-	} else if asfErr != nil {
-		classified := classifyHTTPError(asfErr, "fetch automated security fixes")
-		if isAccessError(classified) {
-			warnings = append(warnings, classified)
-		} else {
-			return nil, nil, fmt.Errorf("fetching automated security fixes: %w", asfErr)
-		}
-	}
-
-	vaEnabled, vaKnown, vaErr := readSecurityFeatureStatus(client, fmt.Sprintf("repos/%s/%s/vulnerability-alerts", owner, name))
-	if vaKnown {
-		s.VulnerabilityAlertsEnabled = ptr.Ptr(vaEnabled)
-	} else if vaErr != nil {
-		classified := classifyHTTPError(vaErr, "fetch vulnerability alerts")
-		if isAccessError(classified) {
-			warnings = append(warnings, classified)
-		} else {
-			return nil, nil, fmt.Errorf("fetching vulnerability alerts: %w", vaErr)
-		}
-	}
-
 	var wfPerms workflowPermissionsResponse
 	if err := client.Get(fmt.Sprintf("repos/%s/%s/actions/permissions/workflow", owner, name), &wfPerms); err != nil {
 		classified := classifyHTTPError(err, "fetch workflow permissions")
@@ -140,47 +96,10 @@ func ReadRepoSettings(client *api.RESTClient, owner, name string) (*model.Reposi
 	return s, warnings, nil
 }
 
-// isHTTP404 returns true when err wraps an *api.HTTPError with status 404.
-func isHTTP404(err error) bool {
-	var httpErr *api.HTTPError
-	return errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound
-}
-
-// readSecurityFeatureEnabled reads a security feature GET endpoint that returns
-// {"enabled": bool} on success and 404 when the feature is disabled. It returns
-// (value, true, nil) on success, (false, true, nil) on 404, and
-// (false, false, err) for any other error. The second return value indicates
-// whether the result is known (true) or the call failed for a non-404 reason
-// and the caller should classify the error.
-func readSecurityFeatureEnabled(client *api.RESTClient, path string) (enabled bool, known bool, err error) {
-	var resp vulnerabilityReportingResponse
-	if err := client.Get(path, &resp); err != nil {
-		if isHTTP404(err) {
-			return false, true, nil
-		}
-		return false, false, err
-	}
-	return resp.Enabled, true, nil
-}
-
-// readSecurityFeatureStatus reads a security feature GET endpoint that returns
-// 204 when enabled and 404 when disabled, with no JSON body (e.g. vulnerability
-// alerts). Returns (true, true, nil) on 204, (false, true, nil) on 404, and
-// (false, false, err) for any other error.
-func readSecurityFeatureStatus(client *api.RESTClient, path string) (enabled bool, known bool, err error) {
-	if err := client.Get(path, nil); err != nil {
-		if isHTTP404(err) {
-			return false, true, nil
-		}
-		return false, false, err
-	}
-	return true, true, nil
-}
-
 // SkippedOperation records a sub-operation that was skipped due to
 // insufficient token scope or repository role.
 type SkippedOperation struct {
-	Operation string // e.g. "enabling private vulnerability reporting"
+	Operation string // e.g. "set workflow permissions"
 	Err       error  // *ErrInsufficientScope or *ErrInsufficientRole
 }
 
@@ -192,9 +111,8 @@ type ApplyResult struct {
 
 // ApplyRepoSettings sends a PATCH /repos/{owner}/{repo} with the declared
 // settings. It also handles fields that require separate API endpoints:
-// private vulnerability reporting, vulnerability alerts, automated security
-// fixes, topics, and Actions workflow permissions. Access errors (insufficient
-// scope or role) are collected in the returned ApplyResult rather than aborting.
+// topics and Actions workflow permissions. Access errors (insufficient scope
+// or role) are collected in the returned ApplyResult rather than aborting.
 // Hard errors still return as the error value.
 func ApplyRepoSettings(client *api.RESTClient, owner, name string, settings *model.RepositorySettings) (*ApplyResult, error) {
 	p := buildSettingsPayload(settings)
@@ -211,84 +129,6 @@ func ApplyRepoSettings(client *api.RESTClient, owner, name string, settings *mod
 				result.Skipped = append(result.Skipped, SkippedOperation{Operation: "patch repo settings", Err: classified})
 			} else {
 				return nil, fmt.Errorf("patching repo settings: %w", err)
-			}
-		}
-	}
-
-	if p.PrivateVulnerabilityReporting != nil {
-		pvrPath := fmt.Sprintf("repos/%s/%s/private-vulnerability-reporting", owner, name)
-		var opName string
-		var pvrErr error
-		if *p.PrivateVulnerabilityReporting {
-			opName = "enable private vulnerability reporting"
-			pvrErr = client.Put(pvrPath, bytes.NewReader([]byte("{}")), nil)
-		} else {
-			opName = "disable private vulnerability reporting"
-			pvrErr = client.Delete(pvrPath, nil)
-		}
-		if pvrErr != nil {
-			classified := classifyHTTPError(pvrErr, opName)
-			if isAccessError(classified) {
-				result.Skipped = append(result.Skipped, SkippedOperation{Operation: opName, Err: classified})
-			} else {
-				return nil, fmt.Errorf("%s: %w", opName, pvrErr)
-			}
-		}
-	}
-
-	// Vulnerability alerts and automated security fixes have ordering
-	// constraints: automated_security_fixes requires vulnerability_alerts to
-	// be active. When enabling both, enable alerts first. When disabling
-	// both, disable security fixes first.
-	vaPath := fmt.Sprintf("repos/%s/%s/vulnerability-alerts", owner, name)
-	asfPath := fmt.Sprintf("repos/%s/%s/automated-security-fixes", owner, name)
-
-	enableVA := p.VulnerabilityAlerts != nil && *p.VulnerabilityAlerts
-	enableASF := p.AutomatedSecurityFixes != nil && *p.AutomatedSecurityFixes
-	disableVA := p.VulnerabilityAlerts != nil && !*p.VulnerabilityAlerts
-	disableASF := p.AutomatedSecurityFixes != nil && !*p.AutomatedSecurityFixes
-
-	// Disable security fixes before disabling alerts.
-	if disableASF {
-		if err := client.Delete(asfPath, nil); err != nil {
-			classified := classifyHTTPError(err, "disable automated security fixes")
-			if isAccessError(classified) {
-				result.Skipped = append(result.Skipped, SkippedOperation{Operation: "disable automated security fixes", Err: classified})
-			} else {
-				return nil, fmt.Errorf("disabling automated security fixes: %w", err)
-			}
-		}
-	}
-
-	// Enable or disable vulnerability alerts.
-	if enableVA {
-		if err := client.Put(vaPath, bytes.NewReader([]byte("{}")), nil); err != nil {
-			classified := classifyHTTPError(err, "enable vulnerability alerts")
-			if isAccessError(classified) {
-				result.Skipped = append(result.Skipped, SkippedOperation{Operation: "enable vulnerability alerts", Err: classified})
-			} else {
-				return nil, fmt.Errorf("enabling vulnerability alerts: %w", err)
-			}
-		}
-	} else if disableVA {
-		if err := client.Delete(vaPath, nil); err != nil {
-			classified := classifyHTTPError(err, "disable vulnerability alerts")
-			if isAccessError(classified) {
-				result.Skipped = append(result.Skipped, SkippedOperation{Operation: "disable vulnerability alerts", Err: classified})
-			} else {
-				return nil, fmt.Errorf("disabling vulnerability alerts: %w", err)
-			}
-		}
-	}
-
-	// Enable security fixes after enabling alerts.
-	if enableASF {
-		if err := client.Put(asfPath, bytes.NewReader([]byte("{}")), nil); err != nil {
-			classified := classifyHTTPError(err, "enable automated security fixes")
-			if isAccessError(classified) {
-				result.Skipped = append(result.Skipped, SkippedOperation{Operation: "enable automated security fixes", Err: classified})
-			} else {
-				return nil, fmt.Errorf("enabling automated security fixes: %w", err)
 			}
 		}
 	}
@@ -369,12 +209,6 @@ func applyWorkflowPermissions(client *api.RESTClient, owner, name string, p sett
 type settingsPayload struct {
 	// Body is the map sent as PATCH /repos/{owner}/{repo}.
 	Body map[string]any
-	// PrivateVulnerabilityReporting is non-nil when the field is declared.
-	PrivateVulnerabilityReporting *bool
-	// VulnerabilityAlerts is non-nil when the field is declared.
-	VulnerabilityAlerts *bool
-	// AutomatedSecurityFixes is non-nil when the field is declared.
-	AutomatedSecurityFixes *bool
 	// Topics is non-nil when the field is declared.
 	Topics *[]string
 	// DefaultWorkflowPermissions is non-nil when the field is declared.
@@ -386,12 +220,9 @@ type settingsPayload struct {
 // nonPatchFields lists yaml keys that must not appear in the PATCH body
 // because they are managed by separate API endpoints.
 var nonPatchFields = map[string]bool{
-	"private_vulnerability_reporting_enabled": true,
-	"vulnerability_alerts_enabled":            true,
-	"automated_security_fixes_enabled":        true,
-	"topics":                                  true,
-	"default_workflow_permissions":            true,
-	"can_approve_pull_request_reviews":        true,
+	"topics":                           true,
+	"default_workflow_permissions":     true,
+	"can_approve_pull_request_reviews": true,
 }
 
 // buildSettingsPayload uses reflection to build a map of non-nil fields from
@@ -420,15 +251,6 @@ func buildSettingsPayload(settings *model.RepositorySettings) settingsPayload {
 
 		if nonPatchFields[key] {
 			switch key {
-			case "private_vulnerability_reporting_enabled":
-				b := fv.Elem().Bool()
-				p.PrivateVulnerabilityReporting = &b
-			case "vulnerability_alerts_enabled":
-				b := fv.Elem().Bool()
-				p.VulnerabilityAlerts = &b
-			case "automated_security_fixes_enabled":
-				b := fv.Elem().Bool()
-				p.AutomatedSecurityFixes = &b
 			case "topics":
 				s := fv.Elem().Interface().([]string)
 				p.Topics = &s

--- a/internal/gh/settings_test.go
+++ b/internal/gh/settings_test.go
@@ -2,7 +2,6 @@ package gh
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -64,8 +63,6 @@ const fullRepoJSON = `{
 }`
 
 const (
-	pvrEnabledJSON   = `{"enabled": true}`
-	asfEnabledJSON   = `{"enabled": true}`
 	wfPermsReadJSON  = `{"default_workflow_permissions": "read", "can_approve_pull_request_reviews": false}`
 	wfPermsWriteJSON = `{"default_workflow_permissions": "write", "can_approve_pull_request_reviews": true}`
 )
@@ -74,10 +71,7 @@ func TestReadRepoSettings(t *testing.T) {
 	tests := []struct {
 		name        string
 		repoJSON    string
-		pvrJSON     string
-		asfJSON     string
 		wfPermsJSON string
-		vaStatus    int // HTTP status for vulnerability-alerts endpoint
 		// expected field checks
 		wantDesc       string
 		wantDescNil    bool
@@ -98,9 +92,6 @@ func TestReadRepoSettings(t *testing.T) {
 		wantUpdate     bool
 		wantAuto       bool
 		wantSignoff    bool
-		wantPVR        bool
-		wantASF        bool
-		wantVA         bool
 		wantTopics     []string
 		wantWfPerms    string
 		wantCanApprove bool
@@ -108,10 +99,7 @@ func TestReadRepoSettings(t *testing.T) {
 		{
 			name:           "all fields populated",
 			repoJSON:       fullRepoJSON,
-			pvrJSON:        pvrEnabledJSON,
-			asfJSON:        asfEnabledJSON,
 			wfPermsJSON:    wfPermsWriteJSON,
-			vaStatus:       http.StatusNoContent,
 			wantDesc:       "A tailor for your repos",
 			wantHome:       "https://tailor.dev",
 			wantWiki:       false,
@@ -129,9 +117,6 @@ func TestReadRepoSettings(t *testing.T) {
 			wantUpdate:     true,
 			wantAuto:       true,
 			wantSignoff:    false,
-			wantPVR:        true,
-			wantASF:        true,
-			wantVA:         true,
 			wantTopics:     []string{"go", "cli-tool"},
 			wantWfPerms:    "write",
 			wantCanApprove: true,
@@ -157,10 +142,7 @@ func TestReadRepoSettings(t *testing.T) {
 				"allow_auto_merge": false,
 				"web_commit_signoff_required": true
 			}`,
-			pvrJSON:        `{"enabled": false}`,
-			asfJSON:        `{"enabled": false}`,
 			wfPermsJSON:    wfPermsReadJSON,
-			vaStatus:       http.StatusNotFound,
 			wantDesc:       "",
 			wantHome:       "",
 			wantWiki:       true,
@@ -178,9 +160,6 @@ func TestReadRepoSettings(t *testing.T) {
 			wantUpdate:     false,
 			wantAuto:       false,
 			wantSignoff:    true,
-			wantPVR:        false,
-			wantASF:        false,
-			wantVA:         false,
 			wantTopics:     nil,
 			wantWfPerms:    "read",
 			wantCanApprove: false,
@@ -193,12 +172,6 @@ func TestReadRepoSettings(t *testing.T) {
 				switch r.URL.Path {
 				case "/repos/testowner/testrepo":
 					fmt.Fprint(w, tt.repoJSON)
-				case "/repos/testowner/testrepo/private-vulnerability-reporting":
-					fmt.Fprint(w, tt.pvrJSON)
-				case "/repos/testowner/testrepo/automated-security-fixes":
-					fmt.Fprint(w, tt.asfJSON)
-				case "/repos/testowner/testrepo/vulnerability-alerts":
-					w.WriteHeader(tt.vaStatus)
 				case "/repos/testowner/testrepo/actions/permissions/workflow":
 					fmt.Fprint(w, tt.wfPermsJSON)
 				default:
@@ -229,9 +202,6 @@ func TestReadRepoSettings(t *testing.T) {
 			testutil.AssertBoolPtr(t, settings.AllowUpdateBranch, false, tt.wantUpdate, "allow_update_branch")
 			testutil.AssertBoolPtr(t, settings.AllowAutoMerge, false, tt.wantAuto, "allow_auto_merge")
 			testutil.AssertBoolPtr(t, settings.WebCommitSignoffRequired, false, tt.wantSignoff, "web_commit_signoff_required")
-			testutil.AssertBoolPtr(t, settings.PrivateVulnerabilityReportEnabled, false, tt.wantPVR, "private_vulnerability_reporting_enabled")
-			testutil.AssertBoolPtr(t, settings.AutomatedSecurityFixesEnabled, false, tt.wantASF, "automated_security_fixes_enabled")
-			testutil.AssertBoolPtr(t, settings.VulnerabilityAlertsEnabled, false, tt.wantVA, "vulnerability_alerts_enabled")
 			testutil.AssertBoolPtr(t, settings.CanApprovePullRequestReviews, false, tt.wantCanApprove, "can_approve_pull_request_reviews")
 
 			// string fields (always non-nil)
@@ -278,134 +248,11 @@ func TestReadRepoSettingsRepoAPIError(t *testing.T) {
 	}
 }
 
-func TestReadRepoSettingsPVR403GracefulDegradation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/repos/testowner/testrepo":
-			fmt.Fprint(w, fullRepoJSON)
-		case "/repos/testowner/testrepo/private-vulnerability-reporting":
-			w.WriteHeader(http.StatusForbidden)
-			fmt.Fprint(w, `{"message": "Forbidden"}`)
-		case "/repos/testowner/testrepo/automated-security-fixes":
-			fmt.Fprint(w, asfEnabledJSON)
-		case "/repos/testowner/testrepo/vulnerability-alerts":
-			w.WriteHeader(http.StatusNoContent)
-		case "/repos/testowner/testrepo/actions/permissions/workflow":
-			fmt.Fprint(w, wfPermsReadJSON)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings, warnings, err := ReadRepoSettings(client, "testowner", "testrepo")
-	if err != nil {
-		t.Fatalf("ReadRepoSettings() unexpected error: %v", err)
-	}
-
-	// PVR should be nil (inaccessible).
-	if settings.PrivateVulnerabilityReportEnabled != nil {
-		t.Errorf("PrivateVulnerabilityReportEnabled = %v, want nil", *settings.PrivateVulnerabilityReportEnabled)
-	}
-	// A warning should be returned for the PVR 403.
-	if len(warnings) != 1 {
-		t.Fatalf("expected 1 warning, got %d", len(warnings))
-	}
-	var roleErr *ErrInsufficientRole
-	if !errors.As(warnings[0], &roleErr) {
-		t.Errorf("expected *ErrInsufficientRole warning, got %T", warnings[0])
-	}
-	// Other fields should be populated.
-	testutil.AssertBoolPtr(t, settings.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
-	testutil.AssertBoolPtr(t, settings.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertStringPtr(t, settings.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
-	testutil.AssertStringPtr(t, settings.Description, false, "A tailor for your repos", "description")
-}
-
-func TestReadRepoSettingsVA403GracefulDegradation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/repos/testowner/testrepo":
-			fmt.Fprint(w, fullRepoJSON)
-		case "/repos/testowner/testrepo/private-vulnerability-reporting":
-			fmt.Fprint(w, pvrEnabledJSON)
-		case "/repos/testowner/testrepo/automated-security-fixes":
-			fmt.Fprint(w, asfEnabledJSON)
-		case "/repos/testowner/testrepo/vulnerability-alerts":
-			w.WriteHeader(http.StatusForbidden)
-			fmt.Fprint(w, `{"message": "Forbidden"}`)
-		case "/repos/testowner/testrepo/actions/permissions/workflow":
-			fmt.Fprint(w, wfPermsReadJSON)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings, _, err := ReadRepoSettings(client, "testowner", "testrepo")
-	if err != nil {
-		t.Fatalf("ReadRepoSettings() unexpected error: %v", err)
-	}
-
-	// VA should be nil (inaccessible).
-	if settings.VulnerabilityAlertsEnabled != nil {
-		t.Errorf("VulnerabilityAlertsEnabled = %v, want nil", *settings.VulnerabilityAlertsEnabled)
-	}
-	// Other fields should be populated.
-	testutil.AssertBoolPtr(t, settings.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertBoolPtr(t, settings.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
-	testutil.AssertStringPtr(t, settings.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
-}
-
-func TestReadRepoSettingsASF403GracefulDegradation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/repos/testowner/testrepo":
-			fmt.Fprint(w, fullRepoJSON)
-		case "/repos/testowner/testrepo/private-vulnerability-reporting":
-			fmt.Fprint(w, pvrEnabledJSON)
-		case "/repos/testowner/testrepo/automated-security-fixes":
-			w.WriteHeader(http.StatusForbidden)
-			fmt.Fprint(w, `{"message": "Forbidden"}`)
-		case "/repos/testowner/testrepo/vulnerability-alerts":
-			w.WriteHeader(http.StatusNoContent)
-		case "/repos/testowner/testrepo/actions/permissions/workflow":
-			fmt.Fprint(w, wfPermsReadJSON)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings, _, err := ReadRepoSettings(client, "testowner", "testrepo")
-	if err != nil {
-		t.Fatalf("ReadRepoSettings() unexpected error: %v", err)
-	}
-
-	// ASF should be nil (inaccessible).
-	if settings.AutomatedSecurityFixesEnabled != nil {
-		t.Errorf("AutomatedSecurityFixesEnabled = %v, want nil", *settings.AutomatedSecurityFixesEnabled)
-	}
-	// Other fields should be populated.
-	testutil.AssertBoolPtr(t, settings.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertBoolPtr(t, settings.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertStringPtr(t, settings.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
-}
-
 func TestReadRepoSettingsWFPerms403GracefulDegradation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/repos/testowner/testrepo":
 			fmt.Fprint(w, fullRepoJSON)
-		case "/repos/testowner/testrepo/private-vulnerability-reporting":
-			fmt.Fprint(w, pvrEnabledJSON)
-		case "/repos/testowner/testrepo/automated-security-fixes":
-			fmt.Fprint(w, asfEnabledJSON)
-		case "/repos/testowner/testrepo/vulnerability-alerts":
-			w.WriteHeader(http.StatusNoContent)
 		case "/repos/testowner/testrepo/actions/permissions/workflow":
 			w.WriteHeader(http.StatusForbidden)
 			fmt.Fprint(w, `{"message": "Forbidden"}`)
@@ -429,110 +276,7 @@ func TestReadRepoSettingsWFPerms403GracefulDegradation(t *testing.T) {
 		t.Errorf("CanApprovePullRequestReviews = %v, want nil", *settings.CanApprovePullRequestReviews)
 	}
 	// Other fields should be populated.
-	testutil.AssertBoolPtr(t, settings.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertBoolPtr(t, settings.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
-	testutil.AssertBoolPtr(t, settings.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-}
-
-func TestReadRepoSettingsPVR404ReturnsDisabled(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/repos/testowner/testrepo":
-			fmt.Fprint(w, fullRepoJSON)
-		case "/repos/testowner/testrepo/private-vulnerability-reporting":
-			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprint(w, `{"message": "Not Found"}`)
-		case "/repos/testowner/testrepo/automated-security-fixes":
-			fmt.Fprint(w, asfEnabledJSON)
-		case "/repos/testowner/testrepo/vulnerability-alerts":
-			w.WriteHeader(http.StatusNoContent)
-		case "/repos/testowner/testrepo/actions/permissions/workflow":
-			fmt.Fprint(w, wfPermsReadJSON)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings, _, err := ReadRepoSettings(client, "testowner", "testrepo")
-	if err != nil {
-		t.Fatalf("ReadRepoSettings() unexpected error: %v", err)
-	}
-
-	// PVR 404 means disabled, not unknown.
-	testutil.AssertBoolPtr(t, settings.PrivateVulnerabilityReportEnabled, false, false, "private_vulnerability_reporting_enabled")
-	// Other fields should be populated normally.
-	testutil.AssertBoolPtr(t, settings.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
-	testutil.AssertBoolPtr(t, settings.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertStringPtr(t, settings.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
-}
-
-func TestReadRepoSettingsASF404ReturnsDisabled(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/repos/testowner/testrepo":
-			fmt.Fprint(w, fullRepoJSON)
-		case "/repos/testowner/testrepo/private-vulnerability-reporting":
-			fmt.Fprint(w, pvrEnabledJSON)
-		case "/repos/testowner/testrepo/automated-security-fixes":
-			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprint(w, `{"message": "Not Found"}`)
-		case "/repos/testowner/testrepo/vulnerability-alerts":
-			w.WriteHeader(http.StatusNoContent)
-		case "/repos/testowner/testrepo/actions/permissions/workflow":
-			fmt.Fprint(w, wfPermsReadJSON)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings, _, err := ReadRepoSettings(client, "testowner", "testrepo")
-	if err != nil {
-		t.Fatalf("ReadRepoSettings() unexpected error: %v", err)
-	}
-
-	// ASF 404 means disabled, not unknown.
-	testutil.AssertBoolPtr(t, settings.AutomatedSecurityFixesEnabled, false, false, "automated_security_fixes_enabled")
-	// Other fields should be populated normally.
-	testutil.AssertBoolPtr(t, settings.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertBoolPtr(t, settings.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertStringPtr(t, settings.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
-}
-
-func TestReadRepoSettingsVA404ReturnsDisabled(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/repos/testowner/testrepo":
-			fmt.Fprint(w, fullRepoJSON)
-		case "/repos/testowner/testrepo/private-vulnerability-reporting":
-			fmt.Fprint(w, pvrEnabledJSON)
-		case "/repos/testowner/testrepo/automated-security-fixes":
-			fmt.Fprint(w, asfEnabledJSON)
-		case "/repos/testowner/testrepo/vulnerability-alerts":
-			w.WriteHeader(http.StatusNotFound)
-		case "/repos/testowner/testrepo/actions/permissions/workflow":
-			fmt.Fprint(w, wfPermsReadJSON)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings, _, err := ReadRepoSettings(client, "testowner", "testrepo")
-	if err != nil {
-		t.Fatalf("ReadRepoSettings() unexpected error: %v", err)
-	}
-
-	// VA 404 means disabled, not unknown.
-	testutil.AssertBoolPtr(t, settings.VulnerabilityAlertsEnabled, false, false, "vulnerability_alerts_enabled")
-	// Other fields should be populated normally.
-	testutil.AssertBoolPtr(t, settings.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertBoolPtr(t, settings.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
-	testutil.AssertStringPtr(t, settings.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
+	testutil.AssertStringPtr(t, settings.Description, false, "A tailor for your repos", "description")
 }
 
 func TestReadRepoSettingsAll403GracefulDegradation(t *testing.T) {
@@ -554,24 +298,15 @@ func TestReadRepoSettingsAll403GracefulDegradation(t *testing.T) {
 	}
 
 	// All sub-call fields should be nil.
-	if settings.PrivateVulnerabilityReportEnabled != nil {
-		t.Errorf("PrivateVulnerabilityReportEnabled = %v, want nil", *settings.PrivateVulnerabilityReportEnabled)
-	}
-	if settings.AutomatedSecurityFixesEnabled != nil {
-		t.Errorf("AutomatedSecurityFixesEnabled = %v, want nil", *settings.AutomatedSecurityFixesEnabled)
-	}
-	if settings.VulnerabilityAlertsEnabled != nil {
-		t.Errorf("VulnerabilityAlertsEnabled = %v, want nil", *settings.VulnerabilityAlertsEnabled)
-	}
 	if settings.DefaultWorkflowPermissions != nil {
 		t.Errorf("DefaultWorkflowPermissions = %v, want nil", *settings.DefaultWorkflowPermissions)
 	}
 	if settings.CanApprovePullRequestReviews != nil {
 		t.Errorf("CanApprovePullRequestReviews = %v, want nil", *settings.CanApprovePullRequestReviews)
 	}
-	// Four warnings: PVR, ASF, VA, workflow permissions.
-	if len(warnings) != 4 {
-		t.Errorf("expected 4 warnings, got %d", len(warnings))
+	// One warning: workflow permissions.
+	if len(warnings) != 1 {
+		t.Errorf("expected 1 warning, got %d", len(warnings))
 	}
 	// Core repo fields should still be populated.
 	testutil.AssertStringPtr(t, settings.Description, false, "A tailor for your repos", "description")
@@ -583,7 +318,7 @@ func TestReadRepoSettingsNon403StillFails(t *testing.T) {
 		switch r.URL.Path {
 		case "/repos/testowner/testrepo":
 			fmt.Fprint(w, fullRepoJSON)
-		case "/repos/testowner/testrepo/private-vulnerability-reporting":
+		case "/repos/testowner/testrepo/actions/permissions/workflow":
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprint(w, `{"message": "Internal Server Error"}`)
 		default:
@@ -648,11 +383,8 @@ func TestApplyRepoSettingsPatchBody(t *testing.T) {
 		t.Error("homepage should not be in PATCH body when nil")
 	}
 
-	// Verify all six non-PATCH fields excluded from body.
+	// Verify all three non-PATCH fields excluded from body.
 	for _, key := range []string{
-		"private_vulnerability_reporting_enabled",
-		"vulnerability_alerts_enabled",
-		"automated_security_fixes_enabled",
 		"topics",
 		"default_workflow_permissions",
 		"can_approve_pull_request_reviews",
@@ -666,14 +398,11 @@ func TestApplyRepoSettingsPatchBody(t *testing.T) {
 func TestBuildSettingsPayloadExtractsAllNonPatchFields(t *testing.T) {
 	topics := []string{"go", "cli"}
 	settings := &model.RepositorySettings{
-		Description:                       ptr.Ptr("desc"),
-		HasWiki:                           ptr.Ptr(true),
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-		VulnerabilityAlertsEnabled:        ptr.Ptr(true),
-		AutomatedSecurityFixesEnabled:     ptr.Ptr(false),
-		Topics:                            &topics,
-		DefaultWorkflowPermissions:        ptr.Ptr("read"),
-		CanApprovePullRequestReviews:      ptr.Ptr(true),
+		Description:                  ptr.Ptr("desc"),
+		HasWiki:                      ptr.Ptr(true),
+		Topics:                       &topics,
+		DefaultWorkflowPermissions:   ptr.Ptr("read"),
+		CanApprovePullRequestReviews: ptr.Ptr(true),
 	}
 
 	p := buildSettingsPayload(settings)
@@ -688,9 +417,6 @@ func TestBuildSettingsPayloadExtractsAllNonPatchFields(t *testing.T) {
 
 	// Non-PATCH fields must not appear in the body.
 	for _, key := range []string{
-		"private_vulnerability_reporting_enabled",
-		"vulnerability_alerts_enabled",
-		"automated_security_fixes_enabled",
 		"topics",
 		"default_workflow_permissions",
 		"can_approve_pull_request_reviews",
@@ -701,15 +427,6 @@ func TestBuildSettingsPayloadExtractsAllNonPatchFields(t *testing.T) {
 	}
 
 	// Verify extracted fields.
-	if p.PrivateVulnerabilityReporting == nil || *p.PrivateVulnerabilityReporting != true {
-		t.Errorf("PrivateVulnerabilityReporting = %v, want ptr(true)", p.PrivateVulnerabilityReporting)
-	}
-	if p.VulnerabilityAlerts == nil || *p.VulnerabilityAlerts != true {
-		t.Errorf("VulnerabilityAlerts = %v, want ptr(true)", p.VulnerabilityAlerts)
-	}
-	if p.AutomatedSecurityFixes == nil || *p.AutomatedSecurityFixes != false {
-		t.Errorf("AutomatedSecurityFixes = %v, want ptr(false)", p.AutomatedSecurityFixes)
-	}
 	if p.Topics == nil {
 		t.Fatal("Topics is nil, want non-nil")
 	}
@@ -731,15 +448,6 @@ func TestBuildSettingsPayloadNilFieldsStayNil(t *testing.T) {
 
 	p := buildSettingsPayload(settings)
 
-	if p.PrivateVulnerabilityReporting != nil {
-		t.Errorf("PrivateVulnerabilityReporting = %v, want nil", p.PrivateVulnerabilityReporting)
-	}
-	if p.VulnerabilityAlerts != nil {
-		t.Errorf("VulnerabilityAlerts = %v, want nil", p.VulnerabilityAlerts)
-	}
-	if p.AutomatedSecurityFixes != nil {
-		t.Errorf("AutomatedSecurityFixes = %v, want nil", p.AutomatedSecurityFixes)
-	}
 	if p.Topics != nil {
 		t.Errorf("Topics = %v, want nil", p.Topics)
 	}
@@ -771,91 +479,6 @@ func TestBuildSettingsPayloadEmptyTopics(t *testing.T) {
 	}
 	if _, ok := p.Body["topics"]; ok {
 		t.Error("topics should not be in PATCH body")
-	}
-}
-
-func TestApplyRepoSettingsPVRPut(t *testing.T) {
-	var gotMethod string
-	var gotPath string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotMethod = r.Method
-		gotPath = r.URL.Path
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-	}
-
-	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err != nil {
-		t.Fatalf("ApplyRepoSettings() error: %v", err)
-	}
-
-	if gotMethod != http.MethodPut {
-		t.Errorf("method = %s, want PUT", gotMethod)
-	}
-	if gotPath != "/repos/testowner/testrepo/private-vulnerability-reporting" {
-		t.Errorf("path = %s, want /repos/testowner/testrepo/private-vulnerability-reporting", gotPath)
-	}
-}
-
-func TestApplyRepoSettingsPVRDelete(t *testing.T) {
-	var gotMethod string
-	var gotPath string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotMethod = r.Method
-		gotPath = r.URL.Path
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(false),
-	}
-
-	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err != nil {
-		t.Fatalf("ApplyRepoSettings() error: %v", err)
-	}
-
-	if gotMethod != http.MethodDelete {
-		t.Errorf("method = %s, want DELETE", gotMethod)
-	}
-	if gotPath != "/repos/testowner/testrepo/private-vulnerability-reporting" {
-		t.Errorf("path = %s, want /repos/testowner/testrepo/private-vulnerability-reporting", gotPath)
-	}
-}
-
-func TestApplyRepoSettingsNoPatchWhenOnlyPVR(t *testing.T) {
-	var methods []string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		methods = append(methods, r.Method)
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-	}
-
-	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err != nil {
-		t.Fatalf("ApplyRepoSettings() error: %v", err)
-	}
-
-	if len(methods) != 1 {
-		t.Fatalf("expected 1 API call, got %d: %v", len(methods), methods)
-	}
-	if methods[0] != http.MethodPut {
-		t.Errorf("single call method = %s, want PUT (no PATCH)", methods[0])
 	}
 }
 
@@ -1059,250 +682,6 @@ func TestApplyRepoSettingsWorkflowPermsPutError(t *testing.T) {
 	}
 }
 
-func TestApplyRepoSettingsPVRError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(w, `{"message": "Internal Server Error"}`)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-	}
-
-	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err == nil {
-		t.Fatal("ApplyRepoSettings() expected error from PUT, got nil")
-	}
-}
-
-func TestApplyRepoSettingsVAPut(t *testing.T) {
-	var gotMethod string
-	var gotPath string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotMethod = r.Method
-		gotPath = r.URL.Path
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		VulnerabilityAlertsEnabled: ptr.Ptr(true),
-	}
-
-	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err != nil {
-		t.Fatalf("ApplyRepoSettings() error: %v", err)
-	}
-
-	if gotMethod != http.MethodPut {
-		t.Errorf("method = %s, want PUT", gotMethod)
-	}
-	if gotPath != "/repos/testowner/testrepo/vulnerability-alerts" {
-		t.Errorf("path = %s, want /repos/testowner/testrepo/vulnerability-alerts", gotPath)
-	}
-}
-
-func TestApplyRepoSettingsVADelete(t *testing.T) {
-	var gotMethod string
-	var gotPath string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotMethod = r.Method
-		gotPath = r.URL.Path
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		VulnerabilityAlertsEnabled: ptr.Ptr(false),
-	}
-
-	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err != nil {
-		t.Fatalf("ApplyRepoSettings() error: %v", err)
-	}
-
-	if gotMethod != http.MethodDelete {
-		t.Errorf("method = %s, want DELETE", gotMethod)
-	}
-	if gotPath != "/repos/testowner/testrepo/vulnerability-alerts" {
-		t.Errorf("path = %s, want /repos/testowner/testrepo/vulnerability-alerts", gotPath)
-	}
-}
-
-func TestApplyRepoSettingsASFPut(t *testing.T) {
-	var gotMethod string
-	var gotPath string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotMethod = r.Method
-		gotPath = r.URL.Path
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		AutomatedSecurityFixesEnabled: ptr.Ptr(true),
-	}
-
-	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err != nil {
-		t.Fatalf("ApplyRepoSettings() error: %v", err)
-	}
-
-	if gotMethod != http.MethodPut {
-		t.Errorf("method = %s, want PUT", gotMethod)
-	}
-	if gotPath != "/repos/testowner/testrepo/automated-security-fixes" {
-		t.Errorf("path = %s, want /repos/testowner/testrepo/automated-security-fixes", gotPath)
-	}
-}
-
-func TestApplyRepoSettingsASFDelete(t *testing.T) {
-	var gotMethod string
-	var gotPath string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotMethod = r.Method
-		gotPath = r.URL.Path
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		AutomatedSecurityFixesEnabled: ptr.Ptr(false),
-	}
-
-	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err != nil {
-		t.Fatalf("ApplyRepoSettings() error: %v", err)
-	}
-
-	if gotMethod != http.MethodDelete {
-		t.Errorf("method = %s, want DELETE", gotMethod)
-	}
-	if gotPath != "/repos/testowner/testrepo/automated-security-fixes" {
-		t.Errorf("path = %s, want /repos/testowner/testrepo/automated-security-fixes", gotPath)
-	}
-}
-
-func TestApplyRepoSettingsEnableBothVABeforeASF(t *testing.T) {
-	type call struct {
-		method string
-		path   string
-	}
-	var calls []call
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls = append(calls, call{method: r.Method, path: r.URL.Path})
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		VulnerabilityAlertsEnabled:    ptr.Ptr(true),
-		AutomatedSecurityFixesEnabled: ptr.Ptr(true),
-	}
-
-	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err != nil {
-		t.Fatalf("ApplyRepoSettings() error: %v", err)
-	}
-
-	if len(calls) != 2 {
-		t.Fatalf("expected 2 API calls, got %d: %v", len(calls), calls)
-	}
-
-	// Alerts must be enabled before security fixes.
-	if calls[0].method != http.MethodPut || calls[0].path != "/repos/testowner/testrepo/vulnerability-alerts" {
-		t.Errorf("call[0] = %s %s, want PUT /repos/testowner/testrepo/vulnerability-alerts", calls[0].method, calls[0].path)
-	}
-	if calls[1].method != http.MethodPut || calls[1].path != "/repos/testowner/testrepo/automated-security-fixes" {
-		t.Errorf("call[1] = %s %s, want PUT /repos/testowner/testrepo/automated-security-fixes", calls[1].method, calls[1].path)
-	}
-}
-
-func TestApplyRepoSettingsDisableBothASFBeforeVA(t *testing.T) {
-	type call struct {
-		method string
-		path   string
-	}
-	var calls []call
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls = append(calls, call{method: r.Method, path: r.URL.Path})
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		VulnerabilityAlertsEnabled:    ptr.Ptr(false),
-		AutomatedSecurityFixesEnabled: ptr.Ptr(false),
-	}
-
-	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err != nil {
-		t.Fatalf("ApplyRepoSettings() error: %v", err)
-	}
-
-	if len(calls) != 2 {
-		t.Fatalf("expected 2 API calls, got %d: %v", len(calls), calls)
-	}
-
-	// Security fixes must be disabled before alerts.
-	if calls[0].method != http.MethodDelete || calls[0].path != "/repos/testowner/testrepo/automated-security-fixes" {
-		t.Errorf("call[0] = %s %s, want DELETE /repos/testowner/testrepo/automated-security-fixes", calls[0].method, calls[0].path)
-	}
-	if calls[1].method != http.MethodDelete || calls[1].path != "/repos/testowner/testrepo/vulnerability-alerts" {
-		t.Errorf("call[1] = %s %s, want DELETE /repos/testowner/testrepo/vulnerability-alerts", calls[1].method, calls[1].path)
-	}
-}
-
-func TestApplyRepoSettingsVAError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(w, `{"message": "Internal Server Error"}`)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		VulnerabilityAlertsEnabled: ptr.Ptr(true),
-	}
-
-	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err == nil {
-		t.Fatal("ApplyRepoSettings() expected error from VA PUT, got nil")
-	}
-}
-
-func TestApplyRepoSettingsASFError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(w, `{"message": "Internal Server Error"}`)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		AutomatedSecurityFixesEnabled: ptr.Ptr(true),
-	}
-
-	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err == nil {
-		t.Fatal("ApplyRepoSettings() expected error from ASF PUT, got nil")
-	}
-}
-
 func TestApplyRepoSettingsTopicsPut(t *testing.T) {
 	var gotMethod string
 	var gotPath string
@@ -1435,102 +814,7 @@ func TestApplyRepoSettingsTopicsError(t *testing.T) {
 	}
 }
 
-func TestApplyRepoSettingsNoPatchWhenOnlyVAAndASF(t *testing.T) {
-	var methods []string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		methods = append(methods, r.Method)
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		VulnerabilityAlertsEnabled:    ptr.Ptr(true),
-		AutomatedSecurityFixesEnabled: ptr.Ptr(true),
-	}
-
-	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err != nil {
-		t.Fatalf("ApplyRepoSettings() error: %v", err)
-	}
-
-	if len(methods) != 2 {
-		t.Fatalf("expected 2 API calls, got %d: %v", len(methods), methods)
-	}
-	for _, m := range methods {
-		if m == http.MethodPatch {
-			t.Error("should not send PATCH when only VA and ASF are set")
-		}
-	}
-}
-
 // --- Task 2.2: partial application tests ---
-
-func TestApplyRepoSettingsPartialPatchSucceedsPVR403(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/repos/testowner/testrepo/private-vulnerability-reporting" {
-			w.WriteHeader(http.StatusForbidden)
-			fmt.Fprint(w, `{"message": "Must have admin rights"}`)
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		HasWiki:                           ptr.Ptr(true),
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-	}
-
-	result, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err != nil {
-		t.Fatalf("unexpected hard error: %v", err)
-	}
-	if len(result.Skipped) != 1 {
-		t.Fatalf("expected 1 skipped, got %d", len(result.Skipped))
-	}
-	if result.Skipped[0].Operation != "enable private vulnerability reporting" {
-		t.Errorf("skipped operation = %q, want %q", result.Skipped[0].Operation, "enable private vulnerability reporting")
-	}
-
-	var roleErr *ErrInsufficientRole
-	if !errors.As(result.Skipped[0].Err, &roleErr) {
-		t.Errorf("skipped error type = %T, want *ErrInsufficientRole", result.Skipped[0].Err)
-	}
-}
-
-func TestApplyRepoSettingsPartialVA403ASFSkipped(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/repos/testowner/testrepo/vulnerability-alerts" {
-			w.WriteHeader(http.StatusForbidden)
-			fmt.Fprint(w, `{"message": "Must have admin rights"}`)
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	settings := &model.RepositorySettings{
-		VulnerabilityAlertsEnabled:    ptr.Ptr(true),
-		AutomatedSecurityFixesEnabled: ptr.Ptr(true),
-	}
-
-	result, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err != nil {
-		t.Fatalf("unexpected hard error: %v", err)
-	}
-
-	// VA skipped, ASF should still be attempted (and succeed).
-	if len(result.Skipped) != 1 {
-		t.Fatalf("expected 1 skipped, got %d: %v", len(result.Skipped), result.Skipped)
-	}
-	if result.Skipped[0].Operation != "enable vulnerability alerts" {
-		t.Errorf("skipped = %q, want %q", result.Skipped[0].Operation, "enable vulnerability alerts")
-	}
-}
 
 func TestApplyRepoSettingsPartialTopics403(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1568,17 +852,15 @@ func TestApplyRepoSettingsAllSkipped(t *testing.T) {
 
 	client := newTestClient(t, server)
 	settings := &model.RepositorySettings{
-		HasWiki:                           ptr.Ptr(true),
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-		VulnerabilityAlertsEnabled:        ptr.Ptr(true),
+		HasWiki: ptr.Ptr(true),
 	}
 
 	result, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
 	if err != nil {
 		t.Fatalf("unexpected hard error: %v", err)
 	}
-	if len(result.Skipped) != 3 {
-		t.Errorf("expected 3 skipped, got %d: %v", len(result.Skipped), result.Skipped)
+	if len(result.Skipped) != 1 {
+		t.Errorf("expected 1 skipped, got %d: %v", len(result.Skipped), result.Skipped)
 	}
 }
 
@@ -1590,9 +872,7 @@ func TestApplyRepoSettingsApplyResultPopulatedOnSuccess(t *testing.T) {
 
 	client := newTestClient(t, server)
 	settings := &model.RepositorySettings{
-		HasWiki:                           ptr.Ptr(true),
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-		VulnerabilityAlertsEnabled:        ptr.Ptr(true),
+		HasWiki: ptr.Ptr(true),
 	}
 
 	result, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
@@ -1601,33 +881,5 @@ func TestApplyRepoSettingsApplyResultPopulatedOnSuccess(t *testing.T) {
 	}
 	if len(result.Skipped) != 0 {
 		t.Errorf("Skipped = %v, want empty", result.Skipped)
-	}
-}
-
-func TestApplyRepoSettingsHardErrorStopsExecution(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/repos/testowner/testrepo/private-vulnerability-reporting" {
-			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprint(w, `{"message": "Internal Server Error"}`)
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	client := newTestClient(t, server)
-	topics := []string{"go"}
-	settings := &model.RepositorySettings{
-		HasWiki:                           ptr.Ptr(true),
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-		Topics:                            &topics,
-	}
-
-	result, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
-	if err == nil {
-		t.Fatal("expected hard error from PVR 500")
-	}
-	if result != nil {
-		t.Errorf("expected nil result on hard error, got %v", result)
 	}
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -24,29 +24,26 @@ func LabelNeedsUpdate(existing, desired LabelEntry) bool {
 // RepositorySettings holds GitHub repository configuration fields.
 // Pointer types distinguish absent fields from zero values.
 type RepositorySettings struct {
-	Description                       *string   `yaml:"description,omitempty"`
-	Homepage                          *string   `yaml:"homepage,omitempty"`
-	HasWiki                           *bool     `yaml:"has_wiki,omitempty"`
-	HasDiscussions                    *bool     `yaml:"has_discussions,omitempty"`
-	HasProjects                       *bool     `yaml:"has_projects,omitempty"`
-	HasIssues                         *bool     `yaml:"has_issues,omitempty"`
-	AllowMergeCommit                  *bool     `yaml:"allow_merge_commit,omitempty"`
-	AllowSquashMerge                  *bool     `yaml:"allow_squash_merge,omitempty"`
-	AllowRebaseMerge                  *bool     `yaml:"allow_rebase_merge,omitempty"`
-	SquashMergeCommitTitle            *string   `yaml:"squash_merge_commit_title,omitempty"`
-	SquashMergeCommitMessage          *string   `yaml:"squash_merge_commit_message,omitempty"`
-	MergeCommitTitle                  *string   `yaml:"merge_commit_title,omitempty"`
-	MergeCommitMessage                *string   `yaml:"merge_commit_message,omitempty"`
-	DeleteBranchOnMerge               *bool     `yaml:"delete_branch_on_merge,omitempty"`
-	AllowUpdateBranch                 *bool     `yaml:"allow_update_branch,omitempty"`
-	AllowAutoMerge                    *bool     `yaml:"allow_auto_merge,omitempty"`
-	WebCommitSignoffRequired          *bool     `yaml:"web_commit_signoff_required,omitempty"`
-	PrivateVulnerabilityReportEnabled *bool     `yaml:"private_vulnerability_reporting_enabled,omitempty"`
-	VulnerabilityAlertsEnabled        *bool     `yaml:"vulnerability_alerts_enabled,omitempty"`
-	AutomatedSecurityFixesEnabled     *bool     `yaml:"automated_security_fixes_enabled,omitempty"`
-	Topics                            *[]string `yaml:"topics,omitempty" json:"topics,omitempty"`
-	DefaultWorkflowPermissions        *string   `yaml:"default_workflow_permissions,omitempty"`
-	CanApprovePullRequestReviews      *bool     `yaml:"can_approve_pull_request_reviews,omitempty"`
+	Description                  *string   `yaml:"description,omitempty"`
+	Homepage                     *string   `yaml:"homepage,omitempty"`
+	HasWiki                      *bool     `yaml:"has_wiki,omitempty"`
+	HasDiscussions               *bool     `yaml:"has_discussions,omitempty"`
+	HasProjects                  *bool     `yaml:"has_projects,omitempty"`
+	HasIssues                    *bool     `yaml:"has_issues,omitempty"`
+	AllowMergeCommit             *bool     `yaml:"allow_merge_commit,omitempty"`
+	AllowSquashMerge             *bool     `yaml:"allow_squash_merge,omitempty"`
+	AllowRebaseMerge             *bool     `yaml:"allow_rebase_merge,omitempty"`
+	SquashMergeCommitTitle       *string   `yaml:"squash_merge_commit_title,omitempty"`
+	SquashMergeCommitMessage     *string   `yaml:"squash_merge_commit_message,omitempty"`
+	MergeCommitTitle             *string   `yaml:"merge_commit_title,omitempty"`
+	MergeCommitMessage           *string   `yaml:"merge_commit_message,omitempty"`
+	DeleteBranchOnMerge          *bool     `yaml:"delete_branch_on_merge,omitempty"`
+	AllowUpdateBranch            *bool     `yaml:"allow_update_branch,omitempty"`
+	AllowAutoMerge               *bool     `yaml:"allow_auto_merge,omitempty"`
+	WebCommitSignoffRequired     *bool     `yaml:"web_commit_signoff_required,omitempty"`
+	Topics                       *[]string `yaml:"topics,omitempty" json:"topics,omitempty"`
+	DefaultWorkflowPermissions   *string   `yaml:"default_workflow_permissions,omitempty"`
+	CanApprovePullRequestReviews *bool     `yaml:"can_approve_pull_request_reviews,omitempty"`
 
 	// Extra captures any YAML keys not mapped to struct fields above.
 	// ValidateRepoSettings uses this to reject unrecognised settings.

--- a/swatches/.tailor.yml
+++ b/swatches/.tailor.yml
@@ -16,9 +16,6 @@ repository:
   allow_update_branch: true
   allow_auto_merge: true
   web_commit_signoff_required: false
-  private_vulnerability_reporting_enabled: true
-  vulnerability_alerts_enabled: true
-  automated_security_fixes_enabled: true
   default_workflow_permissions: read
   can_approve_pull_request_reviews: true
 


### PR DESCRIPTION
- Remove private_vulnerability_reporting_enabled, vulnerability_alerts_enabled, and automated_security_fixes_enabled from repository config, API layer, alter logic, and tests
- GitHub platform constraint: GITHUB_TOKEN never holds admin permissions in workflows, making these fields unimplementable in CI
- Tailor's declarative contract now accurately reflects what the tool can actually manage
- Simplifies codebase by removing dead code paths and impossible config options

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions