### PR TITLE
test: align automerge disabled defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Licences are not swatches. They are fetched from the GitHub REST API (`GET /lice
 | `.envrc` | `first-fit` |
 | `cubic.yaml` | `first-fit` |
 | `.tailor.yml` | `always` |
-| `.github/workflows/tailor-automerge.yml` | `triggered` |
+| `.github/workflows/tailor-automerge.yml` | `never` |
 
 ### Alteration modes
 
@@ -237,7 +237,7 @@ repository:
   has_discussions: false
   allow_squash_merge: true
   delete_branch_on_merge: true
-  allow_auto_merge: true
+  allow_auto_merge: false
   default_workflow_permissions: read
   can_approve_pull_request_reviews: false
 
@@ -352,7 +352,7 @@ Branch protection rules and rulesets require `Administration: write`, which `GIT
 
 ### Automerge
 
-The `.github/workflows/tailor-automerge.yml` swatch auto-approves and merges Dependabot pull requests. It deploys automatically when `allow_auto_merge: true` is set in repository settings and removes itself when the setting is false.
+The `.github/workflows/tailor-automerge.yml` swatch auto-approves and merges Dependabot pull requests. It is disabled by default with `alteration: never`. To use Tailor-managed automerge, change that entry to `triggered`; it then deploys automatically when `allow_auto_merge: true` is set in repository settings and removes itself when the setting is false.
 
 | Ecosystem | Patch | Minor | Major |
 |-----------|-------|-------|-------|

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -120,7 +120,7 @@ Settings deliberately excluded due to risk or org-level scope: `visibility`, `de
 | `.github/ISSUE_TEMPLATE/config.yml` | `first-fit` |
 | `.github/pull_request_template.md` | `always` |
 | `.github/workflows/tailor.yml` | `always` |
-| `.github/workflows/tailor-automerge.yml` | `triggered` |
+| `.github/workflows/tailor-automerge.yml` | `never` |
 | `.github/dependabot.yml` | `first-fit` |
 | `justfile` | `first-fit` |
 | `cubic.yaml` | `first-fit` |
@@ -467,7 +467,7 @@ repository:
   squash_merge_commit_message: PR_BODY
   delete_branch_on_merge: true
   allow_update_branch: true
-  allow_auto_merge: true
+  allow_auto_merge: false
   web_commit_signoff_required: false
   default_workflow_permissions: read
   can_approve_pull_request_reviews: false
@@ -571,7 +571,7 @@ swatches:
     alteration: first-fit
 
   - path: .github/workflows/tailor-automerge.yml
-    alteration: triggered
+    alteration: never
 
   - path: .tailor.yml
     alteration: always
@@ -673,7 +673,7 @@ Action behaviour:
 
 ## Automerge Workflow
 
-The `.github/workflows/tailor-automerge.yml` swatch delivers a GitHub Actions workflow that auto-merges Dependabot pull requests. It is a `triggered` swatch, deployed only when `allow_auto_merge: true` is set in the `repository` section of `.tailor.yml`. The file is namespaced with a `tailor-` prefix to avoid collisions with user-managed automerge workflows.
+The `.github/workflows/tailor-automerge.yml` swatch delivers a GitHub Actions workflow that auto-merges Dependabot pull requests. It is included in the default configuration with `alteration: never`, so new projects do not enable automerge by default. Users who want Tailor-managed automerge can set the entry to `triggered`; it then deploys only when `allow_auto_merge: true` is set in the `repository` section of `.tailor.yml`. The file is namespaced with a `tailor-` prefix to avoid collisions with user-managed automerge workflows.
 
 **Prerequisite**: Auto-merge requires branch protection with at least one required status check on the default branch. Without this, `gh pr merge --auto` merges immediately with no CI gate. See [GitHub's documentation on managing a branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule) for guidance.
 
@@ -690,7 +690,7 @@ The workflow uses `gh pr merge --auto {{MERGE_STRATEGY}}` where `{{MERGE_STRATEG
 
 **Manual catch-up**: The workflow supports `workflow_dispatch` for repositories with pre-existing open Dependabot PRs. When triggered manually, a separate `automerge-existing` job lists all open Dependabot PRs and enables auto-merge on each. The manual job does not apply per-ecosystem filtering; required status checks still gate every merge.
 
-**Opt-out**: Users who have `allow_auto_merge: true` but use their own automerge solution can set `alteration: never` on the automerge swatch entry in `.tailor.yml` to suppress deployment while keeping the entry visible.
+**Opt-in / opt-out**: The default entry is `alteration: never`. Users can opt in by changing it to `triggered`, and users who later want to suppress deployment can change it back to `never` while keeping the entry visible.
 
 ## Justfile Integration
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,7 +28,7 @@ repository:
   squash_merge_commit_message: PR_BODY
   delete_branch_on_merge: true
   allow_update_branch: true
-  allow_auto_merge: true
+  allow_auto_merge: false
   web_commit_signoff_required: false
 
 swatches:
@@ -81,7 +81,7 @@ swatches:
     alteration: always
 
   - path: .github/workflows/tailor-automerge.yml
-    alteration: triggered
+    alteration: never
 `
 
 func TestUnmarshalSpecYAML(t *testing.T) {
@@ -110,7 +110,7 @@ func TestUnmarshalSpecYAML(t *testing.T) {
 	testutil.AssertStringPtr(t, r.SquashMergeCommitMessage, false, "PR_BODY", "squash_merge_commit_message")
 	testutil.AssertBoolPtr(t, r.DeleteBranchOnMerge, false, true, "delete_branch_on_merge")
 	testutil.AssertBoolPtr(t, r.AllowUpdateBranch, false, true, "allow_update_branch")
-	testutil.AssertBoolPtr(t, r.AllowAutoMerge, false, true, "allow_auto_merge")
+	testutil.AssertBoolPtr(t, r.AllowAutoMerge, false, false, "allow_auto_merge")
 	testutil.AssertBoolPtr(t, r.WebCommitSignoffRequired, false, false, "web_commit_signoff_required")
 
 	if len(cfg.Swatches) != 17 {
@@ -130,7 +130,7 @@ func TestUnmarshalSpecYAML(t *testing.T) {
 	if last.Path != ".github/workflows/tailor-automerge.yml" {
 		t.Errorf("last swatch Path = %q", last.Path)
 	}
-	if last.Alteration != swatch.Triggered {
+	if last.Alteration != swatch.Never {
 		t.Errorf("last swatch Alteration = %q", last.Alteration)
 	}
 }

--- a/internal/config/generate_test.go
+++ b/internal/config/generate_test.go
@@ -50,7 +50,7 @@ func TestDefaultConfigMatchesEmbedded(t *testing.T) {
 	testutil.AssertStringPtr(t, got.Repository.SquashMergeCommitMessage, false, "PR_BODY", "squash_merge_commit_message")
 	testutil.AssertBoolPtr(t, got.Repository.DeleteBranchOnMerge, false, true, "delete_branch_on_merge")
 	testutil.AssertBoolPtr(t, got.Repository.AllowUpdateBranch, false, true, "allow_update_branch")
-	testutil.AssertBoolPtr(t, got.Repository.AllowAutoMerge, false, true, "allow_auto_merge")
+	testutil.AssertBoolPtr(t, got.Repository.AllowAutoMerge, false, false, "allow_auto_merge")
 	testutil.AssertBoolPtr(t, got.Repository.WebCommitSignoffRequired, false, false, "web_commit_signoff_required")
 	testutil.AssertStringPtr(t, got.Repository.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
 	testutil.AssertBoolPtr(t, got.Repository.CanApprovePullRequestReviews, false, true, "can_approve_pull_request_reviews")
@@ -144,8 +144,8 @@ func TestDefaultConfigSwatchOrder(t *testing.T) {
 	if last.Path != ".github/workflows/tailor-automerge.yml" {
 		t.Errorf("last swatch Path = %q, want %q", last.Path, ".github/workflows/tailor-automerge.yml")
 	}
-	if last.Alteration != swatch.Triggered {
-		t.Errorf("last swatch Alteration = %q, want %q", last.Alteration, swatch.Triggered)
+	if last.Alteration != swatch.Never {
+		t.Errorf("last swatch Alteration = %q, want %q", last.Alteration, swatch.Never)
 	}
 }
 

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -30,7 +30,7 @@ repository:
   squash_merge_commit_message: PR_BODY
   delete_branch_on_merge: true
   allow_update_branch: true
-  allow_auto_merge: true
+  allow_auto_merge: false
   web_commit_signoff_required: false
   default_workflow_permissions: read
   can_approve_pull_request_reviews: true
@@ -137,7 +137,7 @@ swatches:
     alteration: always
 
   - path: .github/workflows/tailor-automerge.yml
-    alteration: triggered
+    alteration: never
 `
 
 func TestWriteDefaultConfigMatchesSpec(t *testing.T) {

--- a/internal/swatch/registry.go
+++ b/internal/swatch/registry.go
@@ -53,7 +53,7 @@ var registry = []Swatch{
 	{Path: ".github/ISSUE_TEMPLATE/config.yml", DefaultAlteration: FirstFit, Category: Health},
 	{Path: ".github/pull_request_template.md", DefaultAlteration: Always, Category: Health},
 	{Path: ".github/workflows/tailor.yml", DefaultAlteration: Always, Category: Development},
-	{Path: ".github/workflows/tailor-automerge.yml", DefaultAlteration: Triggered, Category: Development},
+	{Path: ".github/workflows/tailor-automerge.yml", DefaultAlteration: Never, Category: Development},
 	{Path: ".tailor.yml", DefaultAlteration: Always, Category: Development},
 }
 

--- a/internal/swatch/registry_test.go
+++ b/internal/swatch/registry_test.go
@@ -19,8 +19,8 @@ func TestAllSwatchesHaveRequiredFields(t *testing.T) {
 			if s.Path == "" {
 				t.Error("Path is empty")
 			}
-			if s.DefaultAlteration != swatch.Always && s.DefaultAlteration != swatch.FirstFit && s.DefaultAlteration != swatch.Triggered {
-				t.Errorf("DefaultAlteration is %q, want %q, %q, or %q", s.DefaultAlteration, swatch.Always, swatch.FirstFit, swatch.Triggered)
+			if s.DefaultAlteration != swatch.Always && s.DefaultAlteration != swatch.FirstFit && s.DefaultAlteration != swatch.Triggered && s.DefaultAlteration != swatch.Never {
+				t.Errorf("DefaultAlteration is %q, want %q, %q, %q, or %q", s.DefaultAlteration, swatch.Always, swatch.FirstFit, swatch.Triggered, swatch.Never)
 			}
 			if s.Category != swatch.Health && s.Category != swatch.Development {
 				t.Errorf("Category is %q, want %q or %q", s.Category, swatch.Health, swatch.Development)
@@ -51,7 +51,7 @@ func TestSwatchAttributes(t *testing.T) {
 		{".github/ISSUE_TEMPLATE/config.yml", swatch.FirstFit, swatch.Health},
 		{".github/pull_request_template.md", swatch.Always, swatch.Health},
 		{".github/workflows/tailor.yml", swatch.Always, swatch.Development},
-		{".github/workflows/tailor-automerge.yml", swatch.Triggered, swatch.Development},
+		{".github/workflows/tailor-automerge.yml", swatch.Never, swatch.Development},
 		{".tailor.yml", swatch.Always, swatch.Development},
 	}
 


### PR DESCRIPTION
## Summary
- Align default config tests and golden fixtures with automerge disabled by default
- Set the built-in automerge swatch registry default to `never`
- Update README and specification docs to describe opt-in Tailor-managed automerge

## Test plan
- `go test ./internal/config ./internal/swatch ./internal/measure ./internal/gh ./internal/docket ./internal/fsutil ./internal/testutil`
- `go test ./...`
- `just lint`
- `git diff --check`

Fixes main CI failure introduced after `chore: disable automerge`.
