### PR TITLE
feat(swatch): add cubic.dev AI code review configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ tailor/
 ├── .github/workflows/  # CI workflows
 ├── cmd/tailor/         # CLI entrypoint
 ├── internal/           # Internal packages (config, swatch, gh wrappers)
-├── swatches/           # Embedded template files (17 swatches)
+├── swatches/           # Embedded template files (18 swatches)
 ├── docs/               # Specification
 └── AGENTS.md
 ```
@@ -47,7 +47,7 @@ tailor/
 - Four alteration modes: `always`, `first-fit`, `triggered`, `never`
 - `never` beats `triggered` - a user can suppress a triggered swatch by setting `alteration: never`
 - Triggered swatches use a lookup table in `internal/swatch/trigger.go` mapping source paths to config field conditions
-- `EvaluateTrigger(source string, repo any)` uses reflection to match yaml tags on `RepositorySettings`; `repo` is `any` (not `*config.RepositorySettings`) to avoid a circular import
+- Adding a new plain swatch requires: the file in `swatches/`, a registry entry (registry.go), an entry in `swatches/.tailor.yml`, updated count assertions in `registry_test.go` and any golden-string test fixtures, plus updates to `docs/SPECIFICATION.md` and `README.md`
 - Adding a new triggered swatch requires: an entry in `triggerConditions` (trigger.go), a registry entry (registry.go), and inclusion in `swatches/.tailor.yml`
 
 ## Testing
@@ -63,6 +63,7 @@ tailor/
 ## Key implementation details
 
 - Swatches are embedded at build time via `//go:embed swatches/*`
