### PR TITLE
ci(workflows): set explicit base branch for flake.lock update PR

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -243,6 +243,7 @@ jobs:
         uses: DeterminateSystems/update-flake-lock@v28
         with:
           inputs: nix-packages
+          base: main
           branch: update_flake_lock_nix-packages
           commit-msg: "flake.lock: update nix-packages"
           pr-title: "chore(flake): update nix-packages input"


### PR DESCRIPTION
When the release job checks out a tag, it enters detached HEAD state, causing the create-pull-request action to fail without an explicit base branch. Setting base: main ensures the flake lock update PR targets the correct branch during release builds.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions