### PR TITLE
ci(workflows): add cubic.dev AI code review configuration

### DIFF
--- a/.github/workflows/tailor.yml
+++ b/.github/workflows/tailor.yml
@@ -14,7 +14,7 @@ jobs:
   alter:
     runs-on: ubuntu-slim
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.TAILOR_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.tailor.yml
+++ b/.tailor.yml
@@ -1,4 +1,4 @@
-# Refitted by tailor on 2026-03-10
+# Refitted by tailor on 2026-03-12
 license: BlueOak-1.0.0
 
 repository:
@@ -133,3 +133,6 @@ swatches:
 
   - path: .github/workflows/tailor-automerge.yml
     alteration: triggered
+
+  - path: cubic.yaml
+    alteration: first-fit

--- a/cubic.yaml
+++ b/cubic.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://cubic.dev/schema/cubic-repository-config.schema.json
+version: 1
+
+reviews:
+  enabled: true
+  sensitivity: medium
+  incremental_commits: true
+  check_drafts: false
+  architecture_diagrams: false
+  resolve_threads_when_addressed: true
+  custom_instructions: ""
+  ignore:
+    files:
+      - "dist/**"
+      - "build/**"
+    pr_titles:
+      - "wip:*"
+    pr_labels:
+      - "wontfix"
+    head_branches: []
+    base_branches: []
+  custom_rules: []
+
+pr_descriptions:
+  cubic_review_link: false
+  generate: false
+  instructions: ""
+
+issues:
+  fix_commits_to_pr: false
+  fix_with_cubic_buttons: false
+  pr_comment_fixes: false


### PR DESCRIPTION
- Update GitHub Actions workflow to use TAILOR_TOKEN with GITHUB_TOKEN fallback
- Add cubic.yaml configuration for incremental code reviews with medium sensitivity
- Register cubic.yaml swatch in tailor configuration

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions
