### PR TITLE
feat: report completed alteration actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ tailor alter --recut    # Overwrite regardless of mode
 
 `--recut` overwrites all files including `first-fit` swatches. `LICENSE` is exempt (fetched content, not an embedded swatch). For `.tailor.yml`, `--recut` appends missing default swatch entries but never modifies existing entries.
 
+After each successful change, `alter` and `alter --recut` report `set`, `created`, `updated`, `copied`, `overwritten`, `deployed`, or `removed`. A default merge into `.tailor.yml` reports `updated`.
+
 ### `baste`
 
 Previews what `alter` would do without making changes.
@@ -322,13 +324,28 @@ Previews what `alter` would do without making changes.
 tailor baste
 ```
 
+`baste` uses planned labels. The write commands use the corresponding completed labels:
+
+| `baste` | `alter` and `alter --recut` |
+|---------|-----------------------------|
+| `would set` | `set` |
+| `would create` | `created` |
+| `would update` | `updated` |
+| `would copy` | `copied` |
+| `would overwrite` | `overwritten` |
+| `would deploy` | `deployed` |
+| `would remove` | `removed` |
+
+A default merge into `.tailor.yml` reports `would update` in `baste` and `updated` after a successful write.
+
 ```
-     would set: repository.has_wiki = false
-    would copy: LICENSE
- would overwrite: SECURITY.md
-     no change: CODE_OF_CONDUCT.md
-skipped (first-fit, exists): justfile
+would set:                                  repository.has_wiki = false
+would update:                               .tailor.yml
+would copy:                                 LICENSE
+would overwrite:                            SECURITY.md
 would deploy (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml
+no change:                                  CODE_OF_CONDUCT.md
+skipped (first-fit, exists):                justfile
 ```
 
 ### `docket`

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -259,61 +259,111 @@ Behaviour:
 - If `.tailor.yml` is missing or malformed, exits immediately with the error described in Error Handling.
 - `baste` performs the same comparison logic as `alter` but writes nothing. It reports what `alter` would do.
 
-Output format - repository settings are shown first (if a `repository` section is present), then labels (if a `labels` section is present), then swatch entries.
+Output contract - repository settings are shown first (if a `repository` section is present), then labels (if a `labels` section is present), then file results. File results include the licence, the `.tailor.yml` default merge, and swatches. `baste` uses planned labels. `alter` and `alter --recut` use completed labels, and report each label only after the change succeeds. Informational and access-warning labels are the same for all three commands.
+
+| Result | `baste` | `alter` and `alter --recut` |
+|---|---|---|
+| Repository setting differs | `would set` | `set` |
+| Label is absent | `would create` | `created` |
+| Label differs | `would update` | `updated` |
+| `.tailor.yml` gains built-in defaults | `would update` | `updated` |
+| Licence or non-triggered swatch destination is absent | `would copy` | `copied` |
+| Non-triggered swatch destination is replaced | `would overwrite` | `overwritten` |
+| Triggered swatch condition is met and content is written | `would deploy (triggered: <field>)` | `deployed (triggered: <field>)` |
+| Triggered swatch condition is false and the file exists | `would remove (triggered: <field>)` | `removed (triggered: <field>)` |
 
 Repository settings output uses the following categories:
 
+`baste`:
+
 ```
-would set:                                    repository.has_wiki = false
-would set:                                    repository.delete_branch_on_merge = true
-no change:                                    repository.allow_squash_merge (already true)
+would set:                           repository.has_wiki = false
+no change:                           repository.allow_squash_merge (already true)
 ```
 
-`would set` - declared value differs from the live repository setting.
+`alter` and `alter --recut`:
+
+```
+set:                                 repository.has_wiki = false
+no change:                           repository.allow_squash_merge (already true)
+```
+
+`would set` - declared value differs from the live repository setting in `baste`.
+`set` - `alter` or `alter --recut` changed the declared value.
 `no change` - declared value matches the live repository setting.
 
-Repository settings entries are sorted lexicographically by field name within each category: `would set` first, then `no change`.
+Repository setting entries are sorted by category, with `would set` or `set` first, `no change` second, and `would skip` variants last. Entries are sorted lexicographically by field name within each category.
 
 Label output uses the following categories:
 
+`baste`:
+
 ```
-would create:                                 label.bug = #d20f39 "Something isn't working"
-would update:                                 label.documentation = #04a5e5 "Documentation improvement"
-no change:                                    label.enhancement (already #1e66f5 "New feature request")
-would skip (insufficient scope: <detail>):    create label "bug"
+would create:                              label.bug = #d20f39 "Something isn't working"
+would update:                              label.documentation = #04a5e5 "Documentation improvement"
+no change:                                 label.enhancement (already #1e66f5 "New feature request")
+would skip (insufficient scope: <detail>): create label "bug"
 ```
 
-`would create` - label does not exist on GitHub and would be created.
-`would update` - label exists on GitHub but colour or description differs from config.
+`alter` and `alter --recut`:
+
+```
+created:                             label.bug = #d20f39 "Something isn't working"
+updated:                             label.documentation = #04a5e5 "Documentation improvement"
+no change:                           label.enhancement (already #1e66f5 "New feature request")
+```
+
+`would create` - label does not exist on GitHub in `baste`.
+`created` - `alter` or `alter --recut` created the label.
+`would update` - label exists on GitHub but colour or description differs from config in `baste`.
+`updated` - `alter` or `alter --recut` updated the label.
 `no change` - label exists on GitHub and matches config.
 `would skip (insufficient scope: <detail>)` - operation could not be applied because the token lacks the required scope or permission. In GitHub Actions, available operations depend on the installation token's repository and job permissions. A suitably scoped PAT can be used when the workflow token cannot access a required endpoint.
 
-Label entries are sorted: `would create` first, then `would update`, then `no change`, then `would skip` variants. Within each category, sorted lexicographically by label name.
+Label entries are sorted by category: `would create` or `created` first, `would update` or `updated` second, `no change` third, then `would skip` variants. Entries are sorted lexicographically by label name within each category.
 
-Swatch output uses the following categories:
+File output uses the following categories:
+
+`baste`:
 
 ```
-would copy:                                LICENSE
-would overwrite:                           SECURITY.md
+would update:                               .tailor.yml
+would copy:                                 LICENSE
+would overwrite:                            SECURITY.md
 would deploy (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml
 would remove (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml
-no change:                                 CODE_OF_CONDUCT.md
-skipped (first-fit, exists):               justfile
-skip (never):                              .github/workflows/tailor-automerge.yml
+no change:                                  CODE_OF_CONDUCT.md
+skipped (first-fit, exists):                justfile
+skip (never):                               .github/workflows/tailor-automerge.yml
 ```
 
+`alter` and `alter --recut`:
+
+```
+updated:                                .tailor.yml
+copied:                                 LICENSE
+overwritten:                            SECURITY.md
+deployed (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml
+removed (triggered: allow_auto_merge):  .github/workflows/tailor-automerge.yml
+```
+
+`would update` - `baste` found built-in defaults to merge into `.tailor.yml`.
+`updated` - `alter` or `alter --recut` merged built-in defaults into `.tailor.yml`.
 `would copy` - destination does not exist and the swatch would be written. Applies regardless of whether the swatch is `always` or `first-fit`.
+`copied` - `alter` or `alter --recut` copied the licence or non-triggered swatch.
 `would overwrite` - `always` swatch whose embedded content differs from the on-disk file.
+`overwritten` - `alter` or `alter --recut` overwrote the non-triggered swatch.
 `would deploy (triggered: <field>)` - triggered swatch whose condition is met; the annotation shows which config field activated it. Covers both copy (file absent) and overwrite (file exists, content differs) cases.
-`would remove (triggered: <field>)` - triggered swatch whose condition is not met and the file exists on disk. In `baste` this is a preview; `alter` uses `removed (triggered: <field>)` when the file is actually deleted.
-`removed (triggered: <field>)` - triggered swatch whose condition is not met and the file has been deleted from disk. Appears in `alter` output only, not in `baste`.
+`deployed (triggered: <field>)` - `alter` or `alter --recut` copied or overwrote the triggered swatch.
+`would remove (triggered: <field>)` - triggered swatch condition is not met and the file exists on disk in `baste`.
+`removed (triggered: <field>)` - `alter` or `alter --recut` deleted the triggered swatch.
 `no change` - `always` or `triggered` swatch whose embedded content matches the on-disk file. `no change` only appears for `always` and active `triggered` swatches; `first-fit` swatches that exist always produce `skipped (first-fit, exists)`, never `no change`. Substituted swatches participate in the normal SHA-256 comparison after token resolution and can produce `no change` when the resolved content matches the on-disk file.
 `skipped (first-fit, exists)` - `first-fit` swatch whose destination already exists; no comparison is performed.
 `skip (never)` - swatch with `alteration: never`; skipped unconditionally.
 
-`baste` and `alter` use the same output format. The categories above apply to both commands; the only category exclusive to `alter` is `removed`.
+File results put actionable categories first: update, copy, overwrite, deploy, and remove. Informational categories follow: `no change`, `skipped (first-fit, exists)`, and `skip (never)`. The planned or completed tense does not change this order. Entries are sorted lexicographically by path within each category.
 
-Output order: actionable items first (`would set`, `would copy`, `would overwrite`, `would deploy`, `would remove`), then informational (`no change`, `skipped (first-fit, exists)`, `skip (never)`). Within each category, entries are sorted lexicographically by path or field name. The category label width is computed dynamically from the longest label in the output, with a minimum of 37 characters to accommodate `would skip (insufficient scope):` labels.
+The category label width is computed dynamically from the longest label in the full output, with a minimum of 37 characters. Trigger and access-warning annotations can increase the width.
 
 ### `measure`
 

--- a/internal/alter/alter.go
+++ b/internal/alter/alter.go
@@ -35,9 +35,11 @@ func Run(cfg *config.Config, dir string, mode ApplyMode, client *api.RESTClient)
 
 	// Keep the local config aligned with built-in defaults only when the
 	// config swatch mode allows tailor to rewrite it.
+	configMerged := false
 	if shouldMerge(cfg, mode) {
 		added, repoMerged, labelsMerged := config.MergeDefaults(cfg)
-		if (len(added) > 0 || repoMerged || labelsMerged) && mode.ShouldWrite() {
+		configMerged = len(added) > 0 || repoMerged || labelsMerged
+		if configMerged && mode.ShouldWrite() {
 			todayDate := time.Now().Format("2006-01-02")
 			if err := config.Write(dir, cfg, todayDate, "Refitted"); err != nil {
 				return fmt.Errorf("writing refitted config: %w", err)
@@ -97,8 +99,11 @@ func Run(cfg *config.Config, dir string, mode ApplyMode, client *api.RESTClient)
 	if licenceResult != nil {
 		swatchResults = append([]SwatchResult{*licenceResult}, swatchResults...)
 	}
+	if configMerged {
+		swatchResults = append(swatchResults, SwatchResult{Path: configPath, Category: WouldUpdateConfig})
+	}
 
-	output := FormatOutput(repoResults, labelResults, swatchResults)
+	output := FormatOutput(repoResults, labelResults, swatchResults, mode)
 	if output != "" {
 		fmt.Print(output)
 	}

--- a/internal/alter/alter_integration_test.go
+++ b/internal/alter/alter_integration_test.go
@@ -414,6 +414,63 @@ swatches:
 	}
 }
 
+func TestAlterRunOutputByMode(t *testing.T) {
+	configYAML := `license: mit
+repository:
+  has_wiki: false
+labels:
+  - name: bug
+    color: d73a4a
+    description: A problem
+swatches:
+  - path: .gitignore
+    alteration: first-fit
+`
+	tests := []struct {
+		name string
+		mode alter.ApplyMode
+		want string
+	}{
+		{
+			name: "dry run",
+			mode: alter.DryRun,
+			want: "would set:                           repository.has_wiki = false\n" +
+				"would create:                        label.bug = #d73a4a \"A problem\"\n" +
+				"would copy:                          .gitignore\n" +
+				"would copy:                          LICENSE\n",
+		},
+		{
+			name: "apply",
+			mode: alter.Apply,
+			want: "set:                                 repository.has_wiki = false\n" +
+				"created:                             label.bug = #d73a4a \"A problem\"\n" +
+				"copied:                              .gitignore\n" +
+				"copied:                              LICENSE\n",
+		},
+		{
+			name: "recut",
+			mode: alter.Recut,
+			want: "set:                                 repository.has_wiki = false\n" +
+				"created:                             label.bug = #d73a4a \"A problem\"\n" +
+				"copied:                              .gitignore\n" +
+				"copied:                              LICENSE\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := setupAlterTest(t, configYAML,
+				WithRepoSettings(repoJSON{HasWiki: true}),
+			)
+			cfg := loadTestConfig(t, tc.Dir)
+			got := captureAlterRun(t, cfg, tc.Dir, tt.mode, tc.Client)
+			if got != tt.want {
+				t.Errorf("alter.Run() output =\n%s\nwant:\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestAlterRunDryRunWithRepoSettings verifies that repo settings appear in
 // dry-run output when they differ from live settings.
 func TestAlterRunDryRunWithRepoSettings(t *testing.T) {
@@ -863,7 +920,7 @@ swatches:
 }
 
 // TestAlterRunDryRunColumnWidth verifies that all category labels in the output
-// are padded to exactly 29 characters (the labelWidth constant from format.go).
+// use the default 37-character column width.
 func TestAlterRunDryRunColumnWidth(t *testing.T) {
 	configYAML := `license: mit
 repository:
@@ -893,9 +950,7 @@ swatches:
 		t.Fatal("expected non-empty output")
 	}
 
-	// Each line should have the label portion padded to 29 characters,
-	// meaning position 29 starts the content (no leading space at pos 29
-	// unless the label itself is shorter).
+	// Each line has the label portion padded to 37 characters.
 	knownLabels := []string{
 		"would copy:",
 		"would overwrite:",
@@ -904,7 +959,7 @@ swatches:
 		"would set:",
 	}
 
-	const expectedWidth = 29
+	const expectedWidth = 37
 	for _, line := range lines {
 		if len(line) < expectedWidth {
 			t.Errorf("line too short to contain label + content: %q", line)
@@ -1646,9 +1701,11 @@ swatches:
 
 	// DryRun: output should indicate the swatch would be deployed.
 	dryOutput := captureAlterRun(t, cfg, tc.Dir, alter.DryRun, tc.Client)
-	requireContains(t, dryOutput, "would deploy")
-	requireContains(t, dryOutput, "tailor-automerge.yml")
-	requireContains(t, dryOutput, "triggered: allow_auto_merge")
+	wantDryOutput := "no change:                                  repository.allow_auto_merge (already true)\n" +
+		"would deploy (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n"
+	if dryOutput != wantDryOutput {
+		t.Errorf("alter.Run() output =\n%s\nwant:\n%s", dryOutput, wantDryOutput)
+	}
 
 	// File must not exist after dry-run.
 	automergeFile := filepath.Join(tc.Dir, ".github/workflows/tailor-automerge.yml")
@@ -1657,7 +1714,12 @@ swatches:
 	}
 
 	// Apply writes the triggered swatch.
-	_ = captureAlterRun(t, cfg, tc.Dir, alter.Apply, tc.Client)
+	applyOutput := captureAlterRun(t, cfg, tc.Dir, alter.Apply, tc.Client)
+	wantApplyOutput := "no change:                              repository.allow_auto_merge (already true)\n" +
+		"deployed (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n"
+	if applyOutput != wantApplyOutput {
+		t.Errorf("alter.Run() output =\n%s\nwant:\n%s", applyOutput, wantApplyOutput)
+	}
 
 	data, err := os.ReadFile(automergeFile)
 	if err != nil {
@@ -1711,15 +1773,23 @@ swatches:
 
 		// Dry-run reports removal without deleting the file.
 		dryOutput := captureAlterRun(t, cfg, tc.Dir, alter.DryRun, tc.Client)
-		requireContains(t, dryOutput, "would remove")
-		requireContains(t, dryOutput, "tailor-automerge.yml")
+		wantDryOutput := "no change:                                  repository.allow_auto_merge (already false)\n" +
+			"would remove (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n"
+		if dryOutput != wantDryOutput {
+			t.Errorf("alter.Run() output =\n%s\nwant:\n%s", dryOutput, wantDryOutput)
+		}
 
 		if _, err := os.Stat(automergeFile); err != nil {
 			t.Errorf("dry run removed tailor-automerge.yml from disk: %v", err)
 		}
 
 		// Apply removes the stale triggered file.
-		_ = captureAlterRun(t, cfg, tc.Dir, alter.Apply, tc.Client)
+		applyOutput := captureAlterRun(t, cfg, tc.Dir, alter.Apply, tc.Client)
+		wantApplyOutput := "no change:                             repository.allow_auto_merge (already false)\n" +
+			"removed (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n"
+		if applyOutput != wantApplyOutput {
+			t.Errorf("alter.Run() output =\n%s\nwant:\n%s", applyOutput, wantApplyOutput)
+		}
 
 		if _, err := os.Stat(automergeFile); err == nil {
 			t.Error("tailor-automerge.yml still exists after apply with trigger not met")
@@ -1878,7 +1948,8 @@ func TestConfigMergeMissingSwatchesApply(t *testing.T) {
 	writeOnDisk(t, tc.Dir, "LICENSE", []byte("existing"))
 
 	cfg := loadTestConfig(t, tc.Dir)
-	_ = captureAlterRun(t, cfg, tc.Dir, alter.Apply, tc.Client)
+	output := captureAlterRun(t, cfg, tc.Dir, alter.Apply, tc.Client)
+	requireContains(t, output, "updated:                             .tailor.yml\n")
 
 	// MergeDefaultSwatches appends the missing entries before swatch processing.
 	for _, dest := range []string{"SUPPORT.md", "justfile"} {
@@ -1979,7 +2050,8 @@ func TestConfigMergeFirstFitRecutAppends(t *testing.T) {
 	writeOnDisk(t, tc.Dir, "LICENSE", []byte("existing"))
 
 	cfg := loadTestConfig(t, tc.Dir)
-	_ = captureAlterRun(t, cfg, tc.Dir, alter.Recut, tc.Client)
+	output := captureAlterRun(t, cfg, tc.Dir, alter.Recut, tc.Client)
+	requireContains(t, output, "updated:                             .tailor.yml\n")
 
 	// Recut merges defaults, then processes the newly merged swatches.
 	for _, dest := range []string{"SUPPORT.md", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "SECURITY.md"} {
@@ -2015,7 +2087,8 @@ func TestConfigMergeDryRunNoRewrite(t *testing.T) {
 	}
 
 	cfg := loadTestConfig(t, tc.Dir)
-	_ = captureAlterRun(t, cfg, tc.Dir, alter.DryRun, tc.Client)
+	output := captureAlterRun(t, cfg, tc.Dir, alter.DryRun, tc.Client)
+	requireContains(t, output, "would update:                        .tailor.yml\n")
 
 	afterData, err := os.ReadFile(filepath.Join(tc.Dir, ".tailor.yml"))
 	if err != nil {

--- a/internal/alter/format.go
+++ b/internal/alter/format.go
@@ -14,18 +14,22 @@ const defaultLabelWidth = 37
 
 // FormatOutput produces the alter command output from repo settings results,
 // label results, and swatch results (including licence).
-func FormatOutput(repoResults []RepoSettingResult, labelResults []LabelResult, swatchResults []SwatchResult) string {
+func FormatOutput(repoResults []RepoSettingResult, labelResults []LabelResult, swatchResults []SwatchResult, mode ApplyMode) string {
 	if len(repoResults) == 0 && len(labelResults) == 0 && len(swatchResults) == 0 {
 		return ""
 	}
+	if mode.ShouldWrite() {
+		repoResults = removeSkippedRepoResults(repoResults)
+		labelResults = removeSkippedLabelResults(labelResults)
+	}
 
 	sortedSwatches := sortSwatchResults(swatchResults)
-	width := labelWidth(repoResults, labelResults, sortedSwatches)
+	width := labelWidth(repoResults, labelResults, sortedSwatches, mode)
 
 	var b strings.Builder
 
 	for _, r := range sortRepoResults(repoResults) {
-		label := repoLabel(r)
+		label := repoLabel(r, mode)
 		switch r.Category {
 		case WouldSet:
 			fmt.Fprintf(&b, "%-*srepository.%s = %s\n", width, label, r.Field, r.Value)
@@ -37,7 +41,7 @@ func FormatOutput(repoResults []RepoSettingResult, labelResults []LabelResult, s
 	}
 
 	for _, r := range sortLabelResults(labelResults) {
-		label := labelResultLabel(r)
+		label := labelResultLabel(r, mode)
 		switch r.Category {
 		case WouldCreate, WouldUpdate:
 			fmt.Fprintf(&b, "%-*slabel.%s = %s\n", width, label, r.Name, r.Value)
@@ -49,11 +53,69 @@ func FormatOutput(repoResults []RepoSettingResult, labelResults []LabelResult, s
 	}
 
 	for _, r := range sortedSwatches {
-		label := swatchLabel(r)
+		label := swatchLabel(r, mode)
 		fmt.Fprintf(&b, "%-*s%s\n", width, label, r.Path)
 	}
 
 	return b.String()
+}
+
+func removeSkippedRepoResults(results []RepoSettingResult) []RepoSettingResult {
+	skipped := make(map[string]bool)
+	for _, result := range results {
+		if result.Category == WouldSkipScope {
+			skipped[result.Field] = true
+		}
+	}
+	if len(skipped) == 0 {
+		return results
+	}
+
+	filtered := make([]RepoSettingResult, 0, len(results))
+	for _, result := range results {
+		if result.Category != WouldSet || !skipped[repoSettingOperation(result.Field)] {
+			filtered = append(filtered, result)
+		}
+	}
+	return filtered
+}
+
+func repoSettingOperation(field string) string {
+	switch field {
+	case "topics":
+		return "set topics"
+	case "default_workflow_permissions", "can_approve_pull_request_reviews":
+		return "set workflow permissions"
+	default:
+		return "patch repo settings"
+	}
+}
+
+func removeSkippedLabelResults(results []LabelResult) []LabelResult {
+	skipped := make(map[string]bool)
+	for _, result := range results {
+		if result.Category == LabelSkipScope {
+			skipped[result.Name] = true
+		}
+	}
+	if len(skipped) == 0 {
+		return results
+	}
+
+	filtered := make([]LabelResult, 0, len(results))
+	for _, result := range results {
+		operation := ""
+		switch result.Category {
+		case WouldCreate:
+			operation = fmt.Sprintf("create label %q", result.Name)
+		case WouldUpdate:
+			operation = fmt.Sprintf("update label %q", result.Name)
+		}
+		if !skipped[operation] {
+			filtered = append(filtered, result)
+		}
+	}
+	return filtered
 }
 
 // formatAnnotatedLabel embeds an annotation into a skip-category label when
@@ -67,44 +129,73 @@ func formatAnnotatedLabel(category, annotation string, isSkip bool) string {
 	return category + ":"
 }
 
+func outputCategory(category string, mode ApplyMode) string {
+	if !mode.ShouldWrite() {
+		if category == "removed" {
+			return "would remove"
+		}
+		return category
+	}
+
+	switch category {
+	case "would set":
+		return "set"
+	case "would create":
+		return "created"
+	case "would update":
+		return "updated"
+	case "would copy":
+		return "copied"
+	case "would overwrite":
+		return "overwritten"
+	case "would deploy":
+		return "deployed"
+	case "would remove":
+		return "removed"
+	default:
+		return category
+	}
+}
+
 // repoLabel returns the formatted label for a repo setting result.
-func repoLabel(r RepoSettingResult) string {
+func repoLabel(r RepoSettingResult, mode ApplyMode) string {
 	isSkip := r.Category == WouldSkipScope
-	return formatAnnotatedLabel(string(r.Category), r.Annotation, isSkip)
+	return formatAnnotatedLabel(outputCategory(string(r.Category), mode), r.Annotation, isSkip)
 }
 
 // labelResultLabel returns the formatted label for a label result.
-func labelResultLabel(r LabelResult) string {
+func labelResultLabel(r LabelResult, mode ApplyMode) string {
 	isSkip := r.Category == LabelSkipScope
-	return formatAnnotatedLabel(string(r.Category), r.Annotation, isSkip)
+	return formatAnnotatedLabel(outputCategory(string(r.Category), mode), r.Annotation, isSkip)
 }
 
 // swatchLabel returns the formatted label for a swatch result, including any
 // trigger annotation. For example: "would deploy (triggered: allow_auto_merge):".
-func swatchLabel(r SwatchResult) string {
+func swatchLabel(r SwatchResult, mode ApplyMode) string {
+	category := outputCategory(string(r.Category), mode)
 	if r.Annotation != "" {
-		return string(r.Category) + " (" + r.Annotation + "):"
+		return category + " (" + r.Annotation + "):"
 	}
-	return string(r.Category) + ":"
+	return category + ":"
 }
 
 // labelWidth computes the column width needed to accommodate all labels. It
 // returns at least defaultLabelWidth, widening if any annotated label exceeds
 // that.
-func labelWidth(repos []RepoSettingResult, labels []LabelResult, swatches []SwatchResult) int {
+func labelWidth(repos []RepoSettingResult, labels []LabelResult, swatches []SwatchResult, mode ApplyMode) int {
 	width := defaultLabelWidth
 	for _, r := range repos {
-		if w := len(repoLabel(r)) + 1; w > width {
+		if w := len(repoLabel(r, mode)) + 1; w > width {
 			width = w
 		}
 	}
 	for _, r := range labels {
-		if w := len(labelResultLabel(r)) + 1; w > width {
+		if w := len(labelResultLabel(r, mode)) + 1; w > width {
 			width = w
 		}
 	}
 	for _, r := range swatches {
-		if w := len(swatchLabel(r)) + 1; w > width {
+		if w := len(swatchLabel(r, mode)) + 1; w > width {
 			width = w
 		}
 	}
@@ -142,9 +233,8 @@ func repoOrder(c RepoSettingCategory) int {
 	}
 }
 
-// sortSwatchResults returns a sorted copy: actionable (WouldCopy, WouldOverwrite)
-// before informational (NoChange, SkippedFirstFit), lexicographic by path within
-// each group.
+// sortSwatchResults returns a sorted copy with actionable results before
+// informational results and paths sorted within each category.
 func sortSwatchResults(results []SwatchResult) []SwatchResult {
 	if len(results) == 0 {
 		return nil
@@ -194,27 +284,28 @@ func labelOrder(c LabelCategory) int {
 }
 
 // swatchOrder returns the sort priority for a SwatchCategory.
-// Actionable categories sort before informational: deploy, overwrite, remove,
-// then no-change, skipped, ignored.
+// Actionable categories sort before informational categories.
 func swatchOrder(c SwatchCategory) int {
 	switch c {
-	case WouldCopy:
+	case WouldUpdateConfig:
 		return 0
-	case WouldOverwrite:
+	case WouldCopy:
 		return 1
-	case WouldDeploy:
+	case WouldOverwrite:
 		return 2
-	case WouldRemove:
+	case WouldDeploy:
 		return 3
-	case Removed:
+	case WouldRemove:
 		return 4
-	case NoChange:
+	case Removed:
 		return 5
-	case SkippedFirstFit:
+	case NoChange:
 		return 6
-	case SkippedNever:
+	case SkippedFirstFit:
 		return 7
-	default:
+	case SkippedNever:
 		return 8
+	default:
+		return 9
 	}
 }

--- a/internal/alter/format_test.go
+++ b/internal/alter/format_test.go
@@ -13,7 +13,7 @@ func TestFormatOutputSwatchesOnly(t *testing.T) {
 		{Path: ".tailor.yml", Category: SkippedFirstFit},
 	}
 
-	got := FormatOutput(nil, nil, swatches)
+	got := FormatOutput(nil, nil, swatches, DryRun)
 	want := "would copy:                          CONTRIBUTING.md\n" +
 		"would overwrite:                     .github/FUNDING.yml\n" +
 		"no change:                           LICENSE\n" +
@@ -31,7 +31,7 @@ func TestFormatOutputRepoSettingsOnly(t *testing.T) {
 		{Field: "description", Category: WouldSet, Value: "My project"},
 	}
 
-	got := FormatOutput(repos, nil, nil)
+	got := FormatOutput(repos, nil, nil, DryRun)
 	want := "would set:                           repository.description = My project\n" +
 		"would set:                           repository.has_wiki = false\n" +
 		"no change:                           repository.has_issues (already true)\n"
@@ -52,7 +52,7 @@ func TestFormatOutputCombined(t *testing.T) {
 		{Path: "LICENSE", Category: NoChange},
 	}
 
-	got := FormatOutput(repos, nil, swatches)
+	got := FormatOutput(repos, nil, swatches, DryRun)
 	want := "would set:                           repository.has_wiki = false\n" +
 		"no change:                           repository.has_issues (already true)\n" +
 		"would copy:                          CONTRIBUTING.md\n" +
@@ -64,14 +64,14 @@ func TestFormatOutputCombined(t *testing.T) {
 }
 
 func TestFormatOutputEmpty(t *testing.T) {
-	got := FormatOutput(nil, nil, nil)
+	got := FormatOutput(nil, nil, nil, DryRun)
 	if got != "" {
 		t.Errorf("FormatOutput empty: got %q, want %q", got, "")
 	}
 }
 
 func TestFormatOutputEmptySlices(t *testing.T) {
-	got := FormatOutput([]RepoSettingResult{}, nil, []SwatchResult{})
+	got := FormatOutput([]RepoSettingResult{}, nil, []SwatchResult{}, DryRun)
 	if got != "" {
 		t.Errorf("FormatOutput empty slices: got %q, want %q", got, "")
 	}
@@ -87,7 +87,7 @@ func TestFormatOutputSwatchSorting(t *testing.T) {
 		{Path: "M-file.md", Category: NoChange},
 	}
 
-	got := FormatOutput(nil, nil, swatches)
+	got := FormatOutput(nil, nil, swatches, DryRun)
 	want := "would copy:                          B-file.md\n" +
 		"would copy:                          C-file.md\n" +
 		"would overwrite:                     A-file.md\n" +
@@ -108,7 +108,7 @@ func TestFormatOutputRepoSettingSorting(t *testing.T) {
 		{Field: "allow_squash_merge", Category: WouldSet, Value: "true"},
 	}
 
-	got := FormatOutput(repos, nil, nil)
+	got := FormatOutput(repos, nil, nil, DryRun)
 	want := "would set:                           repository.allow_squash_merge = true\n" +
 		"would set:                           repository.has_issues = true\n" +
 		"no change:                           repository.description (already A project)\n" +
@@ -150,7 +150,7 @@ func TestFormatOutputActionableBeforeInformational(t *testing.T) {
 		{Path: "action2.md", Category: WouldOverwrite},
 	}
 
-	got := FormatOutput(nil, nil, swatches)
+	got := FormatOutput(nil, nil, swatches, DryRun)
 	want := "would copy:                          action1.md\n" +
 		"would overwrite:                     action2.md\n" +
 		"no change:                           info1.md\n" +
@@ -169,7 +169,7 @@ func TestFormatOutputRepoSettingsBeforeSwatches(t *testing.T) {
 		{Path: "CONTRIBUTING.md", Category: WouldCopy},
 	}
 
-	got := FormatOutput(repos, nil, swatches)
+	got := FormatOutput(repos, nil, swatches, DryRun)
 
 	// Repo settings line must appear before swatch line.
 	repoIdx := 0
@@ -185,7 +185,7 @@ func TestFormatOutputNoTrailingBlankLine(t *testing.T) {
 		{Path: "file.md", Category: WouldCopy},
 	}
 
-	got := FormatOutput(nil, nil, swatches)
+	got := FormatOutput(nil, nil, swatches, DryRun)
 	if got[len(got)-1] != '\n' {
 		t.Error("output should end with newline")
 	}
@@ -202,10 +202,10 @@ func TestFormatOutputNewCategories(t *testing.T) {
 		{Path: "copied.md", Category: WouldCopy},
 	}
 
-	got := FormatOutput(nil, nil, swatches)
+	got := FormatOutput(nil, nil, swatches, DryRun)
 	want := "would copy:                          copied.md\n" +
 		"would remove:                        would-remove.yml\n" +
-		"removed:                             removed.yml\n" +
+		"would remove:                        removed.yml\n" +
 		"skip (never):                        ignored.yml\n"
 
 	if got != want {
@@ -225,12 +225,12 @@ func TestFormatOutputNewCategorySorting(t *testing.T) {
 		{Path: "a-would-remove.yml", Category: WouldRemove},
 	}
 
-	got := FormatOutput(nil, nil, swatches)
+	got := FormatOutput(nil, nil, swatches, DryRun)
 	want := "would copy:                          e-would-copy.md\n" +
 		"would overwrite:                     f-would-overwrite.md\n" +
 		"would remove:                        a-would-remove.yml\n" +
 		"would remove:                        b-would-remove.yml\n" +
-		"removed:                             a-removed.yml\n" +
+		"would remove:                        a-removed.yml\n" +
 		"no change:                           d-no-change.md\n" +
 		"skipped (first-fit, exists):         c-skipped.md\n" +
 		"skip (never):                        z-ignored.yml\n"
@@ -247,7 +247,7 @@ func TestFormatOutputSkipCategories(t *testing.T) {
 		{Field: "patch repo settings", Category: WouldSkipScope, Value: "insufficient scope"},
 	}
 
-	got := FormatOutput(repos, nil, nil)
+	got := FormatOutput(repos, nil, nil, DryRun)
 	want := "would set:                           repository.has_wiki = false\n" +
 		"no change:                           repository.has_issues (already true)\n" +
 		"would skip (insufficient scope):     patch repo settings\n"
@@ -264,7 +264,7 @@ func TestFormatOutputSkipSorting(t *testing.T) {
 		{Field: "patch repo settings", Category: WouldSkipScope, Value: "scope error"},
 	}
 
-	got := FormatOutput(repos, nil, nil)
+	got := FormatOutput(repos, nil, nil, DryRun)
 	want := "would set:                           repository.description = My project\n" +
 		"no change:                           repository.has_wiki (already false)\n" +
 		"would skip (insufficient scope):     patch repo settings\n"
@@ -280,7 +280,7 @@ func TestFormatOutputAnnotations(t *testing.T) {
 		{Path: "LICENSE", Category: NoChange},
 	}
 
-	got := FormatOutput(nil, nil, swatches)
+	got := FormatOutput(nil, nil, swatches, DryRun)
 	// Annotated label "would deploy (triggered: allow_auto_merge):" is 43 chars,
 	// plus 1 space = 44 column width.
 	want := "would deploy (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n" +
@@ -296,7 +296,7 @@ func TestFormatOutputAnnotationWouldRemove(t *testing.T) {
 		{Path: ".github/workflows/tailor-automerge.yml", Category: WouldRemove, Annotation: "triggered: allow_auto_merge"},
 	}
 
-	got := FormatOutput(nil, nil, swatches)
+	got := FormatOutput(nil, nil, swatches, DryRun)
 	want := "would remove (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n"
 
 	if got != want {
@@ -310,7 +310,7 @@ func TestFormatOutputAnnotationSkippedNever(t *testing.T) {
 		{Path: "CONTRIBUTING.md", Category: WouldCopy},
 	}
 
-	got := FormatOutput(nil, nil, swatches)
+	got := FormatOutput(nil, nil, swatches, DryRun)
 	// "skip (never) (triggered: allow_auto_merge):" = 43 chars + 1 space = 44 width
 	want := "would copy:                                 CONTRIBUTING.md\n" +
 		"skip (never) (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n"
@@ -328,7 +328,7 @@ func TestFormatOutputAnnotationMixedWithRepo(t *testing.T) {
 		{Path: ".github/workflows/tailor-automerge.yml", Category: WouldDeploy, Annotation: "triggered: allow_auto_merge"},
 	}
 
-	got := FormatOutput(repos, nil, swatches)
+	got := FormatOutput(repos, nil, swatches, DryRun)
 	// Column width widens to 44 to fit the annotated swatch label.
 	want := "would set:                                  repository.allow_auto_merge = true\n" +
 		"would deploy (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n"
@@ -343,7 +343,7 @@ func TestFormatOutputSkipAnnotationScope(t *testing.T) {
 		{Field: "default_workflow_permissions", Category: WouldSkipScope, Annotation: "token missing required scope"},
 	}
 
-	got := FormatOutput(repos, nil, nil)
+	got := FormatOutput(repos, nil, nil, DryRun)
 	// "would skip (insufficient scope: token missing required scope):" = 62 chars + 1 space = 63 width.
 	want := "would skip (insufficient scope: token missing required scope): default_workflow_permissions\n"
 
@@ -360,7 +360,7 @@ func TestFormatOutputSkipAnnotationMixed(t *testing.T) {
 		{Field: "can_approve_pull_request_reviews", Category: WouldSkipScope, Annotation: "token missing required scope"},
 	}
 
-	got := FormatOutput(repos, nil, nil)
+	got := FormatOutput(repos, nil, nil, DryRun)
 	// Widest label is "would skip (insufficient scope: token missing required scope):" = 62 chars + 1 = 63.
 	want := "would set:                                                     repository.has_wiki = false\n" +
 		"no change:                                                     repository.has_issues (already true)\n" +
@@ -378,7 +378,7 @@ func TestFormatOutputLabelSkipAnnotations(t *testing.T) {
 		{Name: "enhancement", Category: LabelSkipScope, Annotation: "token missing required scope"},
 	}
 
-	got := FormatOutput(nil, labels, nil)
+	got := FormatOutput(nil, labels, nil, DryRun)
 	// Widest label is "would skip (insufficient scope: token missing required scope):" = 62 + 1 = 63.
 	want := "would create:                                                  label.bug = #d73a4a\n" +
 		"would skip (insufficient scope: token missing required scope): enhancement\n"
@@ -393,7 +393,7 @@ func TestFormatOutputSkipAnnotationColumnWidth(t *testing.T) {
 	repos := []RepoSettingResult{
 		{Field: "vuln", Category: WouldSkipScope, Annotation: "token missing required scope"},
 	}
-	got := FormatOutput(repos, nil, nil)
+	got := FormatOutput(repos, nil, nil, DryRun)
 
 	// "would skip (insufficient scope: token missing required scope):" is 62 chars.
 	// Column width = 63 (62 + 1 space). The field starts at position 63.
@@ -413,10 +413,101 @@ func TestFormatOutputSkipWithoutAnnotation(t *testing.T) {
 		{Field: "patch repo settings", Category: WouldSkipScope},
 	}
 
-	got := FormatOutput(repos, nil, nil)
+	got := FormatOutput(repos, nil, nil, DryRun)
 	want := "would skip (insufficient scope):     patch repo settings\n"
 
 	if got != want {
 		t.Errorf("FormatOutput skip without annotation:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestFormatOutputApplyModes(t *testing.T) {
+	repos := []RepoSettingResult{
+		{Field: "has_wiki", Category: WouldSet, Value: "false"},
+	}
+	labels := []LabelResult{
+		{Name: "bug", Category: WouldCreate, Value: "#d73a4a \"A problem\""},
+		{Name: "docs", Category: WouldUpdate, Value: "#0075ca"},
+	}
+	swatches := []SwatchResult{
+		{Path: "LICENSE", Category: WouldCopy},
+		{Path: "CONTRIBUTING.md", Category: WouldOverwrite},
+		{Path: ".tailor.yml", Category: WouldUpdateConfig},
+		{Path: ".github/workflows/tailor-automerge.yml", Category: WouldDeploy, Annotation: "triggered: allow_auto_merge"},
+		{Path: ".github/workflows/tailor-automerge-old.yml", Category: Removed, Annotation: "triggered: allow_auto_merge"},
+	}
+
+	tests := []struct {
+		name string
+		mode ApplyMode
+		want string
+	}{
+		{
+			name: "dry run",
+			mode: DryRun,
+			want: "would set:                                  repository.has_wiki = false\n" +
+				"would create:                               label.bug = #d73a4a \"A problem\"\n" +
+				"would update:                               label.docs = #0075ca\n" +
+				"would update:                               .tailor.yml\n" +
+				"would copy:                                 LICENSE\n" +
+				"would overwrite:                            CONTRIBUTING.md\n" +
+				"would deploy (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n" +
+				"would remove (triggered: allow_auto_merge): .github/workflows/tailor-automerge-old.yml\n",
+		},
+		{
+			name: "apply",
+			mode: Apply,
+			want: "set:                                    repository.has_wiki = false\n" +
+				"created:                                label.bug = #d73a4a \"A problem\"\n" +
+				"updated:                                label.docs = #0075ca\n" +
+				"updated:                                .tailor.yml\n" +
+				"copied:                                 LICENSE\n" +
+				"overwritten:                            CONTRIBUTING.md\n" +
+				"deployed (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n" +
+				"removed (triggered: allow_auto_merge):  .github/workflows/tailor-automerge-old.yml\n",
+		},
+		{
+			name: "recut",
+			mode: Recut,
+			want: "set:                                    repository.has_wiki = false\n" +
+				"created:                                label.bug = #d73a4a \"A problem\"\n" +
+				"updated:                                label.docs = #0075ca\n" +
+				"updated:                                .tailor.yml\n" +
+				"copied:                                 LICENSE\n" +
+				"overwritten:                            CONTRIBUTING.md\n" +
+				"deployed (triggered: allow_auto_merge): .github/workflows/tailor-automerge.yml\n" +
+				"removed (triggered: allow_auto_merge):  .github/workflows/tailor-automerge-old.yml\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatOutput(repos, labels, swatches, tt.mode)
+			if got != tt.want {
+				t.Errorf("FormatOutput() =\n%s\nwant:\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatOutputWriteModesOmitSkippedActions(t *testing.T) {
+	repos := []RepoSettingResult{
+		{Field: "topics", Category: WouldSet, Value: "go, cli"},
+		{Field: "set topics", Category: WouldSkipScope, Annotation: "token missing required scope"},
+	}
+	labels := []LabelResult{
+		{Name: "bug", Category: WouldCreate, Value: "#d73a4a"},
+		{Name: "create label \"bug\"", Category: LabelSkipScope, Annotation: "token missing required scope"},
+	}
+	want := "would skip (insufficient scope: token missing required scope): set topics\n" +
+		"would skip (insufficient scope: token missing required scope): create label \"bug\"\n"
+
+	for _, mode := range []ApplyMode{Apply, Recut} {
+		t.Run(fmt.Sprint(mode), func(t *testing.T) {
+			got := FormatOutput(repos, labels, nil, mode)
+			if got != want {
+				t.Errorf("FormatOutput() =\n%s\nwant:\n%s", got, want)
+			}
+		})
 	}
 }

--- a/internal/alter/swatch.go
+++ b/internal/alter/swatch.go
@@ -16,14 +16,15 @@ import (
 type SwatchCategory string
 
 const (
-	WouldCopy       SwatchCategory = "would copy"
-	WouldOverwrite  SwatchCategory = "would overwrite"
-	WouldDeploy     SwatchCategory = "would deploy"
-	WouldRemove     SwatchCategory = "would remove"
-	Removed         SwatchCategory = "removed"
-	NoChange        SwatchCategory = "no change"
-	SkippedFirstFit SwatchCategory = "skipped (first-fit, exists)"
-	SkippedNever    SwatchCategory = "skip (never)"
+	WouldUpdateConfig SwatchCategory = "would update"
+	WouldCopy         SwatchCategory = "would copy"
+	WouldOverwrite    SwatchCategory = "would overwrite"
+	WouldDeploy       SwatchCategory = "would deploy"
+	WouldRemove       SwatchCategory = "would remove"
+	Removed           SwatchCategory = "removed"
+	NoChange          SwatchCategory = "no change"
+	SkippedFirstFit   SwatchCategory = "skipped (first-fit, exists)"
+	SkippedNever      SwatchCategory = "skip (never)"
 )
 
 // SwatchResult records the path and categorised outcome for one swatch entry.


### PR DESCRIPTION
Show completed labels after alter and alter --recut writes. Keep planned labels in baste and report default config merges.