### PR TITLE
refactor: simplify implementation after maintainability review

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -66,19 +66,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: linux
-            arch: amd64
-            runner: ubuntu-24.04
-          - os: linux
-            arch: arm64
-            runner: ubuntu-24.04-arm
-          - os: darwin
-            arch: amd64
-            runner: macos-15-intel
-          - os: darwin
-            arch: arm64
-            runner: macos-15
+        runner:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - macos-15-intel
+          - macos-15
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -27,15 +27,10 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-      - run: go vet ./...
       - name: Check cyclomatic complexity
         run: |
           go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
           gocyclo -top 20 -ignore '_test\.go$' -avg .
-      - name: Check ineffectual assignments
-        run: |
-          go install github.com/gordonklaus/ineffassign@latest
-          ineffassign ./...
       - uses: golangci/golangci-lint-action@v9
 
   lint-actions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,16 +51,8 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 formatters:
   enable:
     - gofumpt
   exclusions:
     generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -121,6 +121,11 @@ nix:
     homepage: https://github.com/wimpysworld/tailor
     license: blueOak100
 
+retry:
+  attempts: 5
+  delay: 10s
+  max_delay: 2m
+
 dockers_v2:
   - id: ghcr
     dockerfile: Dockerfile
@@ -133,10 +138,6 @@ dockers_v2:
     platforms:
       - linux/amd64
       - linux/arm64
-    retry:
-      attempts: 5
-      delay: 10s
-      max_delay: 2m
     labels:
       "org.opencontainers.image.title": "{{ .ProjectName }}"
       "org.opencontainers.image.description": "Ready-to-wear project templates for GitHub repositories."

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,6 @@
                 gocyclo
                 golangci-lint
                 goreleaser
-                ineffassign
                 just
               ]
               ++ (if tailorPkgs ? tailor then [ tailorPkgs.tailor ] else [ ]);

--- a/internal/alter/actions.go
+++ b/internal/alter/actions.go
@@ -110,16 +110,13 @@ func suppressActionsReadWarnings(results []RepoSettingResult, warnings []error, 
 			}
 		}
 		for _, field := range fields {
-			if !actionFieldDeclared(declared, field) {
+			index := slices.IndexFunc(results, func(result RepoSettingResult) bool {
+				return result.Field == field
+			})
+			if index == -1 {
 				continue
 			}
-			filtered := results[:0]
-			for _, result := range results {
-				if result.Field != field {
-					filtered = append(filtered, result)
-				}
-			}
-			results = filtered
+			results = slices.Delete(results, index, index+1)
 			results = append(results, RepoSettingResult{Section: "actions", Field: field, Category: WouldSkipScope, Value: warning.Error(), Annotation: skipAnnotation(warning)})
 		}
 	}
@@ -136,25 +133,6 @@ func actionsCoreBroadening(result RepoSettingResult, declared, live *model.Actio
 	case "sha_pinning_required":
 		return declared.SHAPinningRequired != nil && !*declared.SHAPinningRequired &&
 			live.SHAPinningRequired != nil && *live.SHAPinningRequired
-	default:
-		return false
-	}
-}
-
-func actionFieldDeclared(a *model.ActionsSettings, field string) bool {
-	switch field {
-	case "enabled":
-		return a.Enabled != nil
-	case "allowed_actions":
-		return a.AllowedActions != nil
-	case "sha_pinning_required":
-		return a.SHAPinningRequired != nil
-	case "github_owned_allowed":
-		return a.GitHubOwnedAllowed != nil
-	case "verified_allowed":
-		return a.VerifiedAllowed != nil
-	case "patterns_allowed":
-		return a.PatternsAllowed != nil
 	default:
 		return false
 	}

--- a/internal/alter/actions.go
+++ b/internal/alter/actions.go
@@ -117,7 +117,7 @@ func suppressActionsReadWarnings(results []RepoSettingResult, warnings []error, 
 				continue
 			}
 			results = slices.Delete(results, index, index+1)
-			results = append(results, RepoSettingResult{Section: "actions", Field: field, Category: WouldSkipScope, Value: warning.Error(), Annotation: skipAnnotation(warning)})
+			results = append(results, RepoSettingResult{Section: "actions", Field: field, Category: WouldSkipScope, Annotation: skipAnnotation})
 		}
 	}
 	return results

--- a/internal/alter/actions_test.go
+++ b/internal/alter/actions_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/wimpysworld/tailor/internal/alter"
 	"github.com/wimpysworld/tailor/internal/config"
 	"github.com/wimpysworld/tailor/internal/model"
-	"github.com/wimpysworld/tailor/internal/ptr"
 	"github.com/wimpysworld/tailor/internal/testutil"
 )
 
@@ -52,8 +51,8 @@ func TestProcessActionsCanonicalNoChange(t *testing.T) {
 	t.Cleanup(server.Close)
 	patterns := []string{"a/*", "z/*"}
 	cfg := &config.Config{Actions: &model.ActionsSettings{
-		Enabled: ptr.Ptr(true), AllowedActions: ptr.Ptr("selected"), SHAPinningRequired: ptr.Ptr(true),
-		GitHubOwnedAllowed: ptr.Ptr(true), VerifiedAllowed: ptr.Ptr(false), PatternsAllowed: &patterns,
+		Enabled: new(true), AllowedActions: new("selected"), SHAPinningRequired: new(true),
+		GitHubOwnedAllowed: new(true), VerifiedAllowed: new(false), PatternsAllowed: &patterns,
 	}}
 	results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
 	if err != nil {
@@ -73,7 +72,7 @@ func TestProcessActionsDryRunAndApply(t *testing.T) {
 	var writes atomic.Int32
 	server := actionsServer(t, &writes, false)
 	t.Cleanup(server.Close)
-	cfg := &config.Config{Actions: &model.ActionsSettings{Enabled: ptr.Ptr(false)}}
+	cfg := &config.Config{Actions: &model.ActionsSettings{Enabled: new(false)}}
 	client := testutil.NewTestClient(t, server)
 	results, err := alter.ProcessActions(cfg, alter.DryRun, client, "acme", "widget", true)
 	if err != nil || len(results) != 1 || results[0].Category != alter.WouldSet || writes.Load() != 0 {
@@ -116,7 +115,7 @@ func TestProcessActionsTransitionsToSelectedInOneApply(t *testing.T) {
 
 	patterns := []string{"acme/*"}
 	cfg := &config.Config{Actions: &model.ActionsSettings{
-		AllowedActions:  ptr.Ptr("selected"),
+		AllowedActions:  new("selected"),
 		PatternsAllowed: &patterns,
 	}}
 	results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
@@ -140,7 +139,7 @@ func TestProcessActionsAccessErrorProducesSkip(t *testing.T) {
 	var writes atomic.Int32
 	server := actionsServer(t, &writes, true)
 	t.Cleanup(server.Close)
-	cfg := &config.Config{Actions: &model.ActionsSettings{Enabled: ptr.Ptr(true)}}
+	cfg := &config.Config{Actions: &model.ActionsSettings{Enabled: new(true)}}
 	results, err := alter.ProcessActions(cfg, alter.DryRun, testutil.NewTestClient(t, server), "acme", "widget", true)
 	if err != nil {
 		t.Fatal(err)
@@ -160,7 +159,7 @@ func TestProcessActionsUnknownCoreSkipsAllDeclaredPolicyFields(t *testing.T) {
 	t.Cleanup(server.Close)
 	patterns := []string{"acme/*"}
 	cfg := &config.Config{Actions: &model.ActionsSettings{
-		AllowedActions: ptr.Ptr("selected"), PatternsAllowed: &patterns,
+		AllowedActions: new("selected"), PatternsAllowed: &patterns,
 	}}
 	results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
 	if err != nil {
@@ -196,8 +195,8 @@ func TestProcessActionsUnknownSelectedPolicyBlocksEnable(t *testing.T) {
 	t.Cleanup(server.Close)
 	patterns := []string{"acme/*"}
 	cfg := &config.Config{Actions: &model.ActionsSettings{
-		Enabled: ptr.Ptr(true), AllowedActions: ptr.Ptr("selected"), SHAPinningRequired: ptr.Ptr(false),
-		GitHubOwnedAllowed: ptr.Ptr(true), VerifiedAllowed: ptr.Ptr(true), PatternsAllowed: &patterns,
+		Enabled: new(true), AllowedActions: new("selected"), SHAPinningRequired: new(false),
+		GitHubOwnedAllowed: new(true), VerifiedAllowed: new(true), PatternsAllowed: &patterns,
 	}}
 	results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
 	if err != nil {
@@ -241,8 +240,8 @@ func TestProcessActionsDisablesBeforeChangingSelectedPolicyAndRelaxingSHAPinning
 
 	patterns := []string{"acme/*"}
 	cfg := &config.Config{Actions: &model.ActionsSettings{
-		Enabled: ptr.Ptr(true), AllowedActions: ptr.Ptr("selected"), SHAPinningRequired: ptr.Ptr(false),
-		GitHubOwnedAllowed: ptr.Ptr(true), VerifiedAllowed: ptr.Ptr(true), PatternsAllowed: &patterns,
+		Enabled: new(true), AllowedActions: new("selected"), SHAPinningRequired: new(false),
+		GitHubOwnedAllowed: new(true), VerifiedAllowed: new(true), PatternsAllowed: &patterns,
 	}}
 	if _, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true); err != nil {
 		t.Fatal(err)
@@ -283,8 +282,8 @@ func TestProcessActionsSelectedOnlyWriteAccessError(t *testing.T) {
 
 	patterns := []string{}
 	cfg := &config.Config{Actions: &model.ActionsSettings{
-		Enabled: ptr.Ptr(true), AllowedActions: ptr.Ptr("selected"), SHAPinningRequired: ptr.Ptr(false),
-		GitHubOwnedAllowed: ptr.Ptr(true), VerifiedAllowed: ptr.Ptr(true), PatternsAllowed: &patterns,
+		Enabled: new(true), AllowedActions: new("selected"), SHAPinningRequired: new(false),
+		GitHubOwnedAllowed: new(true), VerifiedAllowed: new(true), PatternsAllowed: &patterns,
 	}}
 	results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
 	if err != nil {
@@ -318,7 +317,7 @@ func TestProcessActionsWriteAccessErrorProducesClearOutput(t *testing.T) {
 		fmt.Fprint(w, `{"message":"Resource not accessible by integration"}`)
 	}))
 	t.Cleanup(server.Close)
-	cfg := &config.Config{Actions: &model.ActionsSettings{Enabled: ptr.Ptr(false)}}
+	cfg := &config.Config{Actions: &model.ActionsSettings{Enabled: new(false)}}
 	results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
 	if err != nil {
 		t.Fatal(err)
@@ -351,7 +350,7 @@ func TestProcessActionsStopsSelectedWriteAfterCoreFailure(t *testing.T) {
 			t.Cleanup(server.Close)
 			patterns := []string{"acme/*"}
 			cfg := &config.Config{Actions: &model.ActionsSettings{
-				Enabled: ptr.Ptr(false), AllowedActions: ptr.Ptr("selected"), PatternsAllowed: &patterns,
+				Enabled: new(false), AllowedActions: new("selected"), PatternsAllowed: &patterns,
 			}}
 			results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
 			if status == http.StatusForbidden && err != nil {
@@ -391,7 +390,7 @@ func TestProcessActionsTightensSelectedPolicyBeforeEnabling(t *testing.T) {
 	t.Cleanup(server.Close)
 	patterns := []string{"acme/*"}
 	cfg := &config.Config{Actions: &model.ActionsSettings{
-		Enabled: ptr.Ptr(true), AllowedActions: ptr.Ptr("selected"), PatternsAllowed: &patterns,
+		Enabled: new(true), AllowedActions: new("selected"), PatternsAllowed: &patterns,
 	}}
 	if _, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true); err != nil {
 		t.Fatal(err)
@@ -421,7 +420,7 @@ func TestProcessActionsInitialTransitionSkipSuppressesUnattemptedWrites(t *testi
 	t.Cleanup(server.Close)
 	patterns := []string{"acme/*"}
 	cfg := &config.Config{Actions: &model.ActionsSettings{
-		AllowedActions: ptr.Ptr("selected"), PatternsAllowed: &patterns,
+		AllowedActions: new("selected"), PatternsAllowed: &patterns,
 	}}
 	results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
 	if err != nil {
@@ -472,7 +471,7 @@ func TestProcessActionsLocalOnlyTransitionFailsClosed(t *testing.T) {
 				}))
 				t.Cleanup(server.Close)
 				patterns := []string{"acme/*"}
-				cfg := &config.Config{Actions: &model.ActionsSettings{AllowedActions: ptr.Ptr("selected"), PatternsAllowed: &patterns}}
+				cfg := &config.Config{Actions: &model.ActionsSettings{AllowedActions: new("selected"), PatternsAllowed: &patterns}}
 				_, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
 				if err == nil || !strings.Contains(err.Error(), "while actions are disabled") {
 					t.Fatalf("ProcessActions() error = %v, want explicit disabled transition failure", err)
@@ -495,7 +494,7 @@ func TestProcessActionsSelectedTransitionDryRunIsReadOnly(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 	patterns := []string{"acme/*"}
-	cfg := &config.Config{Actions: &model.ActionsSettings{AllowedActions: ptr.Ptr("selected"), PatternsAllowed: &patterns}}
+	cfg := &config.Config{Actions: &model.ActionsSettings{AllowedActions: new("selected"), PatternsAllowed: &patterns}}
 	if _, err := alter.ProcessActions(cfg, alter.DryRun, testutil.NewTestClient(t, server), "acme", "widget", true); err != nil {
 		t.Fatal(err)
 	}
@@ -507,8 +506,8 @@ func TestProcessActionsSelectedTransitionDryRunIsReadOnly(t *testing.T) {
 func TestRunRejectsInvalidActionsBeforeWrites(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{Actions: &model.ActionsSettings{
-		AllowedActions:  ptr.Ptr("all"),
-		VerifiedAllowed: ptr.Ptr(true),
+		AllowedActions:  new("all"),
+		VerifiedAllowed: new(true),
 	}}
 	err := alter.Run(cfg, dir, alter.Apply, nil)
 	if err == nil {
@@ -518,7 +517,7 @@ func TestRunRejectsInvalidActionsBeforeWrites(t *testing.T) {
 
 func TestRunRejectsIncompleteSelectedActions(t *testing.T) {
 	dir := t.TempDir()
-	cfg := &config.Config{Actions: &model.ActionsSettings{AllowedActions: ptr.Ptr("selected")}}
+	cfg := &config.Config{Actions: &model.ActionsSettings{AllowedActions: new("selected")}}
 	err := alter.Run(cfg, dir, alter.Apply, nil)
 	if err == nil || !strings.Contains(err.Error(), "requires github_owned_allowed, verified_allowed, and patterns_allowed") {
 		t.Fatalf("Run() error = %v, want incomplete selected policy error", err)

--- a/internal/alter/alter.go
+++ b/internal/alter/alter.go
@@ -40,8 +40,8 @@ func Run(cfg *config.Config, dir string, mode ApplyMode, client *api.RESTClient)
 	// Keep the local config aligned with built-in defaults only when the
 	// config swatch mode allows tailor to rewrite it.
 	if shouldMerge(cfg, mode) {
-		added, repoMerged, actionsMerged, labelsMerged := config.MergeDefaults(cfg)
-		configChanged = configChanged || len(added) > 0 || repoMerged || actionsMerged || labelsMerged
+		defaultsChanged := config.MergeDefaults(cfg)
+		configChanged = configChanged || defaultsChanged
 		// Re-validate after merge as a safety check.
 		if err := validateConfig(cfg); err != nil {
 			return err

--- a/internal/alter/alter.go
+++ b/internal/alter/alter.go
@@ -36,12 +36,6 @@ func Run(cfg *config.Config, dir string, mode ApplyMode, client *api.RESTClient)
 	if err := validateConfig(cfg); err != nil {
 		return err
 	}
-	if err := config.ValidateRepoSettings(cfg); err != nil {
-		return err
-	}
-	if err := config.ValidateActions(cfg); err != nil {
-		return err
-	}
 
 	// Keep the local config aligned with built-in defaults only when the
 	// config swatch mode allows tailor to rewrite it.
@@ -50,12 +44,6 @@ func Run(cfg *config.Config, dir string, mode ApplyMode, client *api.RESTClient)
 		configChanged = configChanged || len(added) > 0 || repoMerged || actionsMerged || labelsMerged
 		// Re-validate after merge as a safety check.
 		if err := validateConfig(cfg); err != nil {
-			return err
-		}
-		if err := config.ValidateRepoSettings(cfg); err != nil {
-			return err
-		}
-		if err := config.ValidateActions(cfg); err != nil {
 			return err
 		}
 	}
@@ -136,7 +124,7 @@ func Run(cfg *config.Config, dir string, mode ApplyMode, client *api.RESTClient)
 	return nil
 }
 
-// validateConfig runs path and duplicate-path validation in sequence.
+// validateConfig runs the repeated config validation pass in sequence.
 func validateConfig(cfg *config.Config) error {
 	if err := config.ValidateSwatches(cfg); err != nil {
 		return err
@@ -144,7 +132,13 @@ func validateConfig(cfg *config.Config) error {
 	if err := config.ValidatePaths(cfg); err != nil {
 		return err
 	}
-	return config.ValidateDuplicatePaths(cfg)
+	if err := config.ValidateDuplicatePaths(cfg); err != nil {
+		return err
+	}
+	if err := config.ValidateRepoSettings(cfg); err != nil {
+		return err
+	}
+	return config.ValidateActions(cfg)
 }
 
 // shouldMerge reports whether the config merge step should run. It looks up

--- a/internal/alter/format.go
+++ b/internal/alter/format.go
@@ -238,18 +238,12 @@ func labelWidth(repos []RepoSettingResult, labels []LabelResult, swatches []Swat
 // sortRepoResults returns a sorted copy: actionable (WouldSet) before
 // informational (RepoNoChange), lexicographic by field within each group.
 func sortRepoResults(results []RepoSettingResult) []RepoSettingResult {
-	if len(results) == 0 {
-		return nil
-	}
-	sorted := make([]RepoSettingResult, len(results))
-	copy(sorted, results)
-	slices.SortStableFunc(sorted, func(a, b RepoSettingResult) int {
+	return slices.SortedStableFunc(slices.Values(results), func(a, b RepoSettingResult) int {
 		if c := cmp.Compare(repoOrder(a.Category), repoOrder(b.Category)); c != 0 {
 			return c
 		}
 		return cmp.Compare(a.Field, b.Field)
 	})
-	return sorted
 }
 
 // repoOrder returns the sort priority for a RepoSettingCategory.
@@ -269,35 +263,23 @@ func repoOrder(c RepoSettingCategory) int {
 // sortSwatchResults returns a sorted copy with actionable results before
 // informational results and paths sorted within each category.
 func sortSwatchResults(results []SwatchResult) []SwatchResult {
-	if len(results) == 0 {
-		return nil
-	}
-	sorted := make([]SwatchResult, len(results))
-	copy(sorted, results)
-	slices.SortStableFunc(sorted, func(a, b SwatchResult) int {
+	return slices.SortedStableFunc(slices.Values(results), func(a, b SwatchResult) int {
 		if c := cmp.Compare(swatchOrder(a), swatchOrder(b)); c != 0 {
 			return c
 		}
 		return cmp.Compare(a.Path, b.Path)
 	})
-	return sorted
 }
 
 // sortLabelResults returns a sorted copy: actionable (WouldCreate, WouldUpdate)
 // before informational (LabelNoChange), lexicographic by name within each group.
 func sortLabelResults(results []LabelResult) []LabelResult {
-	if len(results) == 0 {
-		return nil
-	}
-	sorted := make([]LabelResult, len(results))
-	copy(sorted, results)
-	slices.SortStableFunc(sorted, func(a, b LabelResult) int {
+	return slices.SortedStableFunc(slices.Values(results), func(a, b LabelResult) int {
 		if c := cmp.Compare(labelOrder(a.Category), labelOrder(b.Category)); c != 0 {
 			return c
 		}
 		return cmp.Compare(a.Name, b.Name)
 	})
-	return sorted
 }
 
 // labelOrder returns the sort priority for a LabelCategory.

--- a/internal/alter/labels.go
+++ b/internal/alter/labels.go
@@ -69,12 +69,10 @@ func labelSkippedToResults(ar *gh.ApplyResult) []LabelResult {
 	}
 	var results []LabelResult
 	for _, sk := range ar.Skipped {
-		cat := LabelCategory(classifySkipCategory(sk.Err))
 		results = append(results, LabelResult{
 			Name:       sk.Operation,
-			Category:   cat,
-			Value:      sk.Err.Error(),
-			Annotation: skipAnnotation(sk.Err),
+			Category:   LabelSkipScope,
+			Annotation: skipAnnotation,
 		})
 	}
 	return results

--- a/internal/alter/labels.go
+++ b/internal/alter/labels.go
@@ -94,27 +94,16 @@ func compareLabels(desired, current []model.LabelEntry) []LabelResult {
 
 		display := formatLabelValue(d)
 
-		if !found {
-			results = append(results, LabelResult{
-				Name:     d.Name,
-				Category: WouldCreate,
-				Value:    display,
-			})
-			continue
+		category := LabelNoChange
+		switch {
+		case !found:
+			category = WouldCreate
+		case model.LabelNeedsUpdate(existing, d):
+			category = WouldUpdate
 		}
-
-		if model.LabelNeedsUpdate(existing, d) {
-			results = append(results, LabelResult{
-				Name:     d.Name,
-				Category: WouldUpdate,
-				Value:    display,
-			})
-			continue
-		}
-
 		results = append(results, LabelResult{
 			Name:     d.Name,
-			Category: LabelNoChange,
+			Category: category,
 			Value:    display,
 		})
 	}

--- a/internal/alter/labels_test.go
+++ b/internal/alter/labels_test.go
@@ -357,22 +357,18 @@ func TestProcessLabelsMixedResults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(results) != 3 {
-		t.Fatalf("got %d results, want 3", len(results))
+	want := []alter.LabelResult{
+		{Name: "bug", Category: alter.LabelNoChange, Value: "#d73a4a \"Something isn't working\""},
+		{Name: "enhancement", Category: alter.WouldUpdate, Value: "#a2eeef \"New feature\""},
+		{Name: "documentation", Category: alter.WouldCreate, Value: "#0075ca \"Docs improvements\""},
 	}
-
-	counts := map[alter.LabelCategory]int{}
-	for _, r := range results {
-		counts[r.Category]++
+	if len(results) != len(want) {
+		t.Fatalf("got %d results, want %d", len(results), len(want))
 	}
-	if counts[alter.LabelNoChange] != 1 {
-		t.Errorf("LabelNoChange count = %d, want 1", counts[alter.LabelNoChange])
-	}
-	if counts[alter.WouldUpdate] != 1 {
-		t.Errorf("WouldUpdate count = %d, want 1", counts[alter.WouldUpdate])
-	}
-	if counts[alter.WouldCreate] != 1 {
-		t.Errorf("WouldCreate count = %d, want 1", counts[alter.WouldCreate])
+	for i := range want {
+		if results[i] != want[i] {
+			t.Errorf("result %d = %#v, want %#v", i, results[i], want[i])
+		}
 	}
 }
 

--- a/internal/alter/settings.go
+++ b/internal/alter/settings.go
@@ -124,12 +124,10 @@ func skippedToResults(ar *gh.ApplyResult) []RepoSettingResult {
 	}
 	var results []RepoSettingResult
 	for _, sk := range ar.Skipped {
-		cat := classifySkipCategory(sk.Err)
 		results = append(results, RepoSettingResult{
 			Field:      sk.Operation,
-			Category:   cat,
-			Value:      sk.Err.Error(),
-			Annotation: skipAnnotation(sk.Err),
+			Category:   WouldSkipScope,
+			Annotation: skipAnnotation,
 		})
 	}
 	return results
@@ -216,9 +214,6 @@ func readWarningsToResults(warnings []error, declared, live *model.RepositorySet
 			continue
 		}
 
-		cat := classifySkipCategory(w)
-		ann := skipAnnotation(w)
-
 		for _, f := range fields {
 			if !declaredFields[f] {
 				continue
@@ -229,9 +224,8 @@ func readWarningsToResults(warnings []error, declared, live *model.RepositorySet
 			skippedFields[f] = true
 			results = append(results, RepoSettingResult{
 				Field:      f,
-				Category:   cat,
-				Value:      w.Error(),
-				Annotation: ann,
+				Category:   WouldSkipScope,
+				Annotation: skipAnnotation,
 			})
 		}
 
@@ -248,9 +242,8 @@ func readWarningsToResults(warnings []error, declared, live *model.RepositorySet
 			skippedFields[dependent] = true
 			results = append(results, RepoSettingResult{
 				Field:      dependent,
-				Category:   cat,
-				Value:      w.Error(),
-				Annotation: ann,
+				Category:   WouldSkipScope,
+				Annotation: skipAnnotation,
 			})
 		}
 	}

--- a/internal/alter/settings.go
+++ b/internal/alter/settings.go
@@ -164,19 +164,15 @@ func compareSettings(declared, live *model.RepositorySettings) []RepoSettingResu
 			equal = !lfv.IsNil() && lfv.Elem().Interface() == declaredVal
 		}
 
+		category := WouldSet
 		if equal {
-			results = append(results, RepoSettingResult{
-				Field:    field.YAMLKey,
-				Category: RepoNoChange,
-				Value:    displayVal,
-			})
-		} else {
-			results = append(results, RepoSettingResult{
-				Field:    field.YAMLKey,
-				Category: WouldSet,
-				Value:    displayVal,
-			})
+			category = RepoNoChange
 		}
+		results = append(results, RepoSettingResult{
+			Field:    field.YAMLKey,
+			Category: category,
+			Value:    displayVal,
+		})
 	}
 
 	return results

--- a/internal/alter/settings_test.go
+++ b/internal/alter/settings_test.go
@@ -340,19 +340,19 @@ func TestProcessRepoSettingsMixedResults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(results) != 4 {
-		t.Fatalf("got %d results, want 4", len(results))
+	want := []alter.RepoSettingResult{
+		{Field: "description", Category: alter.WouldSet, Value: "New"},
+		{Field: "has_wiki", Category: alter.WouldSet, Value: "false"},
+		{Field: "has_issues", Category: alter.RepoNoChange, Value: "true"},
+		{Field: "delete_branch_on_merge", Category: alter.WouldSet, Value: "true"},
 	}
-
-	counts := map[alter.RepoSettingCategory]int{}
-	for _, r := range results {
-		counts[r.Category]++
+	if len(results) != len(want) {
+		t.Fatalf("got %d results, want %d", len(results), len(want))
 	}
-	if counts[alter.WouldSet] != 3 {
-		t.Errorf("WouldSet count = %d, want 3", counts[alter.WouldSet])
-	}
-	if counts[alter.RepoNoChange] != 1 {
-		t.Errorf("RepoNoChange count = %d, want 1", counts[alter.RepoNoChange])
+	for i := range want {
+		if results[i] != want[i] {
+			t.Errorf("result %d = %#v, want %#v", i, results[i], want[i])
+		}
 	}
 }
 

--- a/internal/alter/settings_test.go
+++ b/internal/alter/settings_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/wimpysworld/tailor/internal/config"
 	"github.com/wimpysworld/tailor/internal/ghfake"
 	"github.com/wimpysworld/tailor/internal/model"
-	"github.com/wimpysworld/tailor/internal/ptr"
 	"github.com/wimpysworld/tailor/internal/testutil"
 )
 
@@ -111,7 +110,7 @@ func TestProcessRepoSettingsNoRepoContext(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			HasWiki: ptr.Ptr(false),
+			HasWiki: new(false),
 		},
 	}
 
@@ -145,7 +144,7 @@ func TestProcessRepoSettingsWouldSetWhenDiffer(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			HasWiki: ptr.Ptr(false),
+			HasWiki: new(false),
 		},
 	}
 
@@ -177,7 +176,7 @@ func TestProcessRepoSettingsNoChangeWhenMatch(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			HasWiki: ptr.Ptr(false),
+			HasWiki: new(false),
 		},
 	}
 
@@ -210,7 +209,7 @@ func TestProcessRepoSettingsApplyCallsAPI(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			HasWiki: ptr.Ptr(false),
+			HasWiki: new(false),
 		},
 	}
 
@@ -234,7 +233,7 @@ func TestProcessRepoSettingsRecutCallsAPI(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			HasWiki: ptr.Ptr(false),
+			HasWiki: new(false),
 		},
 	}
 
@@ -258,7 +257,7 @@ func TestProcessRepoSettingsDryRunDoesNotCallAPI(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			HasWiki: ptr.Ptr(false),
+			HasWiki: new(false),
 		},
 	}
 
@@ -282,8 +281,8 @@ func TestProcessRepoSettingsNoApplyWhenAllMatch(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			HasWiki:   ptr.Ptr(false),
-			HasIssues: ptr.Ptr(true),
+			HasWiki:   new(false),
+			HasIssues: new(true),
 		},
 	}
 
@@ -305,7 +304,7 @@ func TestProcessRepoSettingsErrorPropagated(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			HasWiki: ptr.Ptr(false),
+			HasWiki: new(false),
 		},
 	}
 
@@ -330,10 +329,10 @@ func TestProcessRepoSettingsMixedResults(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			HasWiki:             ptr.Ptr(false), // differs
-			HasIssues:           ptr.Ptr(true),  // matches
-			Description:         ptr.Ptr("New"), // differs
-			DeleteBranchOnMerge: ptr.Ptr(true),  // differs
+			HasWiki:             new(false), // differs
+			HasIssues:           new(true),  // matches
+			Description:         new("New"), // differs
+			DeleteBranchOnMerge: new(true),  // differs
 		},
 	}
 
@@ -367,8 +366,8 @@ func TestProcessRepoSettingsStringFieldValues(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			Description: ptr.Ptr("new description"),
-			Homepage:    ptr.Ptr("https://old.example.com"), // matches
+			Description: new("new description"),
+			Homepage:    new("https://old.example.com"), // matches
 		},
 	}
 
@@ -543,7 +542,7 @@ func TestProcessRepoSettingsDefaultWorkflowPermissionsNoChange(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			DefaultWorkflowPermissions: ptr.Ptr("read"),
+			DefaultWorkflowPermissions: new("read"),
 		},
 	}
 
@@ -576,7 +575,7 @@ func TestProcessRepoSettingsDefaultWorkflowPermissionsWouldSet(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			DefaultWorkflowPermissions: ptr.Ptr("write"),
+			DefaultWorkflowPermissions: new("write"),
 		},
 	}
 
@@ -609,7 +608,7 @@ func TestProcessRepoSettingsCanApprovePullRequestReviewsNoChange(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			CanApprovePullRequestReviews: ptr.Ptr(false),
+			CanApprovePullRequestReviews: new(false),
 		},
 	}
 
@@ -636,9 +635,9 @@ func TestProcessRepoSettingsSecurityFeaturesDryRun(t *testing.T) {
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 	cfg := &config.Config{Repository: &model.RepositorySettings{
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-		VulnerabilityAlertsEnabled:        ptr.Ptr(true),
-		AutomatedSecurityFixesEnabled:     ptr.Ptr(true),
+		PrivateVulnerabilityReportEnabled: new(true),
+		VulnerabilityAlertsEnabled:        new(true),
+		AutomatedSecurityFixesEnabled:     new(true),
 	}}
 
 	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
@@ -686,10 +685,10 @@ func TestProcessRepoSettingsAppliesOnlyChangedSecurityEndpoints(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 	cfg := &config.Config{Repository: &model.RepositorySettings{
-		HasWiki:                           ptr.Ptr(false),
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-		VulnerabilityAlertsEnabled:        ptr.Ptr(true),
-		AutomatedSecurityFixesEnabled:     ptr.Ptr(true),
+		HasWiki:                           new(false),
+		PrivateVulnerabilityReportEnabled: new(true),
+		VulnerabilityAlertsEnabled:        new(true),
+		AutomatedSecurityFixesEnabled:     new(true),
 	}}
 	if _, err := alter.ProcessRepoSettings(cfg, alter.Apply, testutil.NewTestClient(t, server), "testowner", "testrepo", true); err != nil {
 		t.Fatal(err)
@@ -708,7 +707,7 @@ func TestProcessRepoSettingsAutomatedFixesPrerequisiteWarning(t *testing.T) {
 	}{
 		{name: "alerts remain disabled", wantWarning: true},
 		{name: "alerts already enabled", alertsLive: true},
-		{name: "same run enables alerts", alertsDesired: ptr.Ptr(true)},
+		{name: "same run enables alerts", alertsDesired: new(true)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -736,7 +735,7 @@ func TestProcessRepoSettingsAutomatedFixesPrerequisiteWarning(t *testing.T) {
 			t.Cleanup(server.Close)
 			cfg := &config.Config{Repository: &model.RepositorySettings{
 				VulnerabilityAlertsEnabled:    tt.alertsDesired,
-				AutomatedSecurityFixesEnabled: ptr.Ptr(true),
+				AutomatedSecurityFixesEnabled: new(true),
 			}}
 			var err error
 			output := captureStderr(t, func() {
@@ -771,7 +770,7 @@ func TestProcessRepoSettingsSecurityReadAccessWarning(t *testing.T) {
 	t.Cleanup(server.Close)
 	client := testutil.NewTestClient(t, server)
 	cfg := &config.Config{Repository: &model.RepositorySettings{
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
+		PrivateVulnerabilityReportEnabled: new(true),
 	}}
 
 	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
@@ -799,7 +798,7 @@ func TestProcessRepoSettingsUnknownSecurityPrerequisiteSkipsDependent(t *testing
 			fixesResponse: func(w http.ResponseWriter) {
 				fmt.Fprint(w, `{"enabled":false,"paused":false}`)
 			},
-			settings:       &model.RepositorySettings{AutomatedSecurityFixesEnabled: ptr.Ptr(true)},
+			settings:       &model.RepositorySettings{AutomatedSecurityFixesEnabled: new(true)},
 			dependentField: "automated_security_fixes_enabled",
 		},
 		{
@@ -810,7 +809,7 @@ func TestProcessRepoSettingsUnknownSecurityPrerequisiteSkipsDependent(t *testing
 			fixesResponse: func(w http.ResponseWriter) {
 				w.WriteHeader(http.StatusForbidden)
 			},
-			settings:       &model.RepositorySettings{VulnerabilityAlertsEnabled: ptr.Ptr(false)},
+			settings:       &model.RepositorySettings{VulnerabilityAlertsEnabled: new(false)},
 			dependentField: "vulnerability_alerts_enabled",
 		},
 	}
@@ -865,7 +864,7 @@ func TestProcessRepoSettingsSkippedSecurityWriteSkipsDependentOutput(t *testing.
 		{
 			name: "alerts write blocks fixes",
 			settings: &model.RepositorySettings{
-				VulnerabilityAlertsEnabled: ptr.Ptr(true), AutomatedSecurityFixesEnabled: ptr.Ptr(true),
+				VulnerabilityAlertsEnabled: new(true), AutomatedSecurityFixesEnabled: new(true),
 			},
 			dependent: "enable automated security fixes",
 		},
@@ -874,7 +873,7 @@ func TestProcessRepoSettingsSkippedSecurityWriteSkipsDependentOutput(t *testing.
 			alertsEnabled: true,
 			fixesEnabled:  true,
 			settings: &model.RepositorySettings{
-				VulnerabilityAlertsEnabled: ptr.Ptr(false), AutomatedSecurityFixesEnabled: ptr.Ptr(false),
+				VulnerabilityAlertsEnabled: new(false), AutomatedSecurityFixesEnabled: new(false),
 			},
 			dependent: "disable vulnerability alerts",
 		},
@@ -960,7 +959,7 @@ func TestProcessRepoSettingsPatch403ScopeProducesSkipScope(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			HasWiki: ptr.Ptr(false),
+			HasWiki: new(false),
 		},
 	}
 
@@ -1020,7 +1019,7 @@ func TestProcessRepoSettingsReadPath403WorkflowProducesSkipScope(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			DefaultWorkflowPermissions: ptr.Ptr("write"),
+			DefaultWorkflowPermissions: new("write"),
 		},
 	}
 
@@ -1049,8 +1048,8 @@ func TestProcessRepoSettingsReadPath403DoesNotProduceWouldSet(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			DefaultWorkflowPermissions:   ptr.Ptr("write"),
-			CanApprovePullRequestReviews: ptr.Ptr(true),
+			DefaultWorkflowPermissions:   new("write"),
+			CanApprovePullRequestReviews: new(true),
 		},
 	}
 
@@ -1088,7 +1087,7 @@ func TestProcessRepoSettingsCanApprovePullRequestReviewsWouldSet(t *testing.T) {
 
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{
-			CanApprovePullRequestReviews: ptr.Ptr(true),
+			CanApprovePullRequestReviews: new(true),
 		},
 	}
 
@@ -1133,8 +1132,8 @@ func TestProcessRepoSettingsDoesNotRewriteDisabledSecurityFixes(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	settings := &model.RepositorySettings{
-		VulnerabilityAlertsEnabled:    ptr.Ptr(false),
-		AutomatedSecurityFixesEnabled: ptr.Ptr(false),
+		VulnerabilityAlertsEnabled:    new(false),
+		AutomatedSecurityFixesEnabled: new(false),
 	}
 	if _, err := alter.ProcessRepoSettings(&config.Config{Repository: settings}, alter.Apply, testutil.NewTestClient(t, server), "testowner", "testrepo", true); err != nil {
 		t.Fatal(err)

--- a/internal/alter/skip.go
+++ b/internal/alter/skip.go
@@ -1,12 +1,3 @@
 package alter
 
-// skipAnnotation extracts a short annotation string from a skip error.
-// For ErrInsufficientScope it returns "token missing required scope".
-func skipAnnotation(err error) string {
-	return "token missing required scope"
-}
-
-// classifySkipCategory returns WouldSkipScope for access errors.
-func classifySkipCategory(err error) RepoSettingCategory {
-	return WouldSkipScope
-}
+const skipAnnotation = "token missing required scope"

--- a/internal/alter/swatch.go
+++ b/internal/alter/swatch.go
@@ -94,18 +94,17 @@ func processSwatch(root *os.Root, entry config.SwatchEntry, content []byte, mode
 
 	switch entry.Alteration {
 	case swatch.FirstFit:
-		return processFirstFit(root, entry, content, exists, mode)
+		if exists {
+			return SwatchResult{Path: entry.Path, Category: Skipped, Reason: SkipFirstFitExists}, nil
+		}
 	case swatch.Always:
-		return processAlways(root, entry, content, exists, mode)
+		if exists {
+			return processAlways(root, entry, content, mode)
+		}
 	default:
 		return SwatchResult{}, fmt.Errorf("unknown alteration mode %q for swatch %q", entry.Alteration, entry.Path)
 	}
-}
 
-func processFirstFit(root *os.Root, entry config.SwatchEntry, content []byte, exists bool, mode ApplyMode) (SwatchResult, error) {
-	if exists {
-		return SwatchResult{Path: entry.Path, Category: Skipped, Reason: SkipFirstFitExists}, nil
-	}
 	if mode.ShouldWrite() {
 		if err := writeFile(root, entry.Path, content); err != nil {
 			return SwatchResult{}, err
@@ -114,16 +113,7 @@ func processFirstFit(root *os.Root, entry config.SwatchEntry, content []byte, ex
 	return SwatchResult{Path: entry.Path, Category: WouldCopy}, nil
 }
 
-func processAlways(root *os.Root, entry config.SwatchEntry, content []byte, exists bool, mode ApplyMode) (SwatchResult, error) {
-	if !exists {
-		if mode.ShouldWrite() {
-			if err := writeFile(root, entry.Path, content); err != nil {
-				return SwatchResult{}, err
-			}
-		}
-		return SwatchResult{Path: entry.Path, Category: WouldCopy}, nil
-	}
-
+func processAlways(root *os.Root, entry config.SwatchEntry, content []byte, mode ApplyMode) (SwatchResult, error) {
 	onDisk, err := contentHashFile(root, entry.Path)
 	if err != nil {
 		return SwatchResult{}, fmt.Errorf("hashing on-disk file %q: %w", entry.Path, err)

--- a/internal/alter/swatch.go
+++ b/internal/alter/swatch.go
@@ -2,7 +2,6 @@ package alter
 
 import (
 	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -119,7 +118,7 @@ func processAlways(root *os.Root, entry config.SwatchEntry, content []byte, mode
 		return SwatchResult{}, fmt.Errorf("hashing on-disk file %q: %w", entry.Path, err)
 	}
 
-	if contentHash(content) == onDisk {
+	if sha256.Sum256(content) == onDisk {
 		return SwatchResult{Path: entry.Path, Category: NoChange}, nil
 	}
 
@@ -163,17 +162,11 @@ func writeFile(root *os.Root, path string, data []byte) error {
 	return nil
 }
 
-// contentHash returns the hex-encoded SHA-256 digest of data.
-func contentHash(data []byte) string {
-	h := sha256.Sum256(data)
-	return hex.EncodeToString(h[:])
-}
-
-// contentHashFile returns the hex-encoded SHA-256 digest of the root-relative file at path.
-func contentHashFile(root *os.Root, path string) (string, error) {
+// contentHashFile returns the SHA-256 digest of the root-relative file at path.
+func contentHashFile(root *os.Root, path string) ([sha256.Size]byte, error) {
 	data, err := root.ReadFile(path)
 	if err != nil {
-		return "", err
+		return [sha256.Size]byte{}, err
 	}
-	return contentHash(data), nil
+	return sha256.Sum256(data), nil
 }

--- a/internal/alter/swatch_test.go
+++ b/internal/alter/swatch_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/wimpysworld/tailor/internal/alter"
@@ -146,6 +147,22 @@ func TestAlwaysWouldOverwriteWhenMD5Differs(t *testing.T) {
 	}
 	if results[0].Category != alter.WouldOverwrite {
 		t.Errorf("category = %q, want %q", results[0].Category, alter.WouldOverwrite)
+	}
+}
+
+func TestAlwaysReturnsOnDiskReadError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "CODE_OF_CONDUCT.md"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := newConfig(entry("CODE_OF_CONDUCT.md", swatch.Always))
+	_, err := alter.ProcessSwatches(cfg, dir, alter.DryRun, &alter.TokenContext{})
+	if err == nil {
+		t.Fatal("ProcessSwatches() error = nil, want read error")
+	}
+	if !strings.Contains(err.Error(), `hashing on-disk file "CODE_OF_CONDUCT.md"`) {
+		t.Errorf("error = %q, want on-disk hash context", err)
 	}
 }
 

--- a/internal/config/actions_test.go
+++ b/internal/config/actions_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/wimpysworld/tailor/internal/model"
-	"github.com/wimpysworld/tailor/internal/ptr"
 )
 
 var approvedDefaultActionPatterns = []string{
@@ -80,12 +79,12 @@ func TestValidateActions(t *testing.T) {
 		wantErr string
 	}{
 		{name: "absent"},
-		{name: "all", actions: &model.ActionsSettings{AllowedActions: ptr.Ptr("all")}},
-		{name: "local only", actions: &model.ActionsSettings{AllowedActions: ptr.Ptr("local_only")}},
-		{name: "selected", actions: &model.ActionsSettings{AllowedActions: ptr.Ptr("selected"), PatternsAllowed: &[]string{"acme/*"}}},
-		{name: "invalid enum", actions: &model.ActionsSettings{AllowedActions: ptr.Ptr("private")}, wantErr: "invalid allowed_actions"},
-		{name: "selected field without enum", actions: &model.ActionsSettings{VerifiedAllowed: ptr.Ptr(true)}, wantErr: "require allowed_actions"},
-		{name: "selected field with all", actions: &model.ActionsSettings{AllowedActions: ptr.Ptr("all"), GitHubOwnedAllowed: ptr.Ptr(true)}, wantErr: "require allowed_actions"},
+		{name: "all", actions: &model.ActionsSettings{AllowedActions: new("all")}},
+		{name: "local only", actions: &model.ActionsSettings{AllowedActions: new("local_only")}},
+		{name: "selected", actions: &model.ActionsSettings{AllowedActions: new("selected"), PatternsAllowed: &[]string{"acme/*"}}},
+		{name: "invalid enum", actions: &model.ActionsSettings{AllowedActions: new("private")}, wantErr: "invalid allowed_actions"},
+		{name: "selected field without enum", actions: &model.ActionsSettings{VerifiedAllowed: new(true)}, wantErr: "require allowed_actions"},
+		{name: "selected field with all", actions: &model.ActionsSettings{AllowedActions: new("all"), GitHubOwnedAllowed: new(true)}, wantErr: "require allowed_actions"},
 		{name: "unknown", actions: &model.ActionsSettings{Extra: map[string]interface{}{"unknown": true}}, wantErr: "unrecognised actions setting"},
 	}
 	for _, tt := range tests {
@@ -109,23 +108,23 @@ func TestValidateCompleteActions(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "absent"},
-		{name: "all", actions: &model.ActionsSettings{AllowedActions: ptr.Ptr("all")}},
-		{name: "local only", actions: &model.ActionsSettings{AllowedActions: ptr.Ptr("local_only")}},
+		{name: "all", actions: &model.ActionsSettings{AllowedActions: new("all")}},
+		{name: "local only", actions: &model.ActionsSettings{AllowedActions: new("local_only")}},
 		{
 			name: "complete selected",
 			actions: &model.ActionsSettings{
-				AllowedActions:     ptr.Ptr("selected"),
-				GitHubOwnedAllowed: ptr.Ptr(true),
-				VerifiedAllowed:    ptr.Ptr(true),
+				AllowedActions:     new("selected"),
+				GitHubOwnedAllowed: new(true),
+				VerifiedAllowed:    new(true),
 				PatternsAllowed:    &completePatterns,
 			},
 		},
-		{name: "missing all selected fields", actions: &model.ActionsSettings{AllowedActions: ptr.Ptr("selected")}, wantErr: true},
+		{name: "missing all selected fields", actions: &model.ActionsSettings{AllowedActions: new("selected")}, wantErr: true},
 		{
 			name: "missing github owned",
 			actions: &model.ActionsSettings{
-				AllowedActions:  ptr.Ptr("selected"),
-				VerifiedAllowed: ptr.Ptr(true),
+				AllowedActions:  new("selected"),
+				VerifiedAllowed: new(true),
 				PatternsAllowed: &completePatterns,
 			},
 			wantErr: true,
@@ -133,8 +132,8 @@ func TestValidateCompleteActions(t *testing.T) {
 		{
 			name: "missing verified",
 			actions: &model.ActionsSettings{
-				AllowedActions:     ptr.Ptr("selected"),
-				GitHubOwnedAllowed: ptr.Ptr(true),
+				AllowedActions:     new("selected"),
+				GitHubOwnedAllowed: new(true),
 				PatternsAllowed:    &completePatterns,
 			},
 			wantErr: true,
@@ -142,9 +141,9 @@ func TestValidateCompleteActions(t *testing.T) {
 		{
 			name: "missing patterns",
 			actions: &model.ActionsSettings{
-				AllowedActions:     ptr.Ptr("selected"),
-				GitHubOwnedAllowed: ptr.Ptr(true),
-				VerifiedAllowed:    ptr.Ptr(true),
+				AllowedActions:     new("selected"),
+				GitHubOwnedAllowed: new(true),
+				VerifiedAllowed:    new(true),
 			},
 			wantErr: true,
 		},
@@ -198,8 +197,8 @@ func TestMergeActionsDefaults(t *testing.T) {
 
 	t.Run("partial selected gets default patterns", func(t *testing.T) {
 		cfg := &Config{Actions: &model.ActionsSettings{
-			AllowedActions:     ptr.Ptr("selected"),
-			GitHubOwnedAllowed: ptr.Ptr(false),
+			AllowedActions:     new("selected"),
+			GitHubOwnedAllowed: new(false),
 		}}
 		if !mergeActionsFrom(cfg, defaults) {
 			t.Fatal("mergeActionsFrom() changed = false, want true")
@@ -212,9 +211,9 @@ func TestMergeActionsDefaults(t *testing.T) {
 	t.Run("partial selected preserves explicit values", func(t *testing.T) {
 		emptyPatterns := []string{}
 		cfg := &Config{Actions: &model.ActionsSettings{
-			Enabled:            ptr.Ptr(false),
-			AllowedActions:     ptr.Ptr("selected"),
-			GitHubOwnedAllowed: ptr.Ptr(false),
+			Enabled:            new(false),
+			AllowedActions:     new("selected"),
+			GitHubOwnedAllowed: new(false),
 			PatternsAllowed:    &emptyPatterns,
 		}}
 		patternsBefore := cfg.Actions.PatternsAllowed
@@ -244,7 +243,7 @@ func TestMergeActionsDefaults(t *testing.T) {
 	t.Run("partial selected preserves explicit custom patterns", func(t *testing.T) {
 		patterns := []string{"acme/private-action@v1"}
 		cfg := &Config{Actions: &model.ActionsSettings{
-			AllowedActions:  ptr.Ptr("selected"),
+			AllowedActions:  new("selected"),
 			PatternsAllowed: &patterns,
 		}}
 		patternsBefore := cfg.Actions.PatternsAllowed
@@ -259,8 +258,8 @@ func TestMergeActionsDefaults(t *testing.T) {
 	for _, policy := range []string{"all", "local_only"} {
 		t.Run(policy+" skips selected fields", func(t *testing.T) {
 			cfg := &Config{Actions: &model.ActionsSettings{
-				Enabled:        ptr.Ptr(false),
-				AllowedActions: ptr.Ptr(policy),
+				Enabled:        new(false),
+				AllowedActions: new(policy),
 			}}
 			if !mergeActionsFrom(cfg, defaults) {
 				t.Fatal("mergeActionsFrom() changed = false, want true")
@@ -283,11 +282,11 @@ func TestMergeActionsDefaults(t *testing.T) {
 	t.Run("complete selected policy is unchanged", func(t *testing.T) {
 		emptyPatterns := []string{}
 		cfg := &Config{Actions: &model.ActionsSettings{
-			Enabled:            ptr.Ptr(false),
-			AllowedActions:     ptr.Ptr("selected"),
-			SHAPinningRequired: ptr.Ptr(true),
-			GitHubOwnedAllowed: ptr.Ptr(false),
-			VerifiedAllowed:    ptr.Ptr(false),
+			Enabled:            new(false),
+			AllowedActions:     new("selected"),
+			SHAPinningRequired: new(true),
+			GitHubOwnedAllowed: new(false),
+			VerifiedAllowed:    new(false),
 			PatternsAllowed:    &emptyPatterns,
 		}}
 		patternsBefore := cfg.Actions.PatternsAllowed
@@ -302,7 +301,7 @@ func TestMergeActionsDefaults(t *testing.T) {
 
 func TestWriteActionsEmptyPatterns(t *testing.T) {
 	cfg := &Config{License: "none", Actions: &model.ActionsSettings{
-		AllowedActions:  ptr.Ptr("selected"),
+		AllowedActions:  new("selected"),
 		PatternsAllowed: &[]string{},
 	}}
 	dir := t.TempDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,7 +7,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/wimpysworld/tailor/internal/model"
-	"github.com/wimpysworld/tailor/internal/ptr"
 	"github.com/wimpysworld/tailor/internal/swatch"
 	"github.com/wimpysworld/tailor/internal/testutil"
 )
@@ -229,7 +228,7 @@ func TestOptionalRepositoryFieldsOmitted(t *testing.T) {
 	cfg := Config{
 		License: "MIT",
 		Repository: &model.RepositorySettings{
-			HasWiki: ptr.Ptr(false),
+			HasWiki: new(false),
 		},
 		Swatches: []SwatchEntry{
 			{Path: "justfile", Alteration: swatch.FirstFit},
@@ -324,8 +323,8 @@ func TestNewFieldsRoundTrip(t *testing.T) {
 		License: "MIT",
 		Repository: &model.RepositorySettings{
 			Topics:                       &topics,
-			DefaultWorkflowPermissions:   ptr.Ptr("write"),
-			CanApprovePullRequestReviews: ptr.Ptr(true),
+			DefaultWorkflowPermissions:   new("write"),
+			CanApprovePullRequestReviews: new(true),
 		},
 		Swatches: []SwatchEntry{
 			{Path: "justfile", Alteration: swatch.FirstFit},
@@ -359,7 +358,7 @@ func TestNewFieldsOmittedInMarshal(t *testing.T) {
 	cfg := Config{
 		License: "MIT",
 		Repository: &model.RepositorySettings{
-			HasWiki: ptr.Ptr(false),
+			HasWiki: new(false),
 		},
 		Swatches: []SwatchEntry{
 			{Path: "justfile", Alteration: swatch.FirstFit},

--- a/internal/config/generate_test.go
+++ b/internal/config/generate_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/wimpysworld/tailor"
 	"github.com/wimpysworld/tailor/internal/model"
-	"github.com/wimpysworld/tailor/internal/ptr"
 	"github.com/wimpysworld/tailor/internal/swatch"
 	"github.com/wimpysworld/tailor/internal/testutil"
 )
@@ -175,64 +174,64 @@ func TestMergeRepoSettings(t *testing.T) {
 		{
 			name: "live settings override defaults entirely",
 			live: &model.RepositorySettings{
-				Description: ptr.Ptr("live desc"),
-				Homepage:    ptr.Ptr("https://live.example.com"),
-				HasWiki:     ptr.Ptr(true),
-				HasIssues:   ptr.Ptr(false),
+				Description: new("live desc"),
+				Homepage:    new("https://live.example.com"),
+				HasWiki:     new(true),
+				HasIssues:   new(false),
 			},
 			description: "",
-			wantDesc:    ptr.Ptr("live desc"),
-			wantHome:    ptr.Ptr("https://live.example.com"),
+			wantDesc:    new("live desc"),
+			wantHome:    new("https://live.example.com"),
 		},
 		{
 			name: "description flag overrides live description",
 			live: &model.RepositorySettings{
-				Description: ptr.Ptr("live desc"),
-				Homepage:    ptr.Ptr("https://live.example.com"),
+				Description: new("live desc"),
+				Homepage:    new("https://live.example.com"),
 			},
 			description: "flag desc",
-			wantDesc:    ptr.Ptr("flag desc"),
-			wantHome:    ptr.Ptr("https://live.example.com"),
+			wantDesc:    new("flag desc"),
+			wantHome:    new("https://live.example.com"),
 		},
 		{
 			name: "empty description from live produces nil",
 			live: &model.RepositorySettings{
-				Description: ptr.Ptr(""),
-				Homepage:    ptr.Ptr("https://live.example.com"),
+				Description: new(""),
+				Homepage:    new("https://live.example.com"),
 			},
 			description: "",
 			wantDesc:    nil,
-			wantHome:    ptr.Ptr("https://live.example.com"),
+			wantHome:    new("https://live.example.com"),
 		},
 		{
 			name: "empty homepage from live produces nil",
 			live: &model.RepositorySettings{
-				Description: ptr.Ptr("live desc"),
-				Homepage:    ptr.Ptr(""),
+				Description: new("live desc"),
+				Homepage:    new(""),
 			},
 			description: "",
-			wantDesc:    ptr.Ptr("live desc"),
+			wantDesc:    new("live desc"),
 			wantHome:    nil,
 		},
 		{
 			name: "non-empty description flag with empty live description sets flag value",
 			live: &model.RepositorySettings{
-				Description: ptr.Ptr(""),
-				Homepage:    ptr.Ptr("https://live.example.com"),
+				Description: new(""),
+				Homepage:    new("https://live.example.com"),
 			},
 			description: "flag desc",
-			wantDesc:    ptr.Ptr("flag desc"),
-			wantHome:    ptr.Ptr("https://live.example.com"),
+			wantDesc:    new("flag desc"),
+			wantHome:    new("https://live.example.com"),
 		},
 		{
 			name: "empty description flag with non-empty live description preserves live value",
 			live: &model.RepositorySettings{
-				Description: ptr.Ptr("live desc"),
-				Homepage:    ptr.Ptr("https://live.example.com"),
+				Description: new("live desc"),
+				Homepage:    new("https://live.example.com"),
 			},
 			description: "",
-			wantDesc:    ptr.Ptr("live desc"),
-			wantHome:    ptr.Ptr("https://live.example.com"),
+			wantDesc:    new("live desc"),
+			wantHome:    new("https://live.example.com"),
 		},
 	}
 
@@ -241,8 +240,8 @@ func TestMergeRepoSettings(t *testing.T) {
 			cfg := &Config{
 				License: "BlueOak-1.0.0",
 				Repository: &model.RepositorySettings{
-					HasWiki:   ptr.Ptr(false),
-					HasIssues: ptr.Ptr(true),
+					HasWiki:   new(false),
+					HasIssues: new(true),
 				},
 			}
 
@@ -278,8 +277,8 @@ func TestMergeRepoSettingsPreservesMergeCommitFields(t *testing.T) {
 	mergeTitle := "PR_TITLE"
 	mergeMessage := "PR_BODY"
 	live := &model.RepositorySettings{
-		Description:        ptr.Ptr("desc"),
-		AllowMergeCommit:   ptr.Ptr(false),
+		Description:        new("desc"),
+		AllowMergeCommit:   new(false),
 		MergeCommitTitle:   &mergeTitle,
 		MergeCommitMessage: &mergeMessage,
 	}

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -17,21 +17,20 @@ var repoSettingsSkipFields = map[string]bool{
 	"Topics":      true,
 }
 
-// MergeDefaults calls DefaultConfig once and delegates to the four merge
-// functions, avoiding redundant YAML parses. Returns the newly added swatch
-// entries and whether repo settings, Actions settings, or labels were merged.
-func MergeDefaults(cfg *Config) (swatchesAdded []SwatchEntry, repoMerged, actionsMerged, labelsMerged bool) {
-	swatchesAdded = MergeDefaultSwatches(cfg)
+// MergeDefaults calls DefaultConfig once and reports whether any defaults were
+// merged into the config.
+func MergeDefaults(cfg *Config) bool {
+	swatchesChanged := len(MergeDefaultSwatches(cfg)) > 0
 
 	defaults, err := DefaultConfig("_")
 	if err != nil {
-		return swatchesAdded, false, false, false
+		return swatchesChanged
 	}
 
-	repoMerged = mergeRepoSettingsFrom(cfg, defaults)
-	actionsMerged = mergeActionsFrom(cfg, defaults)
-	labelsMerged = mergeLabelsFrom(cfg, defaults)
-	return swatchesAdded, repoMerged, actionsMerged, labelsMerged
+	repoChanged := mergeRepoSettingsFrom(cfg, defaults)
+	actionsChanged := mergeActionsFrom(cfg, defaults)
+	labelsChanged := mergeLabelsFrom(cfg, defaults)
+	return swatchesChanged || repoChanged || actionsChanged || labelsChanged
 }
 
 // mergeRepoSettingsFrom fills nil pointer fields in cfg.Repository from the

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -8,13 +8,13 @@ import (
 	"github.com/wimpysworld/tailor/internal/swatch"
 )
 
-// repoSettingsSkipFields lists RepositorySettings field names excluded from
+// repoSettingsSkipFields lists RepositorySettings YAML keys excluded from
 // default merging. Description and Homepage are project-specific (nil'd by
 // DefaultConfig). Topics are project-specific per spec.
 var repoSettingsSkipFields = map[string]bool{
-	"Description": true,
-	"Homepage":    true,
-	"Topics":      true,
+	"description": true,
+	"homepage":    true,
+	"topics":      true,
 }
 
 // MergeDefaults calls DefaultConfig once and reports whether any defaults were
@@ -49,7 +49,7 @@ func mergeRepoSettingsFrom(cfg *Config, defaults *Config) bool {
 	changed := false
 
 	for _, field := range model.RepositorySettingFields(defaults.Repository) {
-		if repoSettingsSkipFields[field.GoName] {
+		if repoSettingsSkipFields[field.YAMLKey] {
 			continue
 		}
 		if !field.Set {

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -129,6 +129,52 @@ func TestMergeEmptyConfig(t *testing.T) {
 	}
 }
 
+func TestMergeDefaultsChangedByEachSection(t *testing.T) {
+	tests := []struct {
+		name  string
+		alter func(*Config)
+	}{
+		{
+			name: "swatches",
+			alter: func(cfg *Config) {
+				cfg.Swatches = cfg.Swatches[1:]
+			},
+		},
+		{
+			name: "repository",
+			alter: func(cfg *Config) {
+				cfg.Repository.HasIssues = nil
+			},
+		},
+		{
+			name: "actions",
+			alter: func(cfg *Config) {
+				cfg.Actions.Enabled = nil
+			},
+		},
+		{
+			name: "labels",
+			alter: func(cfg *Config) {
+				cfg.Labels = nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := defaultConfig(t)
+			tt.alter(cfg)
+
+			if !MergeDefaults(cfg) {
+				t.Fatal("MergeDefaults() changed = false, want true")
+			}
+			if MergeDefaults(cfg) {
+				t.Fatal("second MergeDefaults() changed = true, want false")
+			}
+		})
+	}
+}
+
 // defaultRepoDefaults returns the default RepositorySettings from the embedded
 // config, for comparison in merge tests.
 func defaultRepoDefaults(t *testing.T) *model.RepositorySettings {

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -215,7 +215,7 @@ func countMergeableFields(t *testing.T) int {
 	def := defaultRepoDefaults(t)
 	count := 0
 	for _, field := range model.RepositorySettingFields(def) {
-		if _, skip := repoSettingsSkipFields[field.GoName]; skip {
+		if _, skip := repoSettingsSkipFields[field.YAMLKey]; skip {
 			continue
 		}
 		if field.Set {
@@ -238,30 +238,23 @@ func TestMergeRepoSettingsNilRepository(t *testing.T) {
 	}
 
 	def := defaultRepoDefaults(t)
-	dv := reflect.ValueOf(def).Elem()
 	cv := reflect.ValueOf(cfg.Repository).Elem()
-	dt := dv.Type()
 
 	merged := 0
-	for i := range dt.NumField() {
-		f := dt.Field(i)
-		if _, skip := repoSettingsSkipFields[f.Name]; skip {
+	for _, field := range model.RepositorySettingFields(def) {
+		if _, skip := repoSettingsSkipFields[field.YAMLKey]; skip {
 			continue
 		}
-		if f.Tag.Get("yaml") == "" || f.Tag.Get("yaml") == ",inline" {
+		if !field.Set {
 			continue
 		}
-		dfv := dv.Field(i)
-		if dfv.Kind() != reflect.Pointer || dfv.IsNil() {
-			continue
-		}
-		cfv := cv.Field(i)
+		cfv := cv.Field(field.Index)
 		if cfv.IsNil() {
-			t.Errorf("field %s should be set from defaults", f.Name)
+			t.Errorf("field %s should be set from defaults", field.YAMLKey)
 			continue
 		}
-		if !reflect.DeepEqual(cfv.Elem().Interface(), dfv.Elem().Interface()) {
-			t.Errorf("field %s: got %v, want %v", f.Name, cfv.Elem().Interface(), dfv.Elem().Interface())
+		if !reflect.DeepEqual(cfv.Elem().Interface(), field.Value.Elem().Interface()) {
+			t.Errorf("field %s: got %v, want %v", field.YAMLKey, cfv.Elem().Interface(), field.Value.Elem().Interface())
 		}
 		merged++
 	}
@@ -302,25 +295,18 @@ func TestMergeRepoSettingsPartialRepository(t *testing.T) {
 
 	// Nil fields receive values from defaults.
 	def := defaultRepoDefaults(t)
-	dv := reflect.ValueOf(def).Elem()
 	cv := reflect.ValueOf(cfg.Repository).Elem()
-	dt := dv.Type()
 
-	for i := range dt.NumField() {
-		f := dt.Field(i)
-		if _, skip := repoSettingsSkipFields[f.Name]; skip {
+	for _, field := range model.RepositorySettingFields(def) {
+		if _, skip := repoSettingsSkipFields[field.YAMLKey]; skip {
 			continue
 		}
-		if f.Tag.Get("yaml") == "" || f.Tag.Get("yaml") == ",inline" {
+		if !field.Set {
 			continue
 		}
-		dfv := dv.Field(i)
-		if dfv.Kind() != reflect.Pointer || dfv.IsNil() {
-			continue
-		}
-		cfv := cv.Field(i)
+		cfv := cv.Field(field.Index)
 		if cfv.IsNil() {
-			t.Errorf("field %s should be set from defaults", f.Name)
+			t.Errorf("field %s should be set from defaults", field.YAMLKey)
 		}
 	}
 }

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/wimpysworld/tailor/internal/model"
-	"github.com/wimpysworld/tailor/internal/ptr"
 	"github.com/wimpysworld/tailor/internal/swatch"
 	"github.com/wimpysworld/tailor/internal/testutil"
 )
@@ -281,7 +280,7 @@ func TestMergeRepoSettingsPartialRepository(t *testing.T) {
 }
 
 func TestMergeRepoSettingsAddsSecurityDefaults(t *testing.T) {
-	cfg := &Config{Repository: &model.RepositorySettings{HasWiki: ptr.Ptr(false)}}
+	cfg := &Config{Repository: &model.RepositorySettings{HasWiki: new(false)}}
 
 	if !mergeRepoDefaultsForTest(t, cfg) {
 		t.Fatal("expected changed=true for missing security settings")
@@ -294,9 +293,9 @@ func TestMergeRepoSettingsAddsSecurityDefaults(t *testing.T) {
 
 func TestMergeRepoSettingsPreservesExplicitFalseSecuritySettings(t *testing.T) {
 	cfg := &Config{Repository: &model.RepositorySettings{
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(false),
-		VulnerabilityAlertsEnabled:        ptr.Ptr(false),
-		AutomatedSecurityFixesEnabled:     ptr.Ptr(false),
+		PrivateVulnerabilityReportEnabled: new(false),
+		VulnerabilityAlertsEnabled:        new(false),
+		AutomatedSecurityFixesEnabled:     new(false),
 	}}
 
 	if !mergeRepoDefaultsForTest(t, cfg) {

--- a/internal/config/retired.go
+++ b/internal/config/retired.go
@@ -25,20 +25,11 @@ func IsRetiredWorkflowPath(path string) bool {
 
 // RemoveRetiredWorkflowEntries removes every retired workflow entry from cfg.
 func RemoveRetiredWorkflowEntries(cfg *Config) bool {
-	kept := cfg.Swatches[:0]
-	removed := false
-	for _, entry := range cfg.Swatches {
-		if IsRetiredWorkflowPath(entry.Path) {
-			removed = true
-			continue
-		}
-		kept = append(kept, entry)
-	}
-	if removed {
-		clear(cfg.Swatches[len(kept):])
-		cfg.Swatches = kept
-	}
-	return removed
+	originalLength := len(cfg.Swatches)
+	cfg.Swatches = slices.DeleteFunc(cfg.Swatches, func(entry SwatchEntry) bool {
+		return IsRetiredWorkflowPath(entry.Path)
+	})
+	return len(cfg.Swatches) != originalLength
 }
 
 func isLegacyRetiredEntry(entry SwatchEntry) bool {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -20,12 +20,8 @@ var (
 // swatch. Returns an error listing the unrecognised path and all valid paths.
 func ValidatePaths(cfg *Config) error {
 	valid := swatch.Paths()
-	known := make(map[string]bool, len(valid))
-	for _, name := range valid {
-		known[name] = true
-	}
 	for _, s := range cfg.Swatches {
-		if !known[s.Path] {
+		if !slices.Contains(valid, s.Path) {
 			return fmt.Errorf("unrecognised swatch path %q in config; valid paths: %s",
 				s.Path, strings.Join(valid, ", "))
 		}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
 	"slices"
 	"strings"
@@ -54,11 +55,7 @@ func ValidateRepoSettings(cfg *Config) error {
 	}
 
 	if len(cfg.Repository.Extra) > 0 {
-		keys := make([]string, 0, len(cfg.Repository.Extra))
-		for key := range cfg.Repository.Extra {
-			keys = append(keys, key)
-		}
-		slices.Sort(keys)
+		keys := slices.Sorted(maps.Keys(cfg.Repository.Extra))
 		valid := repoSettingNames()
 		return fmt.Errorf("unrecognised repository setting %q in config; valid settings: %s",
 			keys[0], strings.Join(valid, ", "))
@@ -86,11 +83,7 @@ func ValidateActions(cfg *Config) error {
 		return nil
 	}
 	if len(cfg.Actions.Extra) > 0 {
-		keys := make([]string, 0, len(cfg.Actions.Extra))
-		for key := range cfg.Actions.Extra {
-			keys = append(keys, key)
-		}
-		slices.Sort(keys)
+		keys := slices.Sorted(maps.Keys(cfg.Actions.Extra))
 		return fmt.Errorf("unrecognised actions setting %q in config; valid settings: allowed_actions, enabled, github_owned_allowed, patterns_allowed, sha_pinning_required, verified_allowed", keys[0])
 	}
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -8,7 +8,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/wimpysworld/tailor/internal/model"
-	"github.com/wimpysworld/tailor/internal/ptr"
 	"github.com/wimpysworld/tailor/internal/swatch"
 )
 
@@ -98,9 +97,9 @@ func TestValidateDuplicatePathsRejectsDuplicate(t *testing.T) {
 func TestValidateRepoSettingsAcceptsValidConfig(t *testing.T) {
 	cfg := &Config{
 		Repository: &model.RepositorySettings{
-			HasWiki:   ptr.Ptr(false),
-			HasIssues: ptr.Ptr(true),
-			Homepage:  ptr.Ptr("https://example.com"),
+			HasWiki:   new(false),
+			HasIssues: new(true),
+			Homepage:  new("https://example.com"),
 		},
 	}
 	if err := ValidateRepoSettings(cfg); err != nil {
@@ -117,8 +116,8 @@ func TestValidateRepoSettingsAcceptsNilRepository(t *testing.T) {
 
 func TestValidateRepoSettingsAcceptsNormalisableSecuritySettings(t *testing.T) {
 	cfg := &Config{Repository: &model.RepositorySettings{
-		VulnerabilityAlertsEnabled:    ptr.Ptr(false),
-		AutomatedSecurityFixesEnabled: ptr.Ptr(true),
+		VulnerabilityAlertsEnabled:    new(false),
+		AutomatedSecurityFixesEnabled: new(true),
 	}}
 	if err := ValidateRepoSettings(cfg); err != nil {
 		t.Fatalf("ValidateRepoSettings() returned unexpected error: %v", err)
@@ -186,14 +185,14 @@ func TestRepoSettingNamesContainsExpectedFields(t *testing.T) {
 }
 
 func TestValidateWorkflowPermissionsAcceptsRead(t *testing.T) {
-	cfg := &Config{Repository: &model.RepositorySettings{DefaultWorkflowPermissions: ptr.Ptr("read")}}
+	cfg := &Config{Repository: &model.RepositorySettings{DefaultWorkflowPermissions: new("read")}}
 	if err := ValidateWorkflowPermissions(cfg); err != nil {
 		t.Fatalf("ValidateWorkflowPermissions(read): %v", err)
 	}
 }
 
 func TestValidateWorkflowPermissionsAcceptsWrite(t *testing.T) {
-	cfg := &Config{Repository: &model.RepositorySettings{DefaultWorkflowPermissions: ptr.Ptr("write")}}
+	cfg := &Config{Repository: &model.RepositorySettings{DefaultWorkflowPermissions: new("write")}}
 	if err := ValidateWorkflowPermissions(cfg); err != nil {
 		t.Fatalf("ValidateWorkflowPermissions(write): %v", err)
 	}
@@ -214,7 +213,7 @@ func TestValidateWorkflowPermissionsAcceptsNilRepository(t *testing.T) {
 }
 
 func TestValidateWorkflowPermissionsRejectsInvalid(t *testing.T) {
-	cfg := &Config{Repository: &model.RepositorySettings{DefaultWorkflowPermissions: ptr.Ptr("admin")}}
+	cfg := &Config{Repository: &model.RepositorySettings{DefaultWorkflowPermissions: new("admin")}}
 	err := ValidateWorkflowPermissions(cfg)
 	if err == nil {
 		t.Fatal("ValidateWorkflowPermissions(admin) expected error, got nil")

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -13,54 +13,11 @@ const yamlSpecial = ":{}[]#&*!|>'\"%@`\n"
 
 // templateFuncs provides helpers for the config template.
 var templateFuncs = template.FuncMap{
-	"deref": func(p *string) string {
-		if p == nil {
-			return ""
-		}
-		return *p
-	},
-	"yamlString": func(p *string) string {
-		if p == nil {
-			return "\"\""
-		}
-		v := *p
-		if strings.ContainsAny(v, yamlSpecial) || v != strings.TrimSpace(v) || v == "" {
-			return fmt.Sprintf("%q", v)
-		}
-		return v
-	},
 	"yamlVal": func(v string) string {
 		if strings.ContainsAny(v, yamlSpecial) || v != strings.TrimSpace(v) || v == "" {
 			return fmt.Sprintf("%q", v)
 		}
 		return v
-	},
-	"derefSlice": func(p *[]string) []string {
-		if p == nil {
-			return nil
-		}
-		return *p
-	},
-	"derefBool": func(p *bool) string {
-		if p == nil {
-			return ""
-		}
-		if *p {
-			return "true"
-		}
-		return "false"
-	},
-	"set": func(p any) bool {
-		switch v := p.(type) {
-		case *string:
-			return v != nil
-		case *bool:
-			return v != nil
-		case *[]string:
-			return v != nil
-		default:
-			return false
-		}
 	},
 }
 
@@ -74,75 +31,75 @@ license: {{ .License }}
 {{- if .Repository }}
 
 repository:
-{{- if set .Repository.Description }}
-  description: {{ yamlString .Repository.Description }}
+{{- if .Repository.Description }}
+  description: {{ yamlVal .Repository.Description }}
 {{- end }}
-{{- if set .Repository.Homepage }}
-  homepage: {{ deref .Repository.Homepage }}
+{{- if .Repository.Homepage }}
+  homepage: {{ .Repository.Homepage }}
 {{- end }}
-{{- if set .Repository.HasWiki }}
-  has_wiki: {{ derefBool .Repository.HasWiki }}
+{{- if .Repository.HasWiki }}
+  has_wiki: {{ .Repository.HasWiki }}
 {{- end }}
-{{- if set .Repository.HasDiscussions }}
-  has_discussions: {{ derefBool .Repository.HasDiscussions }}
+{{- if .Repository.HasDiscussions }}
+  has_discussions: {{ .Repository.HasDiscussions }}
 {{- end }}
-{{- if set .Repository.HasProjects }}
-  has_projects: {{ derefBool .Repository.HasProjects }}
+{{- if .Repository.HasProjects }}
+  has_projects: {{ .Repository.HasProjects }}
 {{- end }}
-{{- if set .Repository.HasIssues }}
-  has_issues: {{ derefBool .Repository.HasIssues }}
+{{- if .Repository.HasIssues }}
+  has_issues: {{ .Repository.HasIssues }}
 {{- end }}
-{{- if set .Repository.AllowMergeCommit }}
-  allow_merge_commit: {{ derefBool .Repository.AllowMergeCommit }}
+{{- if .Repository.AllowMergeCommit }}
+  allow_merge_commit: {{ .Repository.AllowMergeCommit }}
 {{- end }}
-{{- if set .Repository.AllowSquashMerge }}
-  allow_squash_merge: {{ derefBool .Repository.AllowSquashMerge }}
+{{- if .Repository.AllowSquashMerge }}
+  allow_squash_merge: {{ .Repository.AllowSquashMerge }}
 {{- end }}
-{{- if set .Repository.AllowRebaseMerge }}
-  allow_rebase_merge: {{ derefBool .Repository.AllowRebaseMerge }}
+{{- if .Repository.AllowRebaseMerge }}
+  allow_rebase_merge: {{ .Repository.AllowRebaseMerge }}
 {{- end }}
-{{- if set .Repository.SquashMergeCommitTitle }}
-  squash_merge_commit_title: {{ yamlString .Repository.SquashMergeCommitTitle }}
+{{- if .Repository.SquashMergeCommitTitle }}
+  squash_merge_commit_title: {{ yamlVal .Repository.SquashMergeCommitTitle }}
 {{- end }}
-{{- if set .Repository.SquashMergeCommitMessage }}
-  squash_merge_commit_message: {{ yamlString .Repository.SquashMergeCommitMessage }}
+{{- if .Repository.SquashMergeCommitMessage }}
+  squash_merge_commit_message: {{ yamlVal .Repository.SquashMergeCommitMessage }}
 {{- end }}
-{{- if set .Repository.MergeCommitTitle }}
-  merge_commit_title: {{ yamlString .Repository.MergeCommitTitle }}
+{{- if .Repository.MergeCommitTitle }}
+  merge_commit_title: {{ yamlVal .Repository.MergeCommitTitle }}
 {{- end }}
-{{- if set .Repository.MergeCommitMessage }}
-  merge_commit_message: {{ yamlString .Repository.MergeCommitMessage }}
+{{- if .Repository.MergeCommitMessage }}
+  merge_commit_message: {{ yamlVal .Repository.MergeCommitMessage }}
 {{- end }}
-{{- if set .Repository.DeleteBranchOnMerge }}
-  delete_branch_on_merge: {{ derefBool .Repository.DeleteBranchOnMerge }}
+{{- if .Repository.DeleteBranchOnMerge }}
+  delete_branch_on_merge: {{ .Repository.DeleteBranchOnMerge }}
 {{- end }}
-{{- if set .Repository.AllowUpdateBranch }}
-  allow_update_branch: {{ derefBool .Repository.AllowUpdateBranch }}
+{{- if .Repository.AllowUpdateBranch }}
+  allow_update_branch: {{ .Repository.AllowUpdateBranch }}
 {{- end }}
-{{- if set .Repository.AllowAutoMerge }}
-  allow_auto_merge: {{ derefBool .Repository.AllowAutoMerge }}
+{{- if .Repository.AllowAutoMerge }}
+  allow_auto_merge: {{ .Repository.AllowAutoMerge }}
 {{- end }}
-{{- if set .Repository.WebCommitSignoffRequired }}
-  web_commit_signoff_required: {{ derefBool .Repository.WebCommitSignoffRequired }}
+{{- if .Repository.WebCommitSignoffRequired }}
+  web_commit_signoff_required: {{ .Repository.WebCommitSignoffRequired }}
 {{- end }}
-{{- if set .Repository.PrivateVulnerabilityReportEnabled }}
-  private_vulnerability_reporting_enabled: {{ derefBool .Repository.PrivateVulnerabilityReportEnabled }}
+{{- if .Repository.PrivateVulnerabilityReportEnabled }}
+  private_vulnerability_reporting_enabled: {{ .Repository.PrivateVulnerabilityReportEnabled }}
 {{- end }}
-{{- if set .Repository.VulnerabilityAlertsEnabled }}
-  vulnerability_alerts_enabled: {{ derefBool .Repository.VulnerabilityAlertsEnabled }}
+{{- if .Repository.VulnerabilityAlertsEnabled }}
+  vulnerability_alerts_enabled: {{ .Repository.VulnerabilityAlertsEnabled }}
 {{- end }}
-{{- if set .Repository.AutomatedSecurityFixesEnabled }}
-  automated_security_fixes_enabled: {{ derefBool .Repository.AutomatedSecurityFixesEnabled }}
+{{- if .Repository.AutomatedSecurityFixesEnabled }}
+  automated_security_fixes_enabled: {{ .Repository.AutomatedSecurityFixesEnabled }}
 {{- end }}
-{{- if set .Repository.DefaultWorkflowPermissions }}
-  default_workflow_permissions: {{ deref .Repository.DefaultWorkflowPermissions }}
+{{- if .Repository.DefaultWorkflowPermissions }}
+  default_workflow_permissions: {{ .Repository.DefaultWorkflowPermissions }}
 {{- end }}
-{{- if set .Repository.CanApprovePullRequestReviews }}
-  can_approve_pull_request_reviews: {{ derefBool .Repository.CanApprovePullRequestReviews }}
+{{- if .Repository.CanApprovePullRequestReviews }}
+  can_approve_pull_request_reviews: {{ .Repository.CanApprovePullRequestReviews }}
 {{- end }}
-{{- if set .Repository.Topics }}
-  topics:{{ if eq (len (derefSlice .Repository.Topics)) 0 }} []{{ else }}
-{{- range derefSlice .Repository.Topics }}
+{{- if .Repository.Topics }}
+  topics:{{ if eq (len .Repository.Topics) 0 }} []{{ else }}
+{{- range .Repository.Topics }}
     - {{ yamlVal . }}
 {{- end }}{{ end }}
 {{- end }}
@@ -150,24 +107,24 @@ repository:
 {{- if .Actions }}
 
 actions:
-{{- if set .Actions.Enabled }}
-  enabled: {{ derefBool .Actions.Enabled }}
+{{- if .Actions.Enabled }}
+  enabled: {{ .Actions.Enabled }}
 {{- end }}
-{{- if set .Actions.AllowedActions }}
-  allowed_actions: {{ deref .Actions.AllowedActions }}
+{{- if .Actions.AllowedActions }}
+  allowed_actions: {{ .Actions.AllowedActions }}
 {{- end }}
-{{- if set .Actions.SHAPinningRequired }}
-  sha_pinning_required: {{ derefBool .Actions.SHAPinningRequired }}
+{{- if .Actions.SHAPinningRequired }}
+  sha_pinning_required: {{ .Actions.SHAPinningRequired }}
 {{- end }}
-{{- if set .Actions.GitHubOwnedAllowed }}
-  github_owned_allowed: {{ derefBool .Actions.GitHubOwnedAllowed }}
+{{- if .Actions.GitHubOwnedAllowed }}
+  github_owned_allowed: {{ .Actions.GitHubOwnedAllowed }}
 {{- end }}
-{{- if set .Actions.VerifiedAllowed }}
-  verified_allowed: {{ derefBool .Actions.VerifiedAllowed }}
+{{- if .Actions.VerifiedAllowed }}
+  verified_allowed: {{ .Actions.VerifiedAllowed }}
 {{- end }}
-{{- if set .Actions.PatternsAllowed }}
-  patterns_allowed:{{ if eq (len (derefSlice .Actions.PatternsAllowed)) 0 }} []{{ else }}
-{{- range derefSlice .Actions.PatternsAllowed }}
+{{- if .Actions.PatternsAllowed }}
+  patterns_allowed:{{ if eq (len .Actions.PatternsAllowed) 0 }} []{{ else }}
+{{- range .Actions.PatternsAllowed }}
     - {{ yamlVal . }}
 {{- end }}{{ end }}
 {{- end }}

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -9,7 +9,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/wimpysworld/tailor/internal/model"
-	"github.com/wimpysworld/tailor/internal/ptr"
 	"github.com/wimpysworld/tailor/internal/swatch"
 )
 
@@ -184,7 +183,7 @@ func TestWriteCreatesFile(t *testing.T) {
 	cfg := &Config{
 		License: "MIT",
 		Repository: &model.RepositorySettings{
-			HasWiki: ptr.Ptr(false),
+			HasWiki: new(false),
 		},
 		Swatches: []SwatchEntry{
 			{Path: "justfile", Alteration: swatch.FirstFit},
@@ -245,28 +244,28 @@ func TestWriteOptionalFieldsPresent(t *testing.T) {
 	cfg := &Config{
 		License: "Apache-2.0",
 		Repository: &model.RepositorySettings{
-			Description:                       ptr.Ptr("My project"),
-			Homepage:                          ptr.Ptr("https://example.com"),
-			HasWiki:                           ptr.Ptr(true),
-			HasDiscussions:                    ptr.Ptr(false),
-			HasProjects:                       ptr.Ptr(false),
-			HasIssues:                         ptr.Ptr(true),
-			AllowMergeCommit:                  ptr.Ptr(true),
-			AllowSquashMerge:                  ptr.Ptr(true),
-			AllowRebaseMerge:                  ptr.Ptr(false),
-			SquashMergeCommitTitle:            ptr.Ptr("PR_TITLE"),
-			SquashMergeCommitMessage:          ptr.Ptr("COMMIT_MESSAGES"),
-			MergeCommitTitle:                  ptr.Ptr("PR_TITLE"),
-			MergeCommitMessage:                ptr.Ptr("PR_BODY"),
-			DeleteBranchOnMerge:               ptr.Ptr(true),
-			AllowUpdateBranch:                 ptr.Ptr(true),
-			AllowAutoMerge:                    ptr.Ptr(false),
-			WebCommitSignoffRequired:          ptr.Ptr(true),
-			PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-			VulnerabilityAlertsEnabled:        ptr.Ptr(false),
-			AutomatedSecurityFixesEnabled:     ptr.Ptr(true),
-			DefaultWorkflowPermissions:        ptr.Ptr("write"),
-			CanApprovePullRequestReviews:      ptr.Ptr(true),
+			Description:                       new("My project"),
+			Homepage:                          new("https://example.com"),
+			HasWiki:                           new(true),
+			HasDiscussions:                    new(false),
+			HasProjects:                       new(false),
+			HasIssues:                         new(true),
+			AllowMergeCommit:                  new(true),
+			AllowSquashMerge:                  new(true),
+			AllowRebaseMerge:                  new(false),
+			SquashMergeCommitTitle:            new("PR_TITLE"),
+			SquashMergeCommitMessage:          new("COMMIT_MESSAGES"),
+			MergeCommitTitle:                  new("PR_TITLE"),
+			MergeCommitMessage:                new("PR_BODY"),
+			DeleteBranchOnMerge:               new(true),
+			AllowUpdateBranch:                 new(true),
+			AllowAutoMerge:                    new(false),
+			WebCommitSignoffRequired:          new(true),
+			PrivateVulnerabilityReportEnabled: new(true),
+			VulnerabilityAlertsEnabled:        new(false),
+			AutomatedSecurityFixesEnabled:     new(true),
+			DefaultWorkflowPermissions:        new("write"),
+			CanApprovePullRequestReviews:      new(true),
 		},
 		Swatches: []SwatchEntry{
 			{Path: "justfile", Alteration: swatch.FirstFit},
@@ -325,21 +324,21 @@ func TestWriteOptionalFieldsOmitted(t *testing.T) {
 		License: "MIT",
 		Repository: &model.RepositorySettings{
 			// Description, Homepage, MergeCommitTitle, MergeCommitMessage are nil.
-			HasWiki:                      ptr.Ptr(false),
-			HasDiscussions:               ptr.Ptr(false),
-			HasProjects:                  ptr.Ptr(false),
-			HasIssues:                    ptr.Ptr(true),
-			AllowMergeCommit:             ptr.Ptr(false),
-			AllowSquashMerge:             ptr.Ptr(true),
-			AllowRebaseMerge:             ptr.Ptr(true),
-			SquashMergeCommitTitle:       ptr.Ptr("PR_TITLE"),
-			SquashMergeCommitMessage:     ptr.Ptr("PR_BODY"),
-			DeleteBranchOnMerge:          ptr.Ptr(true),
-			AllowUpdateBranch:            ptr.Ptr(true),
-			AllowAutoMerge:               ptr.Ptr(true),
-			WebCommitSignoffRequired:     ptr.Ptr(false),
-			DefaultWorkflowPermissions:   ptr.Ptr("read"),
-			CanApprovePullRequestReviews: ptr.Ptr(false),
+			HasWiki:                      new(false),
+			HasDiscussions:               new(false),
+			HasProjects:                  new(false),
+			HasIssues:                    new(true),
+			AllowMergeCommit:             new(false),
+			AllowSquashMerge:             new(true),
+			AllowRebaseMerge:             new(true),
+			SquashMergeCommitTitle:       new("PR_TITLE"),
+			SquashMergeCommitMessage:     new("PR_BODY"),
+			DeleteBranchOnMerge:          new(true),
+			AllowUpdateBranch:            new(true),
+			AllowAutoMerge:               new(true),
+			WebCommitSignoffRequired:     new(false),
+			DefaultWorkflowPermissions:   new("read"),
+			CanApprovePullRequestReviews: new(false),
 		},
 		Swatches: []SwatchEntry{
 			{Path: "justfile", Alteration: swatch.FirstFit},
@@ -392,8 +391,8 @@ func TestWriteYAMLSpecialCharactersQuoted(t *testing.T) {
 		License: "MIT",
 		Repository: &model.RepositorySettings{
 			Description:      &desc,
-			HasWiki:          ptr.Ptr(false),
-			AllowSquashMerge: ptr.Ptr(true),
+			HasWiki:          new(false),
+			AllowSquashMerge: new(true),
 		},
 		Swatches: []SwatchEntry{
 			{Path: "justfile", Alteration: swatch.FirstFit},
@@ -429,7 +428,7 @@ func TestWriteTopicsPreserved(t *testing.T) {
 	cfg := &Config{
 		License: "MIT",
 		Repository: &model.RepositorySettings{
-			HasWiki: ptr.Ptr(false),
+			HasWiki: new(false),
 			Topics:  &topics,
 		},
 		Swatches: []SwatchEntry{
@@ -475,7 +474,7 @@ func TestWriteTopicsOmittedWhenNil(t *testing.T) {
 	cfg := &Config{
 		License: "MIT",
 		Repository: &model.RepositorySettings{
-			HasWiki: ptr.Ptr(false),
+			HasWiki: new(false),
 			// Nil topics are omitted from output.
 		},
 		Swatches: []SwatchEntry{
@@ -503,7 +502,7 @@ func TestWriteEmptyTopicsRoundTrip(t *testing.T) {
 	cfg := &Config{
 		License: "MIT",
 		Repository: &model.RepositorySettings{
-			HasWiki: ptr.Ptr(false),
+			HasWiki: new(false),
 			Topics:  &topics,
 		},
 		Swatches: []SwatchEntry{

--- a/internal/gh/actions.go
+++ b/internal/gh/actions.go
@@ -147,9 +147,7 @@ func ApplyActionsPolicy(client *api.RESTClient, owner, name string, desired, cur
 			if actionsDisabled {
 				return nil, fmt.Errorf("setting selected actions permissions failed while actions are disabled: %w", err)
 			}
-			classified := classifyHTTPError(err, "set selected actions permissions")
-			if isAccessError(classified) {
-				result.Skipped = append(result.Skipped, SkippedOperation{Operation: "set selected actions permissions", Err: classified})
+			if recordAccessError(result, "set selected actions permissions", err) {
 				appendSkippedDependency(result, "set actions permissions")
 				return result, nil
 			}
@@ -177,10 +175,7 @@ func ApplyActionsPolicy(client *api.RESTClient, owner, name string, desired, cur
 	}
 	if selected && coreApplied {
 		if err := putActionsPolicy(client, base+"/selected-actions", selectedBody); err != nil {
-			classified := classifyHTTPError(err, "set selected actions permissions")
-			if isAccessError(classified) {
-				result.Skipped = append(result.Skipped, SkippedOperation{Operation: "set selected actions permissions", Err: classified})
-			} else {
+			if !recordAccessError(result, "set selected actions permissions", err) {
 				return nil, fmt.Errorf("setting selected actions permissions: %w", err)
 			}
 		}
@@ -271,9 +266,7 @@ func actionsSelectedBody(desired *model.ActionsSettings) map[string]any {
 
 func applyActionsWrite(client *api.RESTClient, path string, body map[string]any, operation string, result *ApplyResult) (bool, error) {
 	if err := putActionsPolicy(client, path, body); err != nil {
-		classified := classifyHTTPError(err, operation)
-		if isAccessError(classified) {
-			result.Skipped = append(result.Skipped, SkippedOperation{Operation: operation, Err: classified})
+		if recordAccessError(result, operation, err) {
 			return false, nil
 		}
 		return false, fmt.Errorf("%s: %w", operation, err)

--- a/internal/gh/actions.go
+++ b/internal/gh/actions.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/wimpysworld/tailor/internal/model"
-	"github.com/wimpysworld/tailor/internal/ptr"
 )
 
 type actionsPermissionsResponse struct {
@@ -45,9 +44,9 @@ func ReadActionsPolicy(client *api.RESTClient, owner, name string, selected bool
 		}
 	} else {
 		coreKnown = true
-		settings.Enabled = ptr.Ptr(permissions.Enabled)
-		settings.AllowedActions = ptr.Ptr(permissions.AllowedActions)
-		settings.SHAPinningRequired = ptr.Ptr(permissions.SHAPinningRequired)
+		settings.Enabled = new(permissions.Enabled)
+		settings.AllowedActions = new(permissions.AllowedActions)
+		settings.SHAPinningRequired = new(permissions.SHAPinningRequired)
 	}
 
 	// GitHub rejects the selected-actions read while another policy is active.
@@ -62,8 +61,8 @@ func ReadActionsPolicy(client *api.RESTClient, owner, name string, selected bool
 				return nil, nil, fmt.Errorf("fetching selected actions permissions: %w", err)
 			}
 		} else {
-			settings.GitHubOwnedAllowed = ptr.Ptr(policy.GitHubOwnedAllowed)
-			settings.VerifiedAllowed = ptr.Ptr(policy.VerifiedAllowed)
+			settings.GitHubOwnedAllowed = new(policy.GitHubOwnedAllowed)
+			settings.VerifiedAllowed = new(policy.VerifiedAllowed)
 			settings.PatternsAllowed = &policy.PatternsAllowed
 		}
 	}

--- a/internal/gh/actions_test.go
+++ b/internal/gh/actions_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/wimpysworld/tailor/internal/model"
-	"github.com/wimpysworld/tailor/internal/ptr"
 )
 
 func TestReadActionsPolicy(t *testing.T) {
@@ -111,8 +110,8 @@ func TestApplyActionsPolicyPayloads(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 	patterns := []string{"z/*", "a/*"}
-	desired := &model.ActionsSettings{AllowedActions: ptr.Ptr("selected"), PatternsAllowed: &patterns}
-	current := &model.ActionsSettings{Enabled: ptr.Ptr(true)}
+	desired := &model.ActionsSettings{AllowedActions: new("selected"), PatternsAllowed: &patterns}
+	current := &model.ActionsSettings{Enabled: new(true)}
 	if _, err := ApplyActionsPolicy(newTestClient(t, server), "acme", "widget", desired, current, true, true); err != nil {
 		t.Fatal(err)
 	}
@@ -149,12 +148,12 @@ func TestApplyActionsPolicyEmptyPatternsPayload(t *testing.T) {
 
 	patterns := []string{}
 	desired := &model.ActionsSettings{
-		AllowedActions:     ptr.Ptr("selected"),
-		GitHubOwnedAllowed: ptr.Ptr(true),
-		VerifiedAllowed:    ptr.Ptr(true),
+		AllowedActions:     new("selected"),
+		GitHubOwnedAllowed: new(true),
+		VerifiedAllowed:    new(true),
 		PatternsAllowed:    &patterns,
 	}
-	current := &model.ActionsSettings{Enabled: ptr.Ptr(true), AllowedActions: ptr.Ptr("selected")}
+	current := &model.ActionsSettings{Enabled: new(true), AllowedActions: new("selected")}
 	if _, err := ApplyActionsPolicy(newTestClient(t, server), "acme", "widget", desired, current, false, true); err != nil {
 		t.Fatal(err)
 	}
@@ -173,17 +172,17 @@ func TestApplyActionsPolicyRestrictsEnabledAllToSelected(t *testing.T) {
 		"nick-fields/retry@*",
 	}
 	desired := &model.ActionsSettings{
-		Enabled:            ptr.Ptr(true),
-		AllowedActions:     ptr.Ptr("selected"),
-		SHAPinningRequired: ptr.Ptr(false),
-		GitHubOwnedAllowed: ptr.Ptr(true),
-		VerifiedAllowed:    ptr.Ptr(true),
+		Enabled:            new(true),
+		AllowedActions:     new("selected"),
+		SHAPinningRequired: new(false),
+		GitHubOwnedAllowed: new(true),
+		VerifiedAllowed:    new(true),
 		PatternsAllowed:    &patterns,
 	}
 	current := &model.ActionsSettings{
-		Enabled:            ptr.Ptr(true),
-		AllowedActions:     ptr.Ptr("all"),
-		SHAPinningRequired: ptr.Ptr(false),
+		Enabled:            new(true),
+		AllowedActions:     new("all"),
+		SHAPinningRequired: new(false),
 	}
 
 	var calls []string
@@ -332,21 +331,21 @@ func TestApplyActionsPolicySelectedTransitionPayloadsAndFailures(t *testing.T) {
 				patterns := []string{"z/*", "a/*"}
 				currentPatterns := []string{"a/*"}
 				desired := &model.ActionsSettings{
-					Enabled:            ptr.Ptr(transition.enabled),
-					AllowedActions:     ptr.Ptr("selected"),
-					SHAPinningRequired: ptr.Ptr(false),
-					GitHubOwnedAllowed: ptr.Ptr(true),
-					VerifiedAllowed:    ptr.Ptr(false),
+					Enabled:            new(transition.enabled),
+					AllowedActions:     new("selected"),
+					SHAPinningRequired: new(false),
+					GitHubOwnedAllowed: new(true),
+					VerifiedAllowed:    new(false),
 					PatternsAllowed:    &patterns,
 				}
 				current := &model.ActionsSettings{
-					Enabled:            ptr.Ptr(transition.enabled),
-					AllowedActions:     ptr.Ptr(transition.policy),
-					SHAPinningRequired: ptr.Ptr(false),
+					Enabled:            new(transition.enabled),
+					AllowedActions:     new(transition.policy),
+					SHAPinningRequired: new(false),
 				}
 				if transition.policy == "selected" {
-					current.GitHubOwnedAllowed = ptr.Ptr(false)
-					current.VerifiedAllowed = ptr.Ptr(false)
+					current.GitHubOwnedAllowed = new(false)
+					current.VerifiedAllowed = new(false)
 					current.PatternsAllowed = &currentPatterns
 				}
 
@@ -431,11 +430,11 @@ func TestApplyActionsPolicyAllToSelectedDefersSHAPinningRelaxation(t *testing.T)
 
 			patterns := []string{"acme/*"}
 			desired := &model.ActionsSettings{
-				Enabled: ptr.Ptr(true), AllowedActions: ptr.Ptr("selected"), SHAPinningRequired: ptr.Ptr(false),
-				GitHubOwnedAllowed: ptr.Ptr(true), VerifiedAllowed: ptr.Ptr(false), PatternsAllowed: &patterns,
+				Enabled: new(true), AllowedActions: new("selected"), SHAPinningRequired: new(false),
+				GitHubOwnedAllowed: new(true), VerifiedAllowed: new(false), PatternsAllowed: &patterns,
 			}
 			current := &model.ActionsSettings{
-				Enabled: ptr.Ptr(true), AllowedActions: ptr.Ptr("all"), SHAPinningRequired: ptr.Ptr(true),
+				Enabled: new(true), AllowedActions: new("all"), SHAPinningRequired: new(true),
 			}
 			_, err := ApplyActionsPolicy(newTestClient(t, server), "acme", "widget", desired, current, true, true)
 			if (err != nil) != tt.wantError {
@@ -485,9 +484,9 @@ func TestApplyActionsPolicyAllToSelectedStopsAfterInitialCoreFailure(t *testing.
 
 	patterns := []string{"acme/*"}
 	desired := &model.ActionsSettings{
-		Enabled: ptr.Ptr(true), AllowedActions: ptr.Ptr("selected"), PatternsAllowed: &patterns,
+		Enabled: new(true), AllowedActions: new("selected"), PatternsAllowed: &patterns,
 	}
-	current := &model.ActionsSettings{Enabled: ptr.Ptr(true), AllowedActions: ptr.Ptr("all")}
+	current := &model.ActionsSettings{Enabled: new(true), AllowedActions: new("all")}
 	_, err := ApplyActionsPolicy(newTestClient(t, server), "acme", "widget", desired, current, true, true)
 	if err == nil || !strings.Contains(err.Error(), "The repository policy could not be changed") {
 		t.Fatalf("ApplyActionsPolicy() error = %v, want GitHub error detail", err)
@@ -517,9 +516,9 @@ func TestApplyActionsPolicyAllToSelectedFailureLeavesSelectedRestriction(t *test
 
 	patterns := []string{"acme/*"}
 	desired := &model.ActionsSettings{
-		Enabled: ptr.Ptr(true), AllowedActions: ptr.Ptr("selected"), PatternsAllowed: &patterns,
+		Enabled: new(true), AllowedActions: new("selected"), PatternsAllowed: &patterns,
 	}
-	current := &model.ActionsSettings{Enabled: ptr.Ptr(true), AllowedActions: ptr.Ptr("all")}
+	current := &model.ActionsSettings{Enabled: new(true), AllowedActions: new("all")}
 	_, err := ApplyActionsPolicy(newTestClient(t, server), "acme", "widget", desired, current, true, true)
 	if err == nil || !strings.Contains(err.Error(), "Selected actions policy update is in progress") {
 		t.Fatalf("ApplyActionsPolicy() error = %v, want selected-policy error detail", err)
@@ -641,19 +640,19 @@ func TestApplyActionsPolicyDisablesBeforeSelectedBroadeningAndSHAPinning(t *test
 			t.Cleanup(server.Close)
 
 			desired := &model.ActionsSettings{
-				Enabled:            ptr.Ptr(true),
-				AllowedActions:     ptr.Ptr("selected"),
-				SHAPinningRequired: ptr.Ptr(true),
-				GitHubOwnedAllowed: ptr.Ptr(tt.desiredGitHub),
-				VerifiedAllowed:    ptr.Ptr(tt.desiredVerified),
+				Enabled:            new(true),
+				AllowedActions:     new("selected"),
+				SHAPinningRequired: new(true),
+				GitHubOwnedAllowed: new(tt.desiredGitHub),
+				VerifiedAllowed:    new(tt.desiredVerified),
 				PatternsAllowed:    &tt.desiredPatterns,
 			}
 			current := &model.ActionsSettings{
-				Enabled:            ptr.Ptr(true),
-				AllowedActions:     ptr.Ptr("selected"),
-				SHAPinningRequired: ptr.Ptr(false),
-				GitHubOwnedAllowed: ptr.Ptr(tt.currentGitHub),
-				VerifiedAllowed:    ptr.Ptr(tt.currentVerified),
+				Enabled:            new(true),
+				AllowedActions:     new("selected"),
+				SHAPinningRequired: new(false),
+				GitHubOwnedAllowed: new(tt.currentGitHub),
+				VerifiedAllowed:    new(tt.currentVerified),
 				PatternsAllowed:    &tt.currentPatterns,
 			}
 			if _, err := ApplyActionsPolicy(newTestClient(t, server), "acme", "widget", desired, current, true, true); err != nil {
@@ -767,12 +766,12 @@ func TestApplyActionsPolicyMixedTighteningFailureLeavesActionsDisabled(t *testin
 			t.Cleanup(server.Close)
 
 			desired := &model.ActionsSettings{
-				Enabled: ptr.Ptr(true), AllowedActions: ptr.Ptr("selected"), SHAPinningRequired: ptr.Ptr(tt.desiredSHAPin),
-				GitHubOwnedAllowed: ptr.Ptr(false), VerifiedAllowed: ptr.Ptr(false), PatternsAllowed: &tt.desiredPatterns,
+				Enabled: new(true), AllowedActions: new("selected"), SHAPinningRequired: new(tt.desiredSHAPin),
+				GitHubOwnedAllowed: new(false), VerifiedAllowed: new(false), PatternsAllowed: &tt.desiredPatterns,
 			}
 			current := &model.ActionsSettings{
-				Enabled: ptr.Ptr(true), AllowedActions: ptr.Ptr("selected"), SHAPinningRequired: ptr.Ptr(tt.currentSHAPin),
-				GitHubOwnedAllowed: ptr.Ptr(false), VerifiedAllowed: ptr.Ptr(false), PatternsAllowed: &tt.currentPatterns,
+				Enabled: new(true), AllowedActions: new("selected"), SHAPinningRequired: new(tt.currentSHAPin),
+				GitHubOwnedAllowed: new(false), VerifiedAllowed: new(false), PatternsAllowed: &tt.currentPatterns,
 			}
 			_, err := ApplyActionsPolicy(newTestClient(t, server), "acme", "widget", desired, current, true, true)
 			if err == nil || !strings.Contains(err.Error(), "while actions are disabled") {

--- a/internal/gh/labels.go
+++ b/internal/gh/labels.go
@@ -94,9 +94,7 @@ func ApplyLabels(client *api.RESTClient, owner, repo string, desired, current []
 		if !found {
 			if err := createLabel(client, owner, repo, d); err != nil {
 				opName := fmt.Sprintf("create label %q", d.Name)
-				classified := classifyHTTPError(err, opName)
-				if isAccessError(classified) {
-					result.Skipped = append(result.Skipped, SkippedOperation{Operation: opName, Err: classified})
+				if recordAccessError(result, opName, err) {
 					continue
 				}
 				return nil, err
@@ -107,9 +105,7 @@ func ApplyLabels(client *api.RESTClient, owner, repo string, desired, current []
 		if model.LabelNeedsUpdate(existing, d) {
 			if err := updateLabel(client, owner, repo, existing.Name, d); err != nil {
 				opName := fmt.Sprintf("update label %q", d.Name)
-				classified := classifyHTTPError(err, opName)
-				if isAccessError(classified) {
-					result.Skipped = append(result.Skipped, SkippedOperation{Operation: opName, Err: classified})
+				if recordAccessError(result, opName, err) {
 					continue
 				}
 				return nil, err

--- a/internal/gh/settings.go
+++ b/internal/gh/settings.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/wimpysworld/tailor/internal/model"
-	"github.com/wimpysworld/tailor/internal/ptr"
 )
 
 // repoResponse holds the subset of GitHub repository fields read from the API.
@@ -62,24 +61,24 @@ func ReadRepoSettings(client *api.RESTClient, owner, name string) (*model.Reposi
 	}
 
 	s := &model.RepositorySettings{
-		Description:              ptr.Ptr(repo.Description),
-		Homepage:                 ptr.Ptr(repo.Homepage),
-		HasWiki:                  ptr.Ptr(repo.HasWiki),
-		HasDiscussions:           ptr.Ptr(repo.HasDiscussions),
-		HasProjects:              ptr.Ptr(repo.HasProjects),
-		HasIssues:                ptr.Ptr(repo.HasIssues),
-		AllowMergeCommit:         ptr.Ptr(repo.AllowMergeCommit),
-		AllowSquashMerge:         ptr.Ptr(repo.AllowSquashMerge),
-		AllowRebaseMerge:         ptr.Ptr(repo.AllowRebaseMerge),
-		SquashMergeCommitTitle:   ptr.Ptr(repo.SquashMergeCommitTitle),
-		SquashMergeCommitMessage: ptr.Ptr(repo.SquashMergeCommitMessage),
-		MergeCommitTitle:         ptr.Ptr(repo.MergeCommitTitle),
-		MergeCommitMessage:       ptr.Ptr(repo.MergeCommitMessage),
-		DeleteBranchOnMerge:      ptr.Ptr(repo.DeleteBranchOnMerge),
-		AllowUpdateBranch:        ptr.Ptr(repo.AllowUpdateBranch),
-		AllowAutoMerge:           ptr.Ptr(repo.AllowAutoMerge),
+		Description:              new(repo.Description),
+		Homepage:                 new(repo.Homepage),
+		HasWiki:                  new(repo.HasWiki),
+		HasDiscussions:           new(repo.HasDiscussions),
+		HasProjects:              new(repo.HasProjects),
+		HasIssues:                new(repo.HasIssues),
+		AllowMergeCommit:         new(repo.AllowMergeCommit),
+		AllowSquashMerge:         new(repo.AllowSquashMerge),
+		AllowRebaseMerge:         new(repo.AllowRebaseMerge),
+		SquashMergeCommitTitle:   new(repo.SquashMergeCommitTitle),
+		SquashMergeCommitMessage: new(repo.SquashMergeCommitMessage),
+		MergeCommitTitle:         new(repo.MergeCommitTitle),
+		MergeCommitMessage:       new(repo.MergeCommitMessage),
+		DeleteBranchOnMerge:      new(repo.DeleteBranchOnMerge),
+		AllowUpdateBranch:        new(repo.AllowUpdateBranch),
+		AllowAutoMerge:           new(repo.AllowAutoMerge),
 		Topics:                   &repo.Topics,
-		WebCommitSignoffRequired: ptr.Ptr(repo.WebCommitSignoffRequired),
+		WebCommitSignoffRequired: new(repo.WebCommitSignoffRequired),
 	}
 
 	var warnings []error
@@ -94,8 +93,8 @@ func ReadRepoSettings(client *api.RESTClient, owner, name string) (*model.Reposi
 		}
 	} else {
 		adminRead = true
-		s.DefaultWorkflowPermissions = ptr.Ptr(wfPerms.DefaultWorkflowPermissions)
-		s.CanApprovePullRequestReviews = ptr.Ptr(wfPerms.CanApprovePullRequestReviews)
+		s.DefaultWorkflowPermissions = new(wfPerms.DefaultWorkflowPermissions)
+		s.CanApprovePullRequestReviews = new(wfPerms.CanApprovePullRequestReviews)
 	}
 
 	securityFeatures := []struct {
@@ -108,20 +107,20 @@ func ReadRepoSettings(client *api.RESTClient, owner, name string) (*model.Reposi
 		{
 			path:      fmt.Sprintf("repos/%s/%s/private-vulnerability-reporting", owner, name),
 			operation: "fetch private vulnerability reporting",
-			set:       func(enabled bool) { s.PrivateVulnerabilityReportEnabled = ptr.Ptr(enabled) },
+			set:       func(enabled bool) { s.PrivateVulnerabilityReportEnabled = new(enabled) },
 		},
 		{
 			path:             fmt.Sprintf("repos/%s/%s/vulnerability-alerts", owner, name),
 			operation:        "fetch vulnerability alerts",
 			statusOnly:       true,
 			allow404Disabled: adminRead && repo.Permissions.Admin,
-			set:              func(enabled bool) { s.VulnerabilityAlertsEnabled = ptr.Ptr(enabled) },
+			set:              func(enabled bool) { s.VulnerabilityAlertsEnabled = new(enabled) },
 		},
 		{
 			path:             fmt.Sprintf("repos/%s/%s/automated-security-fixes", owner, name),
 			operation:        "fetch automated security fixes",
 			allow404Disabled: adminRead && repo.Permissions.Admin,
-			set:              func(enabled bool) { s.AutomatedSecurityFixesEnabled = ptr.Ptr(enabled) },
+			set:              func(enabled bool) { s.AutomatedSecurityFixesEnabled = new(enabled) },
 		},
 	}
 	for _, feature := range securityFeatures {

--- a/internal/gh/settings.go
+++ b/internal/gh/settings.go
@@ -280,37 +280,23 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 	return result, nil
 }
 
-func operationName(enabled bool, feature string) string {
-	if enabled {
-		return "enable " + feature
-	}
-	return "disable " + feature
-}
-
-func applyBooleanEndpoint(client *api.RESTClient, path string, enabled bool, feature string) error {
-	operation := operationName(enabled, feature)
-	if enabled {
-		if err := client.Put(path, bytes.NewReader([]byte("{}")), nil); err != nil {
-			return fmt.Errorf("%s: %w", operation, err)
-		}
-		return nil
-	}
-	if err := client.Delete(path, nil); err != nil {
-		return fmt.Errorf("%s: %w", operation, err)
-	}
-	return nil
-}
-
 func applySecuritySetting(client *api.RESTClient, path string, enabled bool, feature string, result *ApplyResult) (bool, error) {
-	operation := operationName(enabled, feature)
-	err := applyBooleanEndpoint(client, path, enabled, feature)
+	action := "disable"
+	var err error
+	if enabled {
+		action = "enable"
+		err = client.Put(path, bytes.NewReader([]byte("{}")), nil)
+	} else {
+		err = client.Delete(path, nil)
+	}
 	if err == nil {
 		return true, nil
 	}
+	operation := action + " " + feature
 	if recordAccessError(result, operation, err) {
 		return false, nil
 	}
-	return false, err
+	return false, fmt.Errorf("%s: %w", operation, err)
 }
 
 func appendSkippedDependency(result *ApplyResult, operation string) {

--- a/internal/gh/settings.go
+++ b/internal/gh/settings.go
@@ -395,37 +395,23 @@ var nonPatchFields = map[string]bool{
 // appear in the PATCH body.
 func buildSettingsPayload(settings *model.RepositorySettings) settingsPayload {
 	p := settingsPayload{Body: make(map[string]any)}
+	if settings == nil {
+		return p
+	}
+
+	p.PrivateVulnerabilityReporting = settings.PrivateVulnerabilityReportEnabled
+	p.VulnerabilityAlerts = settings.VulnerabilityAlertsEnabled
+	p.AutomatedSecurityFixes = settings.AutomatedSecurityFixesEnabled
+	p.Topics = settings.Topics
+	p.DefaultWorkflowPermissions = settings.DefaultWorkflowPermissions
+	p.CanApprovePullRequestReviews = settings.CanApprovePullRequestReviews
 
 	for _, field := range model.RepositorySettingFields(settings) {
-		if !field.Set {
+		if !field.Set || nonPatchFields[field.YAMLKey] {
 			continue
 		}
 
 		fv := field.Value
-		if nonPatchFields[field.YAMLKey] {
-			switch field.YAMLKey {
-			case "private_vulnerability_reporting_enabled":
-				b := fv.Elem().Bool()
-				p.PrivateVulnerabilityReporting = &b
-			case "vulnerability_alerts_enabled":
-				b := fv.Elem().Bool()
-				p.VulnerabilityAlerts = &b
-			case "automated_security_fixes_enabled":
-				b := fv.Elem().Bool()
-				p.AutomatedSecurityFixes = &b
-			case "topics":
-				s := fv.Elem().Interface().([]string)
-				p.Topics = &s
-			case "default_workflow_permissions":
-				s := fv.Elem().String()
-				p.DefaultWorkflowPermissions = &s
-			case "can_approve_pull_request_reviews":
-				b := fv.Elem().Bool()
-				p.CanApprovePullRequestReviews = &b
-			}
-			continue
-		}
-
 		p.Body[field.YAMLKey] = fv.Elem().Interface()
 	}
 

--- a/internal/gh/settings.go
+++ b/internal/gh/settings.go
@@ -175,6 +175,15 @@ type ApplyResult struct {
 	Skipped []SkippedOperation
 }
 
+func recordAccessError(result *ApplyResult, operation string, err error) bool {
+	classified := classifyHTTPError(err, operation)
+	if !isAccessError(classified) {
+		return false
+	}
+	result.Skipped = append(result.Skipped, SkippedOperation{Operation: operation, Err: classified})
+	return true
+}
+
 // ApplyRepoSettings sends a PATCH /repos/{owner}/{repo} with the declared
 // settings. It also handles fields that require separate API endpoints:
 // security features, topics, and Actions workflow permissions. Access errors
@@ -199,10 +208,7 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 			return nil, fmt.Errorf("marshalling repo settings: %w", err)
 		}
 		if err := client.Patch(fmt.Sprintf("repos/%s/%s", owner, name), bytes.NewReader(payload), nil); err != nil {
-			classified := classifyHTTPError(err, "patch repo settings")
-			if isAccessError(classified) {
-				result.Skipped = append(result.Skipped, SkippedOperation{Operation: "patch repo settings", Err: classified})
-			} else {
+			if !recordAccessError(result, "patch repo settings", err) {
 				return nil, fmt.Errorf("patching repo settings: %w", err)
 			}
 		}
@@ -250,10 +256,7 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 
 	if p.DefaultWorkflowPermissions != nil || p.CanApprovePullRequestReviews != nil {
 		if err := applyWorkflowPermissions(client, owner, name, p); err != nil {
-			classified := classifyHTTPError(err, "set workflow permissions")
-			if isAccessError(classified) {
-				result.Skipped = append(result.Skipped, SkippedOperation{Operation: "set workflow permissions", Err: classified})
-			} else {
+			if !recordAccessError(result, "set workflow permissions", err) {
 				return nil, err
 			}
 		}
@@ -268,10 +271,7 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 			return nil, fmt.Errorf("marshalling topics: %w", err)
 		}
 		if err := client.Put(fmt.Sprintf("repos/%s/%s/topics", owner, name), bytes.NewReader(payload), nil); err != nil {
-			classified := classifyHTTPError(err, "set topics")
-			if isAccessError(classified) {
-				result.Skipped = append(result.Skipped, SkippedOperation{Operation: "set topics", Err: classified})
-			} else {
+			if !recordAccessError(result, "set topics", err) {
 				return nil, fmt.Errorf("setting topics: %w", err)
 			}
 		}
@@ -307,9 +307,7 @@ func applySecuritySetting(client *api.RESTClient, path string, enabled bool, fea
 	if err == nil {
 		return true, nil
 	}
-	classified := classifyHTTPError(err, operation)
-	if isAccessError(classified) {
-		result.Skipped = append(result.Skipped, SkippedOperation{Operation: operation, Err: classified})
+	if recordAccessError(result, operation, err) {
 		return false, nil
 	}
 	return false, err

--- a/internal/gh/settings_test.go
+++ b/internal/gh/settings_test.go
@@ -670,6 +670,20 @@ func TestBuildSettingsPayloadNilFieldsStayNil(t *testing.T) {
 	}
 }
 
+func TestBuildSettingsPayloadNilSettings(t *testing.T) {
+	p := buildSettingsPayload(nil)
+
+	if p.Body == nil || len(p.Body) != 0 {
+		t.Errorf("Body = %v, want non-nil empty map", p.Body)
+	}
+	if p.PrivateVulnerabilityReporting != nil || p.VulnerabilityAlerts != nil || p.AutomatedSecurityFixes != nil {
+		t.Error("security feature payloads are non-nil for nil settings")
+	}
+	if p.Topics != nil || p.DefaultWorkflowPermissions != nil || p.CanApprovePullRequestReviews != nil {
+		t.Error("dedicated endpoint payloads are non-nil for nil settings")
+	}
+}
+
 func TestBuildSettingsPayloadEmptyTopics(t *testing.T) {
 	topics := []string{}
 	settings := &model.RepositorySettings{

--- a/internal/gh/settings_test.go
+++ b/internal/gh/settings_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/wimpysworld/tailor/internal/model"
-	"github.com/wimpysworld/tailor/internal/ptr"
 	"github.com/wimpysworld/tailor/internal/testutil"
 )
 
@@ -537,9 +536,9 @@ func TestApplyRepoSettingsPatchBody(t *testing.T) {
 
 	client := newTestClient(t, server)
 	settings := &model.RepositorySettings{
-		Description:    ptr.Ptr("new desc"),
-		HasWiki:        ptr.Ptr(true),
-		AllowAutoMerge: ptr.Ptr(false),
+		Description:    new("new desc"),
+		HasWiki:        new(true),
+		AllowAutoMerge: new(false),
 	}
 
 	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
@@ -588,14 +587,14 @@ func TestApplyRepoSettingsPatchBody(t *testing.T) {
 func TestBuildSettingsPayloadExtractsAllNonPatchFields(t *testing.T) {
 	topics := []string{"go", "cli"}
 	settings := &model.RepositorySettings{
-		Description:                       ptr.Ptr("desc"),
-		HasWiki:                           ptr.Ptr(true),
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-		VulnerabilityAlertsEnabled:        ptr.Ptr(false),
-		AutomatedSecurityFixesEnabled:     ptr.Ptr(true),
+		Description:                       new("desc"),
+		HasWiki:                           new(true),
+		PrivateVulnerabilityReportEnabled: new(true),
+		VulnerabilityAlertsEnabled:        new(false),
+		AutomatedSecurityFixesEnabled:     new(true),
 		Topics:                            &topics,
-		DefaultWorkflowPermissions:        ptr.Ptr("read"),
-		CanApprovePullRequestReviews:      ptr.Ptr(true),
+		DefaultWorkflowPermissions:        new("read"),
+		CanApprovePullRequestReviews:      new(true),
 	}
 
 	p := buildSettingsPayload(settings)
@@ -648,7 +647,7 @@ func TestBuildSettingsPayloadExtractsAllNonPatchFields(t *testing.T) {
 
 func TestBuildSettingsPayloadNilFieldsStayNil(t *testing.T) {
 	settings := &model.RepositorySettings{
-		HasWiki: ptr.Ptr(true),
+		HasWiki: new(true),
 	}
 
 	p := buildSettingsPayload(settings)
@@ -699,7 +698,7 @@ func TestApplyRepoSettingsPatchError(t *testing.T) {
 
 	client := newTestClient(t, server)
 	settings := &model.RepositorySettings{
-		HasWiki: ptr.Ptr(true),
+		HasWiki: new(true),
 	}
 
 	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
@@ -717,7 +716,7 @@ func TestApplyRepoSettingsPatch403Skipped(t *testing.T) {
 
 	client := newTestClient(t, server)
 	settings := &model.RepositorySettings{
-		HasWiki: ptr.Ptr(true),
+		HasWiki: new(true),
 	}
 
 	result, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
@@ -748,8 +747,8 @@ func TestApplyRepoSettingsWorkflowPermsBothFields(t *testing.T) {
 
 	client := newTestClient(t, server)
 	settings := &model.RepositorySettings{
-		DefaultWorkflowPermissions:   ptr.Ptr("read"),
-		CanApprovePullRequestReviews: ptr.Ptr(false),
+		DefaultWorkflowPermissions:   new("read"),
+		CanApprovePullRequestReviews: new(false),
 	}
 
 	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
@@ -796,7 +795,7 @@ func TestApplyRepoSettingsWorkflowPermsPartialFetchesCurrent(t *testing.T) {
 
 	client := newTestClient(t, server)
 	settings := &model.RepositorySettings{
-		DefaultWorkflowPermissions: ptr.Ptr("read"),
+		DefaultWorkflowPermissions: new("read"),
 	}
 
 	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
@@ -826,7 +825,7 @@ func TestApplyRepoSettingsWorkflowPermsSkippedWhenBothNil(t *testing.T) {
 
 	client := newTestClient(t, server)
 	settings := &model.RepositorySettings{
-		HasWiki: ptr.Ptr(true),
+		HasWiki: new(true),
 	}
 
 	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
@@ -856,7 +855,7 @@ func TestApplyRepoSettingsWorkflowPermsGetError(t *testing.T) {
 
 	client := newTestClient(t, server)
 	settings := &model.RepositorySettings{
-		CanApprovePullRequestReviews: ptr.Ptr(true),
+		CanApprovePullRequestReviews: new(true),
 	}
 
 	result, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
@@ -880,8 +879,8 @@ func TestApplyRepoSettingsWorkflowPermsPutError(t *testing.T) {
 
 	client := newTestClient(t, server)
 	settings := &model.RepositorySettings{
-		DefaultWorkflowPermissions:   ptr.Ptr("read"),
-		CanApprovePullRequestReviews: ptr.Ptr(false),
+		DefaultWorkflowPermissions:   new("read"),
+		CanApprovePullRequestReviews: new(false),
 	}
 
 	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
@@ -986,7 +985,7 @@ func TestApplyRepoSettingsTopicsSkippedWhenNil(t *testing.T) {
 
 	client := newTestClient(t, server)
 	settings := &model.RepositorySettings{
-		HasWiki: ptr.Ptr(true),
+		HasWiki: new(true),
 	}
 
 	_, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
@@ -1036,7 +1035,7 @@ func TestApplyRepoSettingsPartialTopics403(t *testing.T) {
 	client := newTestClient(t, server)
 	topics := []string{"go"}
 	settings := &model.RepositorySettings{
-		HasWiki: ptr.Ptr(true),
+		HasWiki: new(true),
 		Topics:  &topics,
 	}
 
@@ -1058,7 +1057,7 @@ func TestApplyRepoSettingsAllSkipped(t *testing.T) {
 
 	client := newTestClient(t, server)
 	settings := &model.RepositorySettings{
-		HasWiki: ptr.Ptr(true),
+		HasWiki: new(true),
 	}
 
 	result, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
@@ -1078,7 +1077,7 @@ func TestApplyRepoSettingsApplyResultPopulatedOnSuccess(t *testing.T) {
 
 	client := newTestClient(t, server)
 	settings := &model.RepositorySettings{
-		HasWiki: ptr.Ptr(true),
+		HasWiki: new(true),
 	}
 
 	result, err := ApplyRepoSettings(client, "testowner", "testrepo", settings)
@@ -1103,9 +1102,9 @@ func TestApplyRepoSettingsSecurityFeatureMethodsAndEnableOrder(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	settings := &model.RepositorySettings{
-		PrivateVulnerabilityReportEnabled: ptr.Ptr(true),
-		VulnerabilityAlertsEnabled:        ptr.Ptr(true),
-		AutomatedSecurityFixesEnabled:     ptr.Ptr(true),
+		PrivateVulnerabilityReportEnabled: new(true),
+		VulnerabilityAlertsEnabled:        new(true),
+		AutomatedSecurityFixesEnabled:     new(true),
 	}
 	if _, err := ApplyRepoSettings(newTestClient(t, server), "testowner", "testrepo", settings); err != nil {
 		t.Fatalf("ApplyRepoSettings() error: %v", err)
@@ -1138,8 +1137,8 @@ func TestApplyRepoSettingsSecurityFeatureDisableOrder(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	settings := &model.RepositorySettings{
-		VulnerabilityAlertsEnabled:    ptr.Ptr(false),
-		AutomatedSecurityFixesEnabled: ptr.Ptr(false),
+		VulnerabilityAlertsEnabled:    new(false),
+		AutomatedSecurityFixesEnabled: new(false),
 	}
 	if _, err := ApplyRepoSettings(newTestClient(t, server), "testowner", "testrepo", settings); err != nil {
 		t.Fatalf("ApplyRepoSettings() error: %v", err)
@@ -1162,7 +1161,7 @@ func TestApplyRepoSettingsDoesNotDisableAlertsWhenFixesAreUnmanaged(t *testing.T
 	}))
 	t.Cleanup(server.Close)
 
-	settings := &model.RepositorySettings{VulnerabilityAlertsEnabled: ptr.Ptr(false)}
+	settings := &model.RepositorySettings{VulnerabilityAlertsEnabled: new(false)}
 	_, err := ApplyRepoSettings(newTestClient(t, server), "testowner", "testrepo", settings)
 	if err == nil || err.Error() != "cannot disable vulnerability alerts while automated security fixes are unmanaged" {
 		t.Fatalf("ApplyRepoSettings() error = %v, want unmanaged fixes error", err)
@@ -1179,7 +1178,7 @@ func TestApplyRepoSettingsSecurityFeatureAccessErrorIsSkipped(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	settings := &model.RepositorySettings{VulnerabilityAlertsEnabled: ptr.Ptr(true)}
+	settings := &model.RepositorySettings{VulnerabilityAlertsEnabled: new(true)}
 	result, err := ApplyRepoSettings(newTestClient(t, server), "testowner", "testrepo", settings)
 	if err != nil {
 		t.Fatalf("ApplyRepoSettings() error: %v", err)
@@ -1198,16 +1197,16 @@ func TestApplyRepoSettingsSecurityPrerequisiteStopsDependentWrite(t *testing.T) 
 		{
 			name: "enable alerts before fixes",
 			settings: &model.RepositorySettings{
-				VulnerabilityAlertsEnabled:    ptr.Ptr(true),
-				AutomatedSecurityFixesEnabled: ptr.Ptr(true),
+				VulnerabilityAlertsEnabled:    new(true),
+				AutomatedSecurityFixesEnabled: new(true),
 			},
 			first: "/repos/testowner/testrepo/vulnerability-alerts",
 		},
 		{
 			name: "disable fixes before alerts",
 			settings: &model.RepositorySettings{
-				VulnerabilityAlertsEnabled:    ptr.Ptr(false),
-				AutomatedSecurityFixesEnabled: ptr.Ptr(false),
+				VulnerabilityAlertsEnabled:    new(false),
+				AutomatedSecurityFixesEnabled: new(false),
 			},
 			first: "/repos/testowner/testrepo/automated-security-fixes",
 		},
@@ -1249,7 +1248,7 @@ func TestApplyRepoSettingsSecurityFeatureHardErrorStops(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	settings := &model.RepositorySettings{AutomatedSecurityFixesEnabled: ptr.Ptr(true)}
+	settings := &model.RepositorySettings{AutomatedSecurityFixesEnabled: new(true)}
 	if _, err := ApplyRepoSettings(newTestClient(t, server), "testowner", "testrepo", settings); err == nil {
 		t.Fatal("ApplyRepoSettings() error = nil, want hard error")
 	}

--- a/internal/measure/configdiff.go
+++ b/internal/measure/configdiff.go
@@ -18,9 +18,6 @@ const (
 	ModeDiffers   DiffCategory = "mode-differs"
 )
 
-// Label returns the category string with a trailing colon, suitable for formatted output.
-func (c DiffCategory) Label() string { return string(c) + ":" }
-
 // DiffResult describes a single config-diff finding.
 type DiffResult struct {
 	Path     string

--- a/internal/measure/format.go
+++ b/internal/measure/format.go
@@ -18,19 +18,11 @@ func FormatOutput(health []HealthResult, diff []DiffResult, hasConfig bool) stri
 	var b strings.Builder
 
 	for _, r := range health {
-		line := r.Path
-		if r.Detail != "" {
-			line += " " + r.Detail
-		}
-		fmt.Fprintf(&b, "%-*s%s\n", labelWidth, r.Status.Label(), line)
+		writeResultLine(&b, string(r.Status)+":", r.Path, r.Detail)
 	}
 
 	for _, r := range diff {
-		line := r.Path
-		if r.Detail != "" {
-			line += " " + r.Detail
-		}
-		fmt.Fprintf(&b, "%-*s%s\n", labelWidth, r.Category.Label(), line)
+		writeResultLine(&b, string(r.Category)+":", r.Path, r.Detail)
 	}
 
 	if !hasConfig {
@@ -40,4 +32,11 @@ func FormatOutput(health []HealthResult, diff []DiffResult, hasConfig bool) stri
 	}
 
 	return b.String()
+}
+
+func writeResultLine(b *strings.Builder, label, path, detail string) {
+	if detail != "" {
+		path += " " + detail
+	}
+	fmt.Fprintf(b, "%-*s%s\n", labelWidth, label, path)
 }

--- a/internal/measure/health.go
+++ b/internal/measure/health.go
@@ -22,9 +22,6 @@ const (
 	Present HealthStatus = "present"
 )
 
-// Label returns the status string with a trailing colon, suitable for formatted output.
-func (s HealthStatus) Label() string { return string(s) + ":" }
-
 // HealthResult pairs a path with its on-disk status and optional detail.
 type HealthResult struct {
 	Path   string

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -70,7 +70,6 @@ type RepositorySettings struct {
 // RepositorySettingField describes one supported repository setting.
 type RepositorySettingField struct {
 	YAMLKey string
-	GoName  string
 	Index   int
 	Value   reflect.Value
 	Set     bool
@@ -99,7 +98,6 @@ func RepositorySettingFields(settings *RepositorySettings) []RepositorySettingFi
 
 		field := RepositorySettingField{
 			YAMLKey: key,
-			GoName:  sf.Name,
 			Index:   i,
 		}
 		if v.IsValid() {

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -43,9 +43,6 @@ func TestRepositorySettingFieldsMetadata(t *testing.T) {
 		if fields[i].Index != i {
 			t.Errorf("field %d Index = %d, want %d", i, fields[i].Index, i)
 		}
-		if fields[i].GoName == "Extra" {
-			t.Fatal("Extra should be excluded")
-		}
 		if fields[i].Set {
 			t.Errorf("field %s Set = true for nil settings", fields[i].YAMLKey)
 		}

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -2,8 +2,6 @@ package model
 
 import (
 	"testing"
-
-	"github.com/wimpysworld/tailor/internal/ptr"
 )
 
 func TestRepositorySettingFieldsMetadata(t *testing.T) {
@@ -57,8 +55,8 @@ func TestRepositorySettingFieldsMetadata(t *testing.T) {
 func TestRepositorySettingFieldsValues(t *testing.T) {
 	topics := []string{"go", "cli"}
 	settings := &RepositorySettings{
-		Description: ptr.Ptr("test"),
-		HasWiki:     ptr.Ptr(false),
+		Description: new("test"),
+		HasWiki:     new(false),
 		Topics:      &topics,
 	}
 

--- a/internal/ptr/ptr.go
+++ b/internal/ptr/ptr.go
@@ -1,4 +1,0 @@
-package ptr
-
-// Ptr returns a pointer to the given value.
-func Ptr[T any](v T) *T { return &v }

--- a/internal/swatch/registry.go
+++ b/internal/swatch/registry.go
@@ -56,9 +56,7 @@ var registry = []Swatch{
 
 // All returns every registered swatch in definition order.
 func All() []Swatch {
-	out := make([]Swatch, len(registry))
-	copy(out, registry)
-	return out
+	return slices.Clone(registry)
 }
 
 // Paths returns the paths of all registered swatches, sorted

--- a/justfile
+++ b/justfile
@@ -18,9 +18,7 @@ check:
 
 # Run linters
 lint:
-    @go vet ./...
     @gocyclo -top 20 -avg -ignore '_test\.go$' .
-    @ineffassign ./...
     @golangci-lint run
     @actionlint
 

--- a/justfile
+++ b/justfile
@@ -37,7 +37,7 @@ release VERSION:
     set -e
 
     # Validate version format
-    if ! echo "{{VERSION}}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    if ! [[ "{{VERSION}}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         echo "Error: VERSION must be in format x.y.z (e.g., 0.1.0)"
         exit 1
     fi


### PR DESCRIPTION
Reduce repeated implementation across configuration, alteration, GitHub, and formatting paths after the maintainability review. Replace local helpers with standard library APIs, simplify repository setting access and output formatting, update CI lint configuration, and correct the release retry scope and compared-setting warning behaviour.

Verified with `just test`, `just lint`, and `just check`.