+- `EvaluateTrigger(source string, repo any)` uses reflection to match yaml tags on `RepositorySettings`; `repo` is `any` (not `*config.RepositorySettings`) to avoid a circular import
 - Five commands: `fit` (bootstrap), `alter` (apply), `baste` (preview), `measure` (inspect), `docket` (inspect)
 - `fit`, `alter`, and `baste` require a valid GitHub auth token at startup; `measure` and `docket` do not
 - `alter` execution order: repository settings, then labels, then licence, then swatches

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Licences are not swatches. They are fetched from the GitHub REST API (`GET /lice
 | `flake.nix` | `first-fit` |
 | `.gitignore` | `first-fit` |
 | `.envrc` | `first-fit` |
+| `cubic.yaml` | `first-fit` |
 | `.tailor.yml` | `always` |
 | `.github/workflows/tailor-automerge.yml` | `triggered` |
 

--- a/cmd/tailor/main_test.go
+++ b/cmd/tailor/main_test.go
@@ -36,8 +36,8 @@ func TestFitNewDirectoryDefaultConfig(t *testing.T) {
 	}
 
 	// Verify 17 swatches are present (count "- path:" occurrences).
-	if count := strings.Count(content, "- path:"); count != 17 {
-		t.Errorf("swatch count = %d, want 17", count)
+	if count := strings.Count(content, "- path:"); count != 18 {
+		t.Errorf("swatch count = %d, want 18", count)
 	}
 
 	// Verify the 13 default repo settings are present.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -43,6 +43,7 @@ The `fit`, `alter`, and `baste` commands verify that a valid authentication toke
 | `SUPPORT.md` | `SUPPORT.md` |
 | `flake.nix` | `flake.nix` |
 | `justfile` | `justfile` |
+| `cubic.yaml` | `cubic.yaml` |
 | `.github/FUNDING.yml` | `.github/FUNDING.yml` |
 | `.github/dependabot.yml` | `.github/dependabot.yml` |
 | `.github/ISSUE_TEMPLATE/bug_report.yml` | `.github/ISSUE_TEMPLATE/bug_report.yml` |
@@ -122,6 +123,7 @@ Settings deliberately excluded due to risk or org-level scope: `visibility`, `de
 | `.github/workflows/tailor-automerge.yml` | `triggered` |
 | `.github/dependabot.yml` | `first-fit` |
 | `justfile` | `first-fit` |
+| `cubic.yaml` | `first-fit` |
 | `flake.nix` | `first-fit` |
 | `.tailor.yml` | `always` |
 
@@ -145,6 +147,7 @@ Settings deliberately excluded due to risk or org-level scope: `visibility`, `de
 - `.envrc`
 - `flake.nix`
 - `justfile`
+- `cubic.yaml`
 - `.github/workflows/tailor.yml`
 - `.github/workflows/tailor-automerge.yml`
 - `.tailor.yml`
@@ -179,6 +182,7 @@ The default swatch set embedded in the binary is:
 - `flake.nix`
 - `.gitignore`
 - `.envrc`
+- `cubic.yaml`
 - `.tailor.yml`
 
 A `license` key is included in `.tailor.yml` by default (`license: BlueOak-1.0.0`). Use `--license=<id>` to select a different licence or `--license=none` to opt out entirely.
@@ -561,6 +565,9 @@ swatches:
   - path: .envrc
     alteration: first-fit
 
+  - path: cubic.yaml
+    alteration: first-fit
+
   - path: .github/workflows/tailor-automerge.yml
     alteration: triggered
 
@@ -589,6 +596,7 @@ Swatches are embedded in the tailor binary at build time from `swatches/`:
 swatches/
 ├── .envrc
 ├── .gitignore
+├── cubic.yaml
 ├── CODE_OF_CONDUCT.md
 ├── CONTRIBUTING.md
 ├── SECURITY.md

--- a/internal/config/generate_test.go
+++ b/internal/config/generate_test.go
@@ -113,8 +113,8 @@ func TestDefaultConfigSwatchCount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig() error: %v", err)
 	}
-	if len(cfg.Swatches) != 17 {
-		t.Errorf("Swatches count = %d, want 17", len(cfg.Swatches))
+	if len(cfg.Swatches) != 18 {
+		t.Errorf("Swatches count = %d, want 18", len(cfg.Swatches))
 	}
 }
 

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -130,6 +130,9 @@ swatches:
   - path: .envrc
     alteration: first-fit
 
+  - path: cubic.yaml
+    alteration: first-fit
+
   - path: .tailor.yml
     alteration: always
 

--- a/internal/swatch/registry.go
+++ b/internal/swatch/registry.go
@@ -44,6 +44,7 @@ var registry = []Swatch{
 	{Path: "CONTRIBUTING.md", DefaultAlteration: Always, Category: Health},
 	{Path: "SUPPORT.md", DefaultAlteration: Always, Category: Health},
 	{Path: "flake.nix", DefaultAlteration: FirstFit, Category: Development},
+	{Path: "cubic.yaml", DefaultAlteration: FirstFit, Category: Development},
 	{Path: "justfile", DefaultAlteration: FirstFit, Category: Development},
 	{Path: ".github/FUNDING.yml", DefaultAlteration: FirstFit, Category: Health},
 	{Path: ".github/dependabot.yml", DefaultAlteration: FirstFit, Category: Health},

--- a/internal/swatch/registry_test.go
+++ b/internal/swatch/registry_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/wimpysworld/tailor/internal/swatch"
 )
 
-func TestAllReturns17Swatches(t *testing.T) {
+func TestAllReturns18Swatches(t *testing.T) {
 	all := swatch.All()
-	if len(all) != 17 {
-		t.Fatalf("All() returned %d swatches, want 17", len(all))
+	if len(all) != 18 {
+		t.Fatalf("All() returned %d swatches, want 18", len(all))
 	}
 }
 
@@ -42,6 +42,7 @@ func TestSwatchAttributes(t *testing.T) {
 		{"CONTRIBUTING.md", swatch.Always, swatch.Health},
 		{"SUPPORT.md", swatch.Always, swatch.Health},
 		{"flake.nix", swatch.FirstFit, swatch.Development},
+		{"cubic.yaml", swatch.FirstFit, swatch.Development},
 		{"justfile", swatch.FirstFit, swatch.Development},
 		{".github/FUNDING.yml", swatch.FirstFit, swatch.Health},
 		{".github/dependabot.yml", swatch.FirstFit, swatch.Health},
@@ -93,8 +94,8 @@ func TestHealthSwatchesReturnsCorrectSubset(t *testing.T) {
 
 func TestPathsReturnsSortedList(t *testing.T) {
 	names := swatch.Paths()
-	if len(names) != 17 {
-		t.Fatalf("Paths() returned %d names, want 17", len(names))
+	if len(names) != 18 {
+		t.Fatalf("Paths() returned %d names, want 18", len(names))
 	}
 	for i := 1; i < len(names); i++ {
 		if names[i] < names[i-1] {

--- a/swatches/.tailor.yml
+++ b/swatches/.tailor.yml
@@ -114,6 +114,9 @@ swatches:
   - path: .envrc
     alteration: first-fit
 
+  - path: cubic.yaml
+    alteration: first-fit
+
   - path: .tailor.yml
     alteration: always
 

--- a/swatches/cubic.yaml
+++ b/swatches/cubic.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://cubic.dev/schema/cubic-repository-config.schema.json
+version: 1
+
+reviews:
+  enabled: true
+  sensitivity: medium
+  incremental_commits: true
+  check_drafts: false
+  architecture_diagrams: false
+  resolve_threads_when_addressed: true
+  custom_instructions: ""
+  ignore:
+    files:
+      - "dist/**"
+      - "build/**"
+    pr_titles:
+      - "wip:*"
+    pr_labels:
+      - "wontfix"
+    head_branches: []
+    base_branches: []
+  custom_rules: []
+
+pr_descriptions:
+  cubic_review_link: false
+  generate: false
+  instructions: ""
+
+issues:
+  fix_commits_to_pr: false
+  fix_with_cubic_buttons: false
+  pr_comment_fixes: false


### PR DESCRIPTION
Registers cubic.yaml as a plain swatch, enabling projects to adopt cubic.dev code review settings. Includes registry entry, swatch template, configuration documentation, and test coverage.

- Add swatches/cubic.yaml with cubic.dev API endpoint configuration
- Register cubic swatch in internal/swatch/registry.go and swatches/.tailor.yml
- Update documentation in SPECIFICATION.md and README.md
- Update test assertions: expected swatch count 17 → 18
- Update project instructions in AGENTS.md with swatch procedures

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions
