### PR TITLE
fix: correct peer-review findings across the codebase

### DIFF
--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -168,11 +168,13 @@ func (m *MeasureCmd) Run() error {
 }
 
 // DocketCmd displays GitHub authentication state and repository context.
-type DocketCmd struct{}
+type DocketCmd struct {
+	client *api.RESTClient
+}
 
 // Run executes the docket command.
 func (d *DocketCmd) Run() error {
-	result, err := docket.Run(nil)
+	result, err := docket.Run(d.client)
 	if err != nil {
 		return err
 	}

--- a/cmd/tailor/main_test.go
+++ b/cmd/tailor/main_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wimpysworld/tailor/internal/config"
 	"github.com/wimpysworld/tailor/internal/ghfake"
 	"github.com/wimpysworld/tailor/internal/swatch"
+	"github.com/wimpysworld/tailor/internal/testutil"
 )
 
 func TestFitNewDirectoryDefaultConfig(t *testing.T) {
@@ -256,20 +257,6 @@ func requireFileContent(t *testing.T, path, want string) {
 	}
 }
 
-// redirectTransport sends all requests to the test server, preserving the
-// original path and query but rewriting scheme and host.
-type redirectTransport struct {
-	target   string // test server URL, e.g. "http://127.0.0.1:PORT"
-	delegate http.RoundTripper
-}
-
-func (rt *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req = req.Clone(req.Context())
-	req.URL.Scheme = "http"
-	req.URL.Host = strings.TrimPrefix(rt.target, "http://")
-	return rt.delegate.RoundTrip(req)
-}
-
 func TestBasteCmdRun(t *testing.T) {
 	dir, output, run := setupSwatchCommandTest(t)
 	cmd := BasteCmd{run: run}
@@ -353,16 +340,7 @@ func TestDocketAuthenticated(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	oldTransport := http.DefaultTransport
-	http.DefaultTransport = &redirectTransport{
-		target:   srv.URL,
-		delegate: oldTransport,
-	}
-	t.Cleanup(func() { http.DefaultTransport = oldTransport })
-
-	t.Setenv("GH_TOKEN", "gho_test")
-
-	cmd := DocketCmd{}
+	cmd := DocketCmd{client: testutil.NewTestClient(t, srv)}
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("DocketCmd.Run() error: %v", err)
 	}

--- a/internal/alter/actions.go
+++ b/internal/alter/actions.go
@@ -99,9 +99,9 @@ func suppressActionsReadWarnings(results []RepoSettingResult, warnings []error, 
 		}
 		fields := []string{"enabled", "allowed_actions", "sha_pinning_required"}
 		switch scopeErr.Operation {
-		case "fetch actions permissions":
+		case gh.OpFetchActionsPermissions:
 			fields = []string{"enabled", "allowed_actions", "sha_pinning_required", "github_owned_allowed", "verified_allowed", "patterns_allowed"}
-		case "fetch selected actions permissions":
+		case gh.OpFetchSelectedActionsPermissions:
 			fields = []string{"github_owned_allowed", "verified_allowed", "patterns_allowed"}
 			for _, result := range results {
 				if actionsCoreBroadening(result, declared, live) {

--- a/internal/alter/alter.go
+++ b/internal/alter/alter.go
@@ -40,7 +40,10 @@ func Run(cfg *config.Config, dir string, mode ApplyMode, client *api.RESTClient)
 	// Keep the local config aligned with built-in defaults only when the
 	// config swatch mode allows tailor to rewrite it.
 	if shouldMerge(cfg, mode) {
-		defaultsChanged := config.MergeDefaults(cfg)
+		defaultsChanged, err := config.MergeDefaults(cfg)
+		if err != nil {
+			return err
+		}
 		configChanged = configChanged || defaultsChanged
 		// Re-validate after merge as a safety check.
 		if err := validateConfig(cfg); err != nil {

--- a/internal/alter/alter_integration_test.go
+++ b/internal/alter/alter_integration_test.go
@@ -1410,7 +1410,7 @@ swatches:
 
 // Non-substituted always swatches use SHA-256 content comparison and are left
 // alone when content matches the embedded swatch.
-func TestAlterRunApplyAlwaysSwatchNoWriteOnMD5Match(t *testing.T) {
+func TestAlterRunApplyAlwaysSwatchNoWriteOnSHA256Match(t *testing.T) {
 	configYAML := `license: none
 swatches:
   - path: CODE_OF_CONDUCT.md
@@ -1439,7 +1439,7 @@ swatches:
 		t.Fatal(err)
 	}
 	if !bytes.Equal(data, original) {
-		t.Error("CODE_OF_CONDUCT.md content changed despite MD5 match")
+		t.Error("CODE_OF_CONDUCT.md content changed despite SHA-256 match")
 	}
 
 	// Matching content is not rewritten.

--- a/internal/alter/alter_integration_test.go
+++ b/internal/alter/alter_integration_test.go
@@ -1607,7 +1607,7 @@ swatches:
 	}
 	// After recut, the merge step rewrites .tailor.yml.
 	if len(data) == 0 {
-		t.Error("config.yml is empty after recut")
+		t.Error(".tailor.yml is empty after recut")
 	}
 }
 
@@ -2072,10 +2072,10 @@ func TestConfigMergeMissingSwatchesApply(t *testing.T) {
 	// The merge step writes the config file.
 	data, err := os.ReadFile(filepath.Join(tc.Dir, ".tailor.yml"))
 	if err != nil {
-		t.Fatalf("config.yml not found after apply: %v", err)
+		t.Fatalf(".tailor.yml not found after apply: %v", err)
 	}
 	if len(data) == 0 {
-		t.Error("config.yml is empty after apply")
+		t.Error(".tailor.yml is empty after apply")
 	}
 }
 
@@ -2109,7 +2109,7 @@ func TestConfigMergeAllPresentApply(t *testing.T) {
 	// swatch processing skips the .tailor.yml entry. The file keeps its
 	// original content, without a "Refitted" header.
 	if strings.Contains(string(afterData), "Refitted by tailor on") {
-		t.Error("config.yml contains 'Refitted' header despite no entries being merged")
+		t.Error(".tailor.yml contains 'Refitted' header despite no entries being merged")
 	}
 }
 
@@ -2138,12 +2138,12 @@ func TestConfigMergeFirstFitApplySkips(t *testing.T) {
 	}
 
 	if !bytes.Equal(originalData, afterData) {
-		t.Error("config.yml was rewritten despite first-fit alteration in Apply mode")
+		t.Error(".tailor.yml was rewritten despite first-fit alteration in Apply mode")
 	}
 
 	// First-fit config mode skips the merge, so SUPPORT.md remains absent.
 	if strings.Contains(string(afterData), "SUPPORT.md") {
-		t.Error("config.yml contains SUPPORT.md despite first-fit skipping merge")
+		t.Error(".tailor.yml contains SUPPORT.md despite first-fit skipping merge")
 	}
 }
 
@@ -2173,10 +2173,10 @@ func TestConfigMergeFirstFitRecutAppends(t *testing.T) {
 	// Recut rewrites .tailor.yml through the config write step.
 	data, err := os.ReadFile(filepath.Join(tc.Dir, ".tailor.yml"))
 	if err != nil {
-		t.Fatalf("config.yml not found after recut: %v", err)
+		t.Fatalf(".tailor.yml not found after recut: %v", err)
 	}
 	if len(data) == 0 {
-		t.Error("config.yml is empty after recut")
+		t.Error(".tailor.yml is empty after recut")
 	}
 }
 
@@ -2206,7 +2206,7 @@ func TestConfigMergeDryRunNoRewrite(t *testing.T) {
 	}
 
 	if !bytes.Equal(originalData, afterData) {
-		t.Error("config.yml was rewritten during dry-run despite ShouldWrite() being false")
+		t.Error(".tailor.yml was rewritten during dry-run despite ShouldWrite() being false")
 	}
 	if calls := tc.MutatingCalls(); len(calls) != 0 {
 		t.Fatalf("dry run made mutating calls: %v", calls)

--- a/internal/alter/alter_integration_test.go
+++ b/internal/alter/alter_integration_test.go
@@ -452,7 +452,7 @@ swatches:
 			}
 			if tt.wantWrite {
 				persisted := loadTestConfig(t, tc.Dir)
-				testutil.AssertBoolPtr(t, persisted.Repository.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
+				testutil.AssertPtr(t, persisted.Repository.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
 				if bytes.Equal(after, before) {
 					t.Error(".tailor.yml bytes did not change")
 				}
@@ -500,7 +500,7 @@ swatches:
 	requireContains(t, stderr, "warning: set vulnerability_alerts_enabled to true")
 
 	persisted := loadTestConfig(t, tc.Dir)
-	testutil.AssertBoolPtr(t, persisted.Repository.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
+	testutil.AssertPtr(t, persisted.Repository.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
 	for _, call := range tc.MutatingCalls() {
 		if strings.Contains(call.Path, "automated-security-fixes") {
 			t.Fatalf("automated security fixes API called after alert failure: %v", tc.MutatingCalls())

--- a/internal/alter/format.go
+++ b/internal/alter/format.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+
+	"github.com/wimpysworld/tailor/internal/gh"
 )
 
 // defaultLabelWidth is the minimum column width for status labels in formatted
@@ -101,32 +103,25 @@ func repoSettingOperation(result RepoSettingResult) string {
 	if result.Section == "actions" {
 		switch result.Field {
 		case "enabled", "allowed_actions", "sha_pinning_required":
-			return "set actions permissions"
+			return gh.OpSetActionsPermissions
 		case "github_owned_allowed", "verified_allowed", "patterns_allowed":
-			return "set selected actions permissions"
+			return gh.OpSetSelectedActionsPermissions
 		}
 	}
 	switch result.Field {
 	case "private_vulnerability_reporting_enabled":
-		return operationForValue(result.Value, "private vulnerability reporting")
+		return gh.SecurityFeatureOp(result.Value == "true", gh.FeaturePrivateVulnerabilityReporting)
 	case "vulnerability_alerts_enabled":
-		return operationForValue(result.Value, "vulnerability alerts")
+		return gh.SecurityFeatureOp(result.Value == "true", gh.FeatureVulnerabilityAlerts)
 	case "automated_security_fixes_enabled":
-		return operationForValue(result.Value, "automated security fixes")
+		return gh.SecurityFeatureOp(result.Value == "true", gh.FeatureAutomatedSecurityFixes)
 	case "topics":
-		return "set topics"
+		return gh.OpSetTopics
 	case "default_workflow_permissions", "can_approve_pull_request_reviews":
-		return "set workflow permissions"
+		return gh.OpSetWorkflowPermissions
 	default:
-		return "patch repo settings"
+		return gh.OpPatchRepoSettings
 	}
-}
-
-func operationForValue(value, feature string) string {
-	if value == "true" {
-		return "enable " + feature
-	}
-	return "disable " + feature
 }
 
 func removeSkippedLabelResults(results []LabelResult) []LabelResult {
@@ -145,9 +140,9 @@ func removeSkippedLabelResults(results []LabelResult) []LabelResult {
 		operation := ""
 		switch result.Category {
 		case WouldCreate:
-			operation = fmt.Sprintf("create label %q", result.Name)
+			operation = gh.CreateLabelOp(result.Name)
 		case WouldUpdate:
-			operation = fmt.Sprintf("update label %q", result.Name)
+			operation = gh.UpdateLabelOp(result.Name)
 		}
 		if !skipped[operation] {
 			filtered = append(filtered, result)

--- a/internal/alter/settings.go
+++ b/internal/alter/settings.go
@@ -181,10 +181,10 @@ func compareSettings(declared, live *model.RepositorySettings) []RepoSettingResu
 // readWarningOperationFields maps read-path operation names from
 // ErrInsufficientScope to the config field names they affect.
 var readWarningOperationFields = map[string][]string{
-	"fetch vulnerability alerts":            {"vulnerability_alerts_enabled"},
-	"fetch automated security fixes":        {"automated_security_fixes_enabled"},
-	"fetch private vulnerability reporting": {"private_vulnerability_reporting_enabled"},
-	"fetch workflow permissions":            {"default_workflow_permissions", "can_approve_pull_request_reviews"},
+	gh.OpFetchVulnerabilityAlerts:           {"vulnerability_alerts_enabled"},
+	gh.OpFetchAutomatedSecurityFixes:        {"automated_security_fixes_enabled"},
+	gh.OpFetchPrivateVulnerabilityReporting: {"private_vulnerability_reporting_enabled"},
+	gh.OpFetchWorkflowPermissions:           {"default_workflow_permissions", "can_approve_pull_request_reviews"},
 }
 
 // readWarningsToResults converts read-path access-error warnings into
@@ -227,10 +227,10 @@ func readWarningsToResults(warnings []error, declared, live *model.RepositorySet
 
 		dependent := ""
 		switch {
-		case op == "fetch vulnerability alerts" && declared.AutomatedSecurityFixesEnabled != nil && *declared.AutomatedSecurityFixesEnabled &&
+		case op == gh.OpFetchVulnerabilityAlerts && declared.AutomatedSecurityFixesEnabled != nil && *declared.AutomatedSecurityFixesEnabled &&
 			live.AutomatedSecurityFixesEnabled != nil && !*live.AutomatedSecurityFixesEnabled:
 			dependent = "automated_security_fixes_enabled"
-		case op == "fetch automated security fixes" && declared.VulnerabilityAlertsEnabled != nil && !*declared.VulnerabilityAlertsEnabled &&
+		case op == gh.OpFetchAutomatedSecurityFixes && declared.VulnerabilityAlertsEnabled != nil && !*declared.VulnerabilityAlertsEnabled &&
 			live.VulnerabilityAlertsEnabled != nil && *live.VulnerabilityAlertsEnabled:
 			dependent = "vulnerability_alerts_enabled"
 		}

--- a/internal/alter/swatch_test.go
+++ b/internal/alter/swatch_test.go
@@ -121,7 +121,7 @@ func TestFirstFitApplyWritesFile(t *testing.T) {
 	}
 }
 
-func TestAlwaysNoChangeWhenMD5Matches(t *testing.T) {
+func TestAlwaysNoChangeWhenSHA256Matches(t *testing.T) {
 	dir := t.TempDir()
 	content := mustContent(t, "CODE_OF_CONDUCT.md")
 	writeOnDisk(t, dir, "CODE_OF_CONDUCT.md", content)
@@ -136,7 +136,7 @@ func TestAlwaysNoChangeWhenMD5Matches(t *testing.T) {
 	}
 }
 
-func TestAlwaysWouldOverwriteWhenMD5Differs(t *testing.T) {
+func TestAlwaysWouldOverwriteWhenSHA256Differs(t *testing.T) {
 	dir := t.TempDir()
 	writeOnDisk(t, dir, "CODE_OF_CONDUCT.md", []byte("old content"))
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -98,22 +98,22 @@ func TestUnmarshalSpecYAML(t *testing.T) {
 	}
 
 	r := cfg.Repository
-	testutil.AssertBoolPtr(t, r.HasWiki, false, false, "has_wiki")
-	testutil.AssertBoolPtr(t, r.HasDiscussions, false, false, "has_discussions")
-	testutil.AssertBoolPtr(t, r.HasProjects, false, false, "has_projects")
-	testutil.AssertBoolPtr(t, r.HasIssues, false, true, "has_issues")
-	testutil.AssertBoolPtr(t, r.AllowMergeCommit, false, false, "allow_merge_commit")
-	testutil.AssertBoolPtr(t, r.AllowSquashMerge, false, true, "allow_squash_merge")
-	testutil.AssertBoolPtr(t, r.AllowRebaseMerge, false, true, "allow_rebase_merge")
-	testutil.AssertStringPtr(t, r.SquashMergeCommitTitle, false, "PR_TITLE", "squash_merge_commit_title")
-	testutil.AssertStringPtr(t, r.SquashMergeCommitMessage, false, "PR_BODY", "squash_merge_commit_message")
-	testutil.AssertBoolPtr(t, r.DeleteBranchOnMerge, false, true, "delete_branch_on_merge")
-	testutil.AssertBoolPtr(t, r.AllowUpdateBranch, false, true, "allow_update_branch")
-	testutil.AssertBoolPtr(t, r.AllowAutoMerge, false, false, "allow_auto_merge")
-	testutil.AssertBoolPtr(t, r.WebCommitSignoffRequired, false, false, "web_commit_signoff_required")
-	testutil.AssertBoolPtr(t, r.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertBoolPtr(t, r.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertBoolPtr(t, r.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
+	testutil.AssertPtr(t, r.HasWiki, false, false, "has_wiki")
+	testutil.AssertPtr(t, r.HasDiscussions, false, false, "has_discussions")
+	testutil.AssertPtr(t, r.HasProjects, false, false, "has_projects")
+	testutil.AssertPtr(t, r.HasIssues, false, true, "has_issues")
+	testutil.AssertPtr(t, r.AllowMergeCommit, false, false, "allow_merge_commit")
+	testutil.AssertPtr(t, r.AllowSquashMerge, false, true, "allow_squash_merge")
+	testutil.AssertPtr(t, r.AllowRebaseMerge, false, true, "allow_rebase_merge")
+	testutil.AssertPtr(t, r.SquashMergeCommitTitle, false, "PR_TITLE", "squash_merge_commit_title")
+	testutil.AssertPtr(t, r.SquashMergeCommitMessage, false, "PR_BODY", "squash_merge_commit_message")
+	testutil.AssertPtr(t, r.DeleteBranchOnMerge, false, true, "delete_branch_on_merge")
+	testutil.AssertPtr(t, r.AllowUpdateBranch, false, true, "allow_update_branch")
+	testutil.AssertPtr(t, r.AllowAutoMerge, false, false, "allow_auto_merge")
+	testutil.AssertPtr(t, r.WebCommitSignoffRequired, false, false, "web_commit_signoff_required")
+	testutil.AssertPtr(t, r.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
+	testutil.AssertPtr(t, r.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
+	testutil.AssertPtr(t, r.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
 
 	if len(cfg.Swatches) != 16 {
 		t.Fatalf("Swatches count = %d, want 16", len(cfg.Swatches))
@@ -185,9 +185,9 @@ func TestUnmarshalOptionalSecuritySettings(t *testing.T) {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
-	testutil.AssertBoolPtr(t, cfg.Repository.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertBoolPtr(t, cfg.Repository.VulnerabilityAlertsEnabled, false, false, "vulnerability_alerts_enabled")
-	testutil.AssertBoolPtr(t, cfg.Repository.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
+	testutil.AssertPtr(t, cfg.Repository.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
+	testutil.AssertPtr(t, cfg.Repository.VulnerabilityAlertsEnabled, false, false, "vulnerability_alerts_enabled")
+	testutil.AssertPtr(t, cfg.Repository.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
 }
 
 func TestRepositoryNilWhenAbsent(t *testing.T) {
@@ -265,8 +265,8 @@ swatches: []
 	}
 
 	r := cfg.Repository
-	testutil.AssertStringPtr(t, r.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
-	testutil.AssertBoolPtr(t, r.CanApprovePullRequestReviews, false, false, "can_approve_pull_request_reviews")
+	testutil.AssertPtr(t, r.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
+	testutil.AssertPtr(t, r.CanApprovePullRequestReviews, false, false, "can_approve_pull_request_reviews")
 
 	if r.Topics == nil {
 		t.Fatal("Topics is nil, want non-nil")
@@ -289,8 +289,8 @@ swatches: []
 	}
 
 	r := cfg.Repository
-	testutil.AssertStringPtr(t, r.DefaultWorkflowPermissions, true, "", "default_workflow_permissions")
-	testutil.AssertBoolPtr(t, r.CanApprovePullRequestReviews, true, false, "can_approve_pull_request_reviews")
+	testutil.AssertPtr(t, r.DefaultWorkflowPermissions, true, "", "default_workflow_permissions")
+	testutil.AssertPtr(t, r.CanApprovePullRequestReviews, true, false, "can_approve_pull_request_reviews")
 
 	if r.Topics != nil {
 		t.Errorf("Topics = %v, want nil when omitted", *r.Topics)
@@ -342,8 +342,8 @@ func TestNewFieldsRoundTrip(t *testing.T) {
 	}
 
 	r := roundTripped.Repository
-	testutil.AssertStringPtr(t, r.DefaultWorkflowPermissions, false, "write", "default_workflow_permissions")
-	testutil.AssertBoolPtr(t, r.CanApprovePullRequestReviews, false, true, "can_approve_pull_request_reviews")
+	testutil.AssertPtr(t, r.DefaultWorkflowPermissions, false, "write", "default_workflow_permissions")
+	testutil.AssertPtr(t, r.CanApprovePullRequestReviews, false, true, "can_approve_pull_request_reviews")
 
 	if r.Topics == nil {
 		t.Fatal("round-tripped Topics is nil")
@@ -551,8 +551,8 @@ swatches: []
 	}
 
 	r := cfg.Repository
-	testutil.AssertStringPtr(t, r.Description, false, "My project", "description")
-	testutil.AssertStringPtr(t, r.Homepage, false, "https://example.com", "homepage")
-	testutil.AssertStringPtr(t, r.MergeCommitTitle, false, "PR_TITLE", "merge_commit_title")
-	testutil.AssertStringPtr(t, r.MergeCommitMessage, false, "PR_BODY", "merge_commit_message")
+	testutil.AssertPtr(t, r.Description, false, "My project", "description")
+	testutil.AssertPtr(t, r.Homepage, false, "https://example.com", "homepage")
+	testutil.AssertPtr(t, r.MergeCommitTitle, false, "PR_TITLE", "merge_commit_title")
+	testutil.AssertPtr(t, r.MergeCommitMessage, false, "PR_BODY", "merge_commit_message")
 }

--- a/internal/config/generate_test.go
+++ b/internal/config/generate_test.go
@@ -39,32 +39,32 @@ func TestDefaultConfigMatchesEmbedded(t *testing.T) {
 	if got.Repository == nil {
 		t.Fatal("Repository is nil, want non-nil")
 	}
-	testutil.AssertBoolPtr(t, got.Repository.HasWiki, false, false, "has_wiki")
-	testutil.AssertBoolPtr(t, got.Repository.HasDiscussions, false, false, "has_discussions")
-	testutil.AssertBoolPtr(t, got.Repository.HasProjects, false, false, "has_projects")
-	testutil.AssertBoolPtr(t, got.Repository.HasIssues, false, true, "has_issues")
-	testutil.AssertBoolPtr(t, got.Repository.AllowMergeCommit, false, false, "allow_merge_commit")
-	testutil.AssertBoolPtr(t, got.Repository.AllowSquashMerge, false, true, "allow_squash_merge")
-	testutil.AssertBoolPtr(t, got.Repository.AllowRebaseMerge, false, true, "allow_rebase_merge")
-	testutil.AssertStringPtr(t, got.Repository.SquashMergeCommitTitle, false, "PR_TITLE", "squash_merge_commit_title")
-	testutil.AssertStringPtr(t, got.Repository.SquashMergeCommitMessage, false, "PR_BODY", "squash_merge_commit_message")
-	testutil.AssertBoolPtr(t, got.Repository.DeleteBranchOnMerge, false, true, "delete_branch_on_merge")
-	testutil.AssertBoolPtr(t, got.Repository.AllowUpdateBranch, false, true, "allow_update_branch")
-	testutil.AssertBoolPtr(t, got.Repository.AllowAutoMerge, false, true, "allow_auto_merge")
-	testutil.AssertBoolPtr(t, got.Repository.WebCommitSignoffRequired, false, false, "web_commit_signoff_required")
-	testutil.AssertBoolPtr(t, got.Repository.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertBoolPtr(t, got.Repository.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertBoolPtr(t, got.Repository.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
-	testutil.AssertStringPtr(t, got.Repository.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
-	testutil.AssertBoolPtr(t, got.Repository.CanApprovePullRequestReviews, false, false, "can_approve_pull_request_reviews")
+	testutil.AssertPtr(t, got.Repository.HasWiki, false, false, "has_wiki")
+	testutil.AssertPtr(t, got.Repository.HasDiscussions, false, false, "has_discussions")
+	testutil.AssertPtr(t, got.Repository.HasProjects, false, false, "has_projects")
+	testutil.AssertPtr(t, got.Repository.HasIssues, false, true, "has_issues")
+	testutil.AssertPtr(t, got.Repository.AllowMergeCommit, false, false, "allow_merge_commit")
+	testutil.AssertPtr(t, got.Repository.AllowSquashMerge, false, true, "allow_squash_merge")
+	testutil.AssertPtr(t, got.Repository.AllowRebaseMerge, false, true, "allow_rebase_merge")
+	testutil.AssertPtr(t, got.Repository.SquashMergeCommitTitle, false, "PR_TITLE", "squash_merge_commit_title")
+	testutil.AssertPtr(t, got.Repository.SquashMergeCommitMessage, false, "PR_BODY", "squash_merge_commit_message")
+	testutil.AssertPtr(t, got.Repository.DeleteBranchOnMerge, false, true, "delete_branch_on_merge")
+	testutil.AssertPtr(t, got.Repository.AllowUpdateBranch, false, true, "allow_update_branch")
+	testutil.AssertPtr(t, got.Repository.AllowAutoMerge, false, true, "allow_auto_merge")
+	testutil.AssertPtr(t, got.Repository.WebCommitSignoffRequired, false, false, "web_commit_signoff_required")
+	testutil.AssertPtr(t, got.Repository.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
+	testutil.AssertPtr(t, got.Repository.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
+	testutil.AssertPtr(t, got.Repository.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
+	testutil.AssertPtr(t, got.Repository.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
+	testutil.AssertPtr(t, got.Repository.CanApprovePullRequestReviews, false, false, "can_approve_pull_request_reviews")
 	if got.Actions == nil {
 		t.Fatal("Actions is nil, want default policy")
 	}
-	testutil.AssertBoolPtr(t, got.Actions.Enabled, false, true, "actions.enabled")
-	testutil.AssertStringPtr(t, got.Actions.AllowedActions, false, "selected", "actions.allowed_actions")
-	testutil.AssertBoolPtr(t, got.Actions.SHAPinningRequired, false, false, "actions.sha_pinning_required")
-	testutil.AssertBoolPtr(t, got.Actions.GitHubOwnedAllowed, false, true, "actions.github_owned_allowed")
-	testutil.AssertBoolPtr(t, got.Actions.VerifiedAllowed, false, true, "actions.verified_allowed")
+	testutil.AssertPtr(t, got.Actions.Enabled, false, true, "actions.enabled")
+	testutil.AssertPtr(t, got.Actions.AllowedActions, false, "selected", "actions.allowed_actions")
+	testutil.AssertPtr(t, got.Actions.SHAPinningRequired, false, false, "actions.sha_pinning_required")
+	testutil.AssertPtr(t, got.Actions.GitHubOwnedAllowed, false, true, "actions.github_owned_allowed")
+	testutil.AssertPtr(t, got.Actions.VerifiedAllowed, false, true, "actions.verified_allowed")
 	if got.Actions.PatternsAllowed == nil || !slices.Equal(*got.Actions.PatternsAllowed, approvedDefaultActionPatterns) {
 		t.Fatalf("actions.patterns_allowed = %v, want %v", got.Actions.PatternsAllowed, approvedDefaultActionPatterns)
 	}
@@ -258,7 +258,7 @@ func TestMergeRepoSettings(t *testing.T) {
 					t.Errorf("Description = %q, want nil", *cfg.Repository.Description)
 				}
 			} else {
-				testutil.AssertStringPtr(t, cfg.Repository.Description, false, *tt.wantDesc, "description")
+				testutil.AssertPtr(t, cfg.Repository.Description, false, *tt.wantDesc, "description")
 			}
 
 			// Check Homepage.
@@ -267,7 +267,7 @@ func TestMergeRepoSettings(t *testing.T) {
 					t.Errorf("Homepage = %q, want nil", *cfg.Repository.Homepage)
 				}
 			} else {
-				testutil.AssertStringPtr(t, cfg.Repository.Homepage, false, *tt.wantHome, "homepage")
+				testutil.AssertPtr(t, cfg.Repository.Homepage, false, *tt.wantHome, "homepage")
 			}
 		})
 	}
@@ -286,8 +286,8 @@ func TestMergeRepoSettingsPreservesMergeCommitFields(t *testing.T) {
 	cfg := &Config{License: "BlueOak-1.0.0"}
 	MergeRepoSettings(cfg, live, "")
 
-	testutil.AssertStringPtr(t, cfg.Repository.MergeCommitTitle, false, "PR_TITLE", "merge_commit_title")
-	testutil.AssertStringPtr(t, cfg.Repository.MergeCommitMessage, false, "PR_BODY", "merge_commit_message")
+	testutil.AssertPtr(t, cfg.Repository.MergeCommitTitle, false, "PR_TITLE", "merge_commit_title")
+	testutil.AssertPtr(t, cfg.Repository.MergeCommitMessage, false, "PR_BODY", "merge_commit_message")
 }
 
 func TestDefaultConfigLicenseValues(t *testing.T) {

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"reflect"
 	"slices"
 
@@ -20,18 +21,18 @@ var repoSettingsSkipFields = map[string]bool{
 // MergeDefaults merges missing swatch entries, repository settings, Actions
 // policy fields, and labels from the embedded defaults into cfg. It reports
 // whether anything changed.
-func MergeDefaults(cfg *Config) bool {
+func MergeDefaults(cfg *Config) (bool, error) {
 	swatchesChanged := len(MergeDefaultSwatches(cfg)) > 0
 
 	defaults, err := DefaultConfig("_")
 	if err != nil {
-		return swatchesChanged
+		return swatchesChanged, fmt.Errorf("loading default config: %w", err)
 	}
 
 	repoChanged := mergeRepoSettingsFrom(cfg, defaults)
 	actionsChanged := mergeActionsFrom(cfg, defaults)
 	labelsChanged := mergeLabelsFrom(cfg, defaults)
-	return swatchesChanged || repoChanged || actionsChanged || labelsChanged
+	return swatchesChanged || repoChanged || actionsChanged || labelsChanged, nil
 }
 
 // mergeRepoSettingsFrom fills nil pointer fields in cfg.Repository from the

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -326,9 +326,9 @@ func TestMergeRepoSettingsAddsSecurityDefaults(t *testing.T) {
 		t.Fatal("expected changed=true for missing security settings")
 	}
 
-	testutil.AssertBoolPtr(t, cfg.Repository.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertBoolPtr(t, cfg.Repository.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertBoolPtr(t, cfg.Repository.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
+	testutil.AssertPtr(t, cfg.Repository.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
+	testutil.AssertPtr(t, cfg.Repository.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
+	testutil.AssertPtr(t, cfg.Repository.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
 }
 
 func TestMergeRepoSettingsPreservesExplicitFalseSecuritySettings(t *testing.T) {
@@ -342,9 +342,9 @@ func TestMergeRepoSettingsPreservesExplicitFalseSecuritySettings(t *testing.T) {
 		t.Fatal("expected changed=true for other missing repository settings")
 	}
 
-	testutil.AssertBoolPtr(t, cfg.Repository.PrivateVulnerabilityReportEnabled, false, false, "private_vulnerability_reporting_enabled")
-	testutil.AssertBoolPtr(t, cfg.Repository.VulnerabilityAlertsEnabled, false, false, "vulnerability_alerts_enabled")
-	testutil.AssertBoolPtr(t, cfg.Repository.AutomatedSecurityFixesEnabled, false, false, "automated_security_fixes_enabled")
+	testutil.AssertPtr(t, cfg.Repository.PrivateVulnerabilityReportEnabled, false, false, "private_vulnerability_reporting_enabled")
+	testutil.AssertPtr(t, cfg.Repository.VulnerabilityAlertsEnabled, false, false, "vulnerability_alerts_enabled")
+	testutil.AssertPtr(t, cfg.Repository.AutomatedSecurityFixesEnabled, false, false, "automated_security_fixes_enabled")
 }
 
 func TestMergeRepoSettingsFullRepository(t *testing.T) {

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -165,10 +165,18 @@ func TestMergeDefaultsChangedByEachSection(t *testing.T) {
 			cfg := defaultConfig(t)
 			tt.alter(cfg)
 
-			if !MergeDefaults(cfg) {
+			changed, err := MergeDefaults(cfg)
+			if err != nil {
+				t.Fatalf("MergeDefaults() error = %v", err)
+			}
+			if !changed {
 				t.Fatal("MergeDefaults() changed = false, want true")
 			}
-			if MergeDefaults(cfg) {
+			changed, err = MergeDefaults(cfg)
+			if err != nil {
+				t.Fatalf("second MergeDefaults() error = %v", err)
+			}
+			if changed {
 				t.Fatal("second MergeDefaults() changed = true, want false")
 			}
 		})

--- a/internal/config/normalise_test.go
+++ b/internal/config/normalise_test.go
@@ -32,7 +32,7 @@ func TestNormaliseSecurityPrerequisites(t *testing.T) {
 			if got := NormaliseSecurityPrerequisites(cfg); got != tt.wantChanged {
 				t.Fatalf("NormaliseSecurityPrerequisites() = %t, want %t", got, tt.wantChanged)
 			}
-			testutil.AssertBoolPtr(t, cfg.Repository.VulnerabilityAlertsEnabled, tt.wantAlerts == nil, valueOrFalse(tt.wantAlerts), "vulnerability_alerts_enabled")
+			testutil.AssertPtr(t, cfg.Repository.VulnerabilityAlertsEnabled, tt.wantAlerts == nil, valueOrFalse(tt.wantAlerts), "vulnerability_alerts_enabled")
 			if got := NormaliseSecurityPrerequisites(cfg); got {
 				t.Fatal("second NormaliseSecurityPrerequisites() call changed the config")
 			}

--- a/internal/gh/actions.go
+++ b/internal/gh/actions.go
@@ -3,13 +3,10 @@ package gh
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"slices"
 	"strings"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/wimpysworld/tailor/internal/model"
@@ -35,7 +32,7 @@ func ReadActionsPolicy(client *api.RESTClient, owner, name string, selected bool
 
 	var permissions actionsPermissionsResponse
 	coreKnown := false
-	if err := boundedActionsHTTPError(client.Get(base, &permissions)); err != nil {
+	if err := boundedHTTPError(client.Get(base, &permissions)); err != nil {
 		classified := classifyHTTPError(err, OpFetchActionsPermissions)
 		if isAccessError(classified) {
 			warnings = append(warnings, classified)
@@ -54,7 +51,7 @@ func ReadActionsPolicy(client *api.RESTClient, owner, name string, selected bool
 	// policy transition path.
 	if selected && coreKnown && permissions.AllowedActions == "selected" {
 		var policy selectedActionsResponse
-		if err := boundedActionsHTTPError(client.Get(base+"/selected-actions", &policy)); err != nil {
+		if err := boundedHTTPError(client.Get(base+"/selected-actions", &policy)); err != nil {
 			classified := classifyHTTPError(err, OpFetchSelectedActionsPermissions)
 			if isAccessError(classified) {
 				warnings = append(warnings, classified)
@@ -286,71 +283,5 @@ func putActionsPolicy(client *api.RESTClient, path string, body map[string]any) 
 	if err != nil {
 		return fmt.Errorf("marshalling actions permissions: %w", err)
 	}
-	return boundedActionsHTTPError(client.Put(path, bytes.NewReader(payload), nil))
-}
-
-// boundedActionsHTTPError limits the text that Tailor can render. go-gh reads
-// the complete response body before it returns, so this is not an allocation
-// limit for the response body.
-func boundedActionsHTTPError(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	var httpErr *api.HTTPError
-	if !errors.As(err, &httpErr) {
-		return err
-	}
-
-	const maxDetails = 3
-	const maxTextLength = 256
-	bounded := &api.HTTPError{
-		Headers:    httpErr.Headers.Clone(),
-		Message:    boundedSanitisedText(httpErr.Message, maxTextLength, true),
-		RequestURL: httpErr.RequestURL,
-		StatusCode: httpErr.StatusCode,
-	}
-	details := make([]string, 0, min(len(httpErr.Errors), maxDetails))
-	for _, item := range httpErr.Errors {
-		detail := boundedSanitisedText(item.Message, maxTextLength, false)
-		if detail == "" {
-			continue
-		}
-		details = append(details, detail)
-		item.Message = detail
-		bounded.Errors = append(bounded.Errors, item)
-		if len(details) == maxDetails {
-			break
-		}
-	}
-	if len(details) != 0 {
-		if bounded.Message == "" {
-			bounded.Message = "GitHub API request failed"
-		}
-		bounded.Message += ": " + strings.Join(details, "; ")
-	}
-	return bounded
-}
-
-func boundedSanitisedText(input string, limit int, firstLineOnly bool) string {
-	var output strings.Builder
-	truncated := false
-	for _, r := range input {
-		if firstLineOnly && r == '\n' {
-			break
-		}
-		if unicode.IsControl(r) {
-			r = ' '
-		}
-		if output.Len()+utf8.RuneLen(r) > limit {
-			truncated = true
-			break
-		}
-		output.WriteRune(r)
-	}
-	text := strings.TrimSpace(output.String())
-	if truncated {
-		text += "..."
-	}
-	return text
+	return boundedHTTPError(client.Put(path, bytes.NewReader(payload), nil))
 }

--- a/internal/gh/actions.go
+++ b/internal/gh/actions.go
@@ -36,7 +36,7 @@ func ReadActionsPolicy(client *api.RESTClient, owner, name string, selected bool
 	var permissions actionsPermissionsResponse
 	coreKnown := false
 	if err := boundedActionsHTTPError(client.Get(base, &permissions)); err != nil {
-		classified := classifyHTTPError(err, "fetch actions permissions")
+		classified := classifyHTTPError(err, OpFetchActionsPermissions)
 		if isAccessError(classified) {
 			warnings = append(warnings, classified)
 		} else {
@@ -55,7 +55,7 @@ func ReadActionsPolicy(client *api.RESTClient, owner, name string, selected bool
 	if selected && coreKnown && permissions.AllowedActions == "selected" {
 		var policy selectedActionsResponse
 		if err := boundedActionsHTTPError(client.Get(base+"/selected-actions", &policy)); err != nil {
-			classified := classifyHTTPError(err, "fetch selected actions permissions")
+			classified := classifyHTTPError(err, OpFetchSelectedActionsPermissions)
 			if isAccessError(classified) {
 				warnings = append(warnings, classified)
 			} else {
@@ -94,12 +94,12 @@ func ApplyActionsPolicy(client *api.RESTClient, owner, name string, desired, cur
 				initialCoreBody = maps.Clone(coreBody)
 				initialCoreBody["sha_pinning_required"] = true
 			}
-			applied, err := applyActionsWrite(client, base, initialCoreBody, "set actions permissions", result)
+			applied, err := applyActionsWrite(client, base, initialCoreBody, OpSetActionsPermissions, result)
 			if err != nil {
 				return nil, err
 			}
 			if !applied {
-				appendSkippedDependency(result, "set selected actions permissions")
+				appendSkippedDependency(result, OpSetSelectedActionsPermissions)
 				return result, nil
 			}
 			if err := putActionsPolicy(client, base+"/selected-actions", selectedBody); err != nil {
@@ -127,8 +127,8 @@ func ApplyActionsPolicy(client *api.RESTClient, owner, name string, desired, cur
 				return result, err
 			}
 			if !applied {
-				appendSkippedDependency(result, "set selected actions permissions")
-				appendSkippedDependency(result, "set actions permissions")
+				appendSkippedDependency(result, OpSetSelectedActionsPermissions)
+				appendSkippedDependency(result, OpSetActionsPermissions)
 				return result, nil
 			}
 			actionsDisabled = true
@@ -138,8 +138,8 @@ func ApplyActionsPolicy(client *api.RESTClient, owner, name string, desired, cur
 				return result, err
 			}
 			if !applied {
-				appendSkippedDependency(result, "set selected actions permissions")
-				appendSkippedDependency(result, "set actions permissions")
+				appendSkippedDependency(result, OpSetSelectedActionsPermissions)
+				appendSkippedDependency(result, OpSetActionsPermissions)
 				return result, nil
 			}
 			actionsDisabled = true
@@ -148,8 +148,8 @@ func ApplyActionsPolicy(client *api.RESTClient, owner, name string, desired, cur
 			if actionsDisabled {
 				return nil, fmt.Errorf("setting selected actions permissions failed while actions are disabled: %w", err)
 			}
-			if recordAccessError(result, "set selected actions permissions", err) {
-				appendSkippedDependency(result, "set actions permissions")
+			if recordAccessError(result, OpSetSelectedActionsPermissions, err) {
+				appendSkippedDependency(result, OpSetActionsPermissions)
 				return result, nil
 			}
 			return nil, fmt.Errorf("setting selected actions permissions: %w", err)
@@ -160,23 +160,23 @@ func ApplyActionsPolicy(client *api.RESTClient, owner, name string, desired, cur
 			}
 			return result, nil
 		}
-		_, err := applyActionsWrite(client, base, coreBody, "set actions permissions", result)
+		_, err := applyActionsWrite(client, base, coreBody, OpSetActionsPermissions, result)
 		return result, err
 	}
 
 	coreApplied := true
 	if core {
-		coreApplied, err = applyActionsWrite(client, base, coreBody, "set actions permissions", result)
+		coreApplied, err = applyActionsWrite(client, base, coreBody, OpSetActionsPermissions, result)
 		if err != nil {
 			return nil, err
 		}
 		if !coreApplied && selected {
-			appendSkippedDependency(result, "set selected actions permissions")
+			appendSkippedDependency(result, OpSetSelectedActionsPermissions)
 		}
 	}
 	if selected && coreApplied {
 		if err := putActionsPolicy(client, base+"/selected-actions", selectedBody); err != nil {
-			if !recordAccessError(result, "set selected actions permissions", err) {
+			if !recordAccessError(result, OpSetSelectedActionsPermissions, err) {
 				return nil, fmt.Errorf("setting selected actions permissions: %w", err)
 			}
 		}

--- a/internal/gh/errors.go
+++ b/internal/gh/errors.go
@@ -102,22 +102,32 @@ func boundedHTTPError(err error) error {
 
 	const maxDetails = 3
 	const maxTextLength = 256
+	// go-gh joins the top-level message and the normalised per-error lines
+	// into Message. Validation errors with a non-custom code carry their
+	// field detail only in those lines, so details come from Message, not
+	// from the per-item Message fields.
+	lines := strings.Split(httpErr.Message, "\n")
 	bounded := &api.HTTPError{
 		Headers:    httpErr.Headers.Clone(),
-		Message:    boundedSanitisedText(httpErr.Message, maxTextLength, true),
+		Message:    boundedSanitisedText(lines[0], maxTextLength),
 		RequestURL: httpErr.RequestURL,
 		StatusCode: httpErr.StatusCode,
 	}
-	details := make([]string, 0, min(len(httpErr.Errors), maxDetails))
-	for _, item := range httpErr.Errors {
-		detail := boundedSanitisedText(item.Message, maxTextLength, false)
+	details := make([]string, 0, min(len(lines)-1, maxDetails))
+	for _, line := range lines[1:] {
+		detail := boundedSanitisedText(line, maxTextLength)
 		if detail == "" {
 			continue
 		}
 		details = append(details, detail)
-		item.Message = detail
-		bounded.Errors = append(bounded.Errors, item)
 		if len(details) == maxDetails {
+			break
+		}
+	}
+	for _, item := range httpErr.Errors {
+		item.Message = boundedSanitisedText(item.Message, maxTextLength)
+		bounded.Errors = append(bounded.Errors, item)
+		if len(bounded.Errors) == maxDetails {
 			break
 		}
 	}
@@ -130,13 +140,10 @@ func boundedHTTPError(err error) error {
 	return bounded
 }
 
-func boundedSanitisedText(input string, limit int, firstLineOnly bool) string {
+func boundedSanitisedText(input string, limit int) string {
 	var output strings.Builder
 	truncated := false
 	for _, r := range input {
-		if firstLineOnly && r == '\n' {
-			break
-		}
 		if unicode.IsControl(r) {
 			r = ' '
 		}

--- a/internal/gh/errors.go
+++ b/internal/gh/errors.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/cli/go-gh/v2/pkg/api"
 )
@@ -83,4 +85,70 @@ func classifyHTTPError(err error, operation string) error {
 		Message:    httpErr.Message,
 		Operation:  operation,
 	}
+}
+
+// boundedHTTPError limits the text that Tailor can render. go-gh reads
+// the complete response body before it returns, so this is not an allocation
+// limit for the response body.
+func boundedHTTPError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var httpErr *api.HTTPError
+	if !errors.As(err, &httpErr) {
+		return err
+	}
+
+	const maxDetails = 3
+	const maxTextLength = 256
+	bounded := &api.HTTPError{
+		Headers:    httpErr.Headers.Clone(),
+		Message:    boundedSanitisedText(httpErr.Message, maxTextLength, true),
+		RequestURL: httpErr.RequestURL,
+		StatusCode: httpErr.StatusCode,
+	}
+	details := make([]string, 0, min(len(httpErr.Errors), maxDetails))
+	for _, item := range httpErr.Errors {
+		detail := boundedSanitisedText(item.Message, maxTextLength, false)
+		if detail == "" {
+			continue
+		}
+		details = append(details, detail)
+		item.Message = detail
+		bounded.Errors = append(bounded.Errors, item)
+		if len(details) == maxDetails {
+			break
+		}
+	}
+	if len(details) != 0 {
+		if bounded.Message == "" {
+			bounded.Message = "GitHub API request failed"
+		}
+		bounded.Message += ": " + strings.Join(details, "; ")
+	}
+	return bounded
+}
+
+func boundedSanitisedText(input string, limit int, firstLineOnly bool) string {
+	var output strings.Builder
+	truncated := false
+	for _, r := range input {
+		if firstLineOnly && r == '\n' {
+			break
+		}
+		if unicode.IsControl(r) {
+			r = ' '
+		}
+		if output.Len()+utf8.RuneLen(r) > limit {
+			truncated = true
+			break
+		}
+		output.WriteRune(r)
+	}
+	text := strings.TrimSpace(output.String())
+	if truncated {
+		text += "..."
+	}
+	return text
 }

--- a/internal/gh/errors_test.go
+++ b/internal/gh/errors_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/cli/go-gh/v2/pkg/api"
@@ -234,5 +235,22 @@ func TestParseCSVScopes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBoundedHTTPErrorKeepsNormalisedValidationDetail(t *testing.T) {
+	// go-gh normalises a validation error with a non-custom code into a
+	// Message line and leaves the item Message empty.
+	httpErr := &api.HTTPError{
+		Message:    "Validation Failed\nLabel.name already exists",
+		RequestURL: &url.URL{Scheme: "https", Host: "api.github.com", Path: "/repos/acme/widget/labels"},
+		StatusCode: http.StatusUnprocessableEntity,
+		Errors: []api.HTTPErrorItem{
+			{Resource: "Label", Field: "name", Code: "already_exists"},
+		},
+	}
+	rendered := boundedHTTPError(httpErr).Error()
+	if !strings.Contains(rendered, "Label.name already exists") {
+		t.Errorf("error is missing the validation detail: %q", rendered)
 	}
 }

--- a/internal/gh/labels.go
+++ b/internal/gh/labels.go
@@ -30,7 +30,7 @@ func ReadLabels(client *api.RESTClient, owner, repo string) ([]model.LabelEntry,
 		path := fmt.Sprintf("repos/%s/%s/labels?per_page=100&page=%d", owner, repo, page)
 		resp, err := client.RequestWithContext(context.Background(), http.MethodGet, path, nil)
 		if err != nil {
-			return nil, fmt.Errorf("fetching labels page %d: %w", page, err)
+			return nil, fmt.Errorf("fetching labels page %d: %w", page, boundedHTTPError(err))
 		}
 
 		body, err := io.ReadAll(resp.Body)
@@ -129,7 +129,7 @@ func createLabel(client *api.RESTClient, owner, repo string, label model.LabelEn
 	}
 
 	path := fmt.Sprintf("repos/%s/%s/labels", owner, repo)
-	if err := client.Post(path, bytes.NewReader(payload), nil); err != nil {
+	if err := boundedHTTPError(client.Post(path, bytes.NewReader(payload), nil)); err != nil {
 		return fmt.Errorf("creating label %q: %w", label.Name, err)
 	}
 	return nil
@@ -149,7 +149,7 @@ func updateLabel(client *api.RESTClient, owner, repo, name string, label model.L
 	}
 
 	path := fmt.Sprintf("repos/%s/%s/labels/%s", owner, repo, url.PathEscape(name))
-	if err := client.Patch(path, bytes.NewReader(payload), nil); err != nil {
+	if err := boundedHTTPError(client.Patch(path, bytes.NewReader(payload), nil)); err != nil {
 		return fmt.Errorf("updating label %q: %w", name, err)
 	}
 	return nil

--- a/internal/gh/labels.go
+++ b/internal/gh/labels.go
@@ -93,7 +93,7 @@ func ApplyLabels(client *api.RESTClient, owner, repo string, desired, current []
 
 		if !found {
 			if err := createLabel(client, owner, repo, d); err != nil {
-				opName := fmt.Sprintf("create label %q", d.Name)
+				opName := CreateLabelOp(d.Name)
 				if recordAccessError(result, opName, err) {
 					continue
 				}
@@ -104,7 +104,7 @@ func ApplyLabels(client *api.RESTClient, owner, repo string, desired, current []
 
 		if model.LabelNeedsUpdate(existing, d) {
 			if err := updateLabel(client, owner, repo, existing.Name, d); err != nil {
-				opName := fmt.Sprintf("update label %q", d.Name)
+				opName := UpdateLabelOp(d.Name)
 				if recordAccessError(result, opName, err) {
 					continue
 				}

--- a/internal/gh/licence.go
+++ b/internal/gh/licence.go
@@ -14,7 +14,7 @@ type licenceResponse struct {
 // FetchLicence returns the licence body text from GET /licenses/{id}.
 func FetchLicence(client *api.RESTClient, id string) (string, error) {
 	var resp licenceResponse
-	if err := client.Get(fmt.Sprintf("licenses/%s", id), &resp); err != nil {
+	if err := boundedHTTPError(client.Get(fmt.Sprintf("licenses/%s", id), &resp)); err != nil {
 		return "", fmt.Errorf("fetching licence %q: %w", id, err)
 	}
 	return resp.Body, nil

--- a/internal/gh/licence_test.go
+++ b/internal/gh/licence_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -40,5 +41,33 @@ func TestFetchLicenceAPIError(t *testing.T) {
 	_, err := FetchLicence(client, "nonexistent")
 	if err == nil {
 		t.Fatal("FetchLicence() expected error, got nil")
+	}
+}
+
+func TestFetchLicenceBoundsAPIErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintf(w, `{"message":"Not Found\u001b[2J\t%s-PRIVATE-TAIL"}`, strings.Repeat("x", 500))
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestClient(t, server)
+	_, err := FetchLicence(client, "nonexistent")
+	if err == nil {
+		t.Fatal("FetchLicence() expected error, got nil")
+	}
+	rendered := err.Error()
+	if !strings.Contains(rendered, "Not Found") {
+		t.Errorf("error is missing the API message: %q", rendered)
+	}
+	if strings.ContainsAny(rendered, "\x1b\t") {
+		t.Errorf("error contains terminal control characters: %q", rendered)
+	}
+	if strings.Contains(rendered, "PRIVATE-TAIL") {
+		t.Errorf("error contains unbounded body tail: %q", rendered)
+	}
+	if len(rendered) > 600 {
+		t.Errorf("rendered error length = %d, want at most 600", len(rendered))
 	}
 }

--- a/internal/gh/operations.go
+++ b/internal/gh/operations.go
@@ -1,0 +1,46 @@
+package gh
+
+import "fmt"
+
+// Operation names recorded in ErrInsufficientScope warnings and ApplyResult
+// skip records. internal/alter matches these strings to map skips back to
+// config fields, so both ends must use these shared definitions.
+const (
+	OpFetchActionsPermissions            = "fetch actions permissions"
+	OpFetchSelectedActionsPermissions    = "fetch selected actions permissions"
+	OpSetActionsPermissions              = "set actions permissions"
+	OpSetSelectedActionsPermissions      = "set selected actions permissions"
+	OpFetchWorkflowPermissions           = "fetch workflow permissions"
+	OpSetWorkflowPermissions             = "set workflow permissions"
+	OpFetchPrivateVulnerabilityReporting = "fetch private vulnerability reporting"
+	OpFetchVulnerabilityAlerts           = "fetch vulnerability alerts"
+	OpFetchAutomatedSecurityFixes        = "fetch automated security fixes"
+	OpPatchRepoSettings                  = "patch repo settings"
+	OpSetTopics                          = "set topics"
+)
+
+// Security feature names embedded in enable/disable operation names.
+const (
+	FeaturePrivateVulnerabilityReporting = "private vulnerability reporting"
+	FeatureVulnerabilityAlerts           = "vulnerability alerts"
+	FeatureAutomatedSecurityFixes        = "automated security fixes"
+)
+
+// SecurityFeatureOp returns the operation name for enabling or disabling a
+// security feature, for example "enable vulnerability alerts".
+func SecurityFeatureOp(enable bool, feature string) string {
+	if enable {
+		return "enable " + feature
+	}
+	return "disable " + feature
+}
+
+// CreateLabelOp returns the operation name for creating the named label.
+func CreateLabelOp(name string) string {
+	return fmt.Sprintf("create label %q", name)
+}
+
+// UpdateLabelOp returns the operation name for updating the named label.
+func UpdateLabelOp(name string) string {
+	return fmt.Sprintf("update label %q", name)
+}

--- a/internal/gh/settings.go
+++ b/internal/gh/settings.go
@@ -56,7 +56,7 @@ type workflowPermissionsResponse struct {
 // log these warnings or ignore them.
 func ReadRepoSettings(client *api.RESTClient, owner, name string) (*model.RepositorySettings, []error, error) {
 	var repo repoResponse
-	if err := client.Get(fmt.Sprintf("repos/%s/%s", owner, name), &repo); err != nil {
+	if err := boundedHTTPError(client.Get(fmt.Sprintf("repos/%s/%s", owner, name), &repo)); err != nil {
 		return nil, nil, fmt.Errorf("fetching repo settings: %w", err)
 	}
 
@@ -84,7 +84,7 @@ func ReadRepoSettings(client *api.RESTClient, owner, name string) (*model.Reposi
 	var warnings []error
 	adminRead := false
 	var wfPerms workflowPermissionsResponse
-	if err := client.Get(fmt.Sprintf("repos/%s/%s/actions/permissions/workflow", owner, name), &wfPerms); err != nil {
+	if err := boundedHTTPError(client.Get(fmt.Sprintf("repos/%s/%s/actions/permissions/workflow", owner, name), &wfPerms)); err != nil {
 		classified := classifyHTTPError(err, OpFetchWorkflowPermissions)
 		if isAccessError(classified) {
 			warnings = append(warnings, classified)
@@ -151,7 +151,7 @@ func readSecurityFeature(client *api.RESTClient, path string, statusOnly, allow4
 	if !statusOnly {
 		response = &feature
 	}
-	if err := client.Get(path, response); err != nil {
+	if err := boundedHTTPError(client.Get(path, response)); err != nil {
 		var httpErr *api.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound && allow404Disabled {
 			return false, true, nil
@@ -215,7 +215,7 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 		if err != nil {
 			return nil, fmt.Errorf("marshalling repo settings: %w", err)
 		}
-		if err := client.Patch(fmt.Sprintf("repos/%s/%s", owner, name), bytes.NewReader(payload), nil); err != nil {
+		if err := boundedHTTPError(client.Patch(fmt.Sprintf("repos/%s/%s", owner, name), bytes.NewReader(payload), nil)); err != nil {
 			if !recordAccessError(result, OpPatchRepoSettings, err) {
 				return nil, fmt.Errorf("patching repo settings: %w", err)
 			}
@@ -278,7 +278,7 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 		if err != nil {
 			return nil, fmt.Errorf("marshalling topics: %w", err)
 		}
-		if err := client.Put(fmt.Sprintf("repos/%s/%s/topics", owner, name), bytes.NewReader(payload), nil); err != nil {
+		if err := boundedHTTPError(client.Put(fmt.Sprintf("repos/%s/%s/topics", owner, name), bytes.NewReader(payload), nil)); err != nil {
 			if !recordAccessError(result, OpSetTopics, err) {
 				return nil, fmt.Errorf("setting topics: %w", err)
 			}
@@ -291,9 +291,9 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 func applySecuritySetting(client *api.RESTClient, path string, enabled bool, feature string, result *ApplyResult) (bool, error) {
 	var err error
 	if enabled {
-		err = client.Put(path, bytes.NewReader([]byte("{}")), nil)
+		err = boundedHTTPError(client.Put(path, bytes.NewReader([]byte("{}")), nil))
 	} else {
-		err = client.Delete(path, nil)
+		err = boundedHTTPError(client.Delete(path, nil))
 	}
 	if err == nil {
 		return true, nil
@@ -332,7 +332,7 @@ func applyWorkflowPermissions(client *api.RESTClient, owner, name string, p sett
 	// PUT body is always complete.
 	if perms == nil || approve == nil {
 		var current workflowPermissionsResponse
-		if err := client.Get(wfpPath, &current); err != nil {
+		if err := boundedHTTPError(client.Get(wfpPath, &current)); err != nil {
 			return fmt.Errorf("fetching current workflow permissions: %w", err)
 		}
 		if perms == nil {
@@ -351,7 +351,7 @@ func applyWorkflowPermissions(client *api.RESTClient, owner, name string, p sett
 	if err != nil {
 		return fmt.Errorf("marshalling workflow permissions: %w", err)
 	}
-	if err := client.Put(wfpPath, bytes.NewReader(payload), nil); err != nil {
+	if err := boundedHTTPError(client.Put(wfpPath, bytes.NewReader(payload), nil)); err != nil {
 		return fmt.Errorf("setting workflow permissions: %w", err)
 	}
 	return nil

--- a/internal/gh/settings.go
+++ b/internal/gh/settings.go
@@ -85,7 +85,7 @@ func ReadRepoSettings(client *api.RESTClient, owner, name string) (*model.Reposi
 	adminRead := false
 	var wfPerms workflowPermissionsResponse
 	if err := client.Get(fmt.Sprintf("repos/%s/%s/actions/permissions/workflow", owner, name), &wfPerms); err != nil {
-		classified := classifyHTTPError(err, "fetch workflow permissions")
+		classified := classifyHTTPError(err, OpFetchWorkflowPermissions)
 		if isAccessError(classified) {
 			warnings = append(warnings, classified)
 		} else {
@@ -106,19 +106,19 @@ func ReadRepoSettings(client *api.RESTClient, owner, name string) (*model.Reposi
 	}{
 		{
 			path:      fmt.Sprintf("repos/%s/%s/private-vulnerability-reporting", owner, name),
-			operation: "fetch private vulnerability reporting",
+			operation: OpFetchPrivateVulnerabilityReporting,
 			set:       func(enabled bool) { s.PrivateVulnerabilityReportEnabled = new(enabled) },
 		},
 		{
 			path:             fmt.Sprintf("repos/%s/%s/vulnerability-alerts", owner, name),
-			operation:        "fetch vulnerability alerts",
+			operation:        OpFetchVulnerabilityAlerts,
 			statusOnly:       true,
 			allow404Disabled: adminRead && repo.Permissions.Admin,
 			set:              func(enabled bool) { s.VulnerabilityAlertsEnabled = new(enabled) },
 		},
 		{
 			path:             fmt.Sprintf("repos/%s/%s/automated-security-fixes", owner, name),
-			operation:        "fetch automated security fixes",
+			operation:        OpFetchAutomatedSecurityFixes,
 			allow404Disabled: adminRead && repo.Permissions.Admin,
 			set:              func(enabled bool) { s.AutomatedSecurityFixesEnabled = new(enabled) },
 		},
@@ -216,7 +216,7 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 			return nil, fmt.Errorf("marshalling repo settings: %w", err)
 		}
 		if err := client.Patch(fmt.Sprintf("repos/%s/%s", owner, name), bytes.NewReader(payload), nil); err != nil {
-			if !recordAccessError(result, "patch repo settings", err) {
+			if !recordAccessError(result, OpPatchRepoSettings, err) {
 				return nil, fmt.Errorf("patching repo settings: %w", err)
 			}
 		}
@@ -224,7 +224,7 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 
 	if p.PrivateVulnerabilityReporting != nil {
 		path := fmt.Sprintf("repos/%s/%s/private-vulnerability-reporting", owner, name)
-		if _, err := applySecuritySetting(client, path, *p.PrivateVulnerabilityReporting, "private vulnerability reporting", result); err != nil {
+		if _, err := applySecuritySetting(client, path, *p.PrivateVulnerabilityReporting, FeaturePrivateVulnerabilityReporting, result); err != nil {
 			return nil, err
 		}
 	}
@@ -234,7 +234,7 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 	fixesDisabled := current != nil && current.AutomatedSecurityFixesEnabled != nil && !*current.AutomatedSecurityFixesEnabled
 	if p.AutomatedSecurityFixes != nil && !*p.AutomatedSecurityFixes && !fixesDisabled {
 		var err error
-		fixesDisabled, err = applySecuritySetting(client, fixesPath, false, "automated security fixes", result)
+		fixesDisabled, err = applySecuritySetting(client, fixesPath, false, FeatureAutomatedSecurityFixes, result)
 		if err != nil {
 			return nil, err
 		}
@@ -243,28 +243,28 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 		if p.AutomatedSecurityFixes == nil {
 			return nil, fmt.Errorf("cannot disable vulnerability alerts while automated security fixes are unmanaged")
 		}
-		appendSkippedDependency(result, "disable vulnerability alerts")
+		appendSkippedDependency(result, SecurityFeatureOp(false, FeatureVulnerabilityAlerts))
 	}
 	alertsApplied := true
 	if p.VulnerabilityAlerts != nil && (*p.VulnerabilityAlerts || fixesDisabled) {
 		var err error
-		alertsApplied, err = applySecuritySetting(client, alertsPath, *p.VulnerabilityAlerts, "vulnerability alerts", result)
+		alertsApplied, err = applySecuritySetting(client, alertsPath, *p.VulnerabilityAlerts, FeatureVulnerabilityAlerts, result)
 		if err != nil {
 			return nil, err
 		}
 		if !alertsApplied && p.AutomatedSecurityFixes != nil && *p.AutomatedSecurityFixes {
-			appendSkippedDependency(result, "enable automated security fixes")
+			appendSkippedDependency(result, SecurityFeatureOp(true, FeatureAutomatedSecurityFixes))
 		}
 	}
 	if p.AutomatedSecurityFixes != nil && *p.AutomatedSecurityFixes && alertsApplied {
-		if _, err := applySecuritySetting(client, fixesPath, true, "automated security fixes", result); err != nil {
+		if _, err := applySecuritySetting(client, fixesPath, true, FeatureAutomatedSecurityFixes, result); err != nil {
 			return nil, err
 		}
 	}
 
 	if p.DefaultWorkflowPermissions != nil || p.CanApprovePullRequestReviews != nil {
 		if err := applyWorkflowPermissions(client, owner, name, p); err != nil {
-			if !recordAccessError(result, "set workflow permissions", err) {
+			if !recordAccessError(result, OpSetWorkflowPermissions, err) {
 				return nil, err
 			}
 		}
@@ -279,7 +279,7 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 			return nil, fmt.Errorf("marshalling topics: %w", err)
 		}
 		if err := client.Put(fmt.Sprintf("repos/%s/%s/topics", owner, name), bytes.NewReader(payload), nil); err != nil {
-			if !recordAccessError(result, "set topics", err) {
+			if !recordAccessError(result, OpSetTopics, err) {
 				return nil, fmt.Errorf("setting topics: %w", err)
 			}
 		}
@@ -289,10 +289,8 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 }
 
 func applySecuritySetting(client *api.RESTClient, path string, enabled bool, feature string, result *ApplyResult) (bool, error) {
-	action := "disable"
 	var err error
 	if enabled {
-		action = "enable"
 		err = client.Put(path, bytes.NewReader([]byte("{}")), nil)
 	} else {
 		err = client.Delete(path, nil)
@@ -300,7 +298,7 @@ func applySecuritySetting(client *api.RESTClient, path string, enabled bool, fea
 	if err == nil {
 		return true, nil
 	}
-	operation := action + " " + feature
+	operation := SecurityFeatureOp(enabled, feature)
 	if recordAccessError(result, operation, err) {
 		return false, nil
 	}

--- a/internal/gh/settings_test.go
+++ b/internal/gh/settings_test.go
@@ -188,29 +188,29 @@ func TestReadRepoSettings(t *testing.T) {
 			}
 
 			// description and homepage
-			testutil.AssertStringPtr(t, settings.Description, tt.wantDescNil, tt.wantDesc, "description")
-			testutil.AssertStringPtr(t, settings.Homepage, tt.wantHomeNil, tt.wantHome, "homepage")
+			testutil.AssertPtr(t, settings.Description, tt.wantDescNil, tt.wantDesc, "description")
+			testutil.AssertPtr(t, settings.Homepage, tt.wantHomeNil, tt.wantHome, "homepage")
 
 			// bool fields
-			testutil.AssertBoolPtr(t, settings.HasWiki, false, tt.wantWiki, "has_wiki")
-			testutil.AssertBoolPtr(t, settings.HasDiscussions, false, tt.wantDisc, "has_discussions")
-			testutil.AssertBoolPtr(t, settings.HasProjects, false, tt.wantProj, "has_projects")
-			testutil.AssertBoolPtr(t, settings.HasIssues, false, tt.wantIssues, "has_issues")
-			testutil.AssertBoolPtr(t, settings.AllowMergeCommit, false, tt.wantMerge, "allow_merge_commit")
-			testutil.AssertBoolPtr(t, settings.AllowSquashMerge, false, tt.wantSquash, "allow_squash_merge")
-			testutil.AssertBoolPtr(t, settings.AllowRebaseMerge, false, tt.wantRebase, "allow_rebase_merge")
-			testutil.AssertBoolPtr(t, settings.DeleteBranchOnMerge, false, tt.wantDelete, "delete_branch_on_merge")
-			testutil.AssertBoolPtr(t, settings.AllowUpdateBranch, false, tt.wantUpdate, "allow_update_branch")
-			testutil.AssertBoolPtr(t, settings.AllowAutoMerge, false, tt.wantAuto, "allow_auto_merge")
-			testutil.AssertBoolPtr(t, settings.WebCommitSignoffRequired, false, tt.wantSignoff, "web_commit_signoff_required")
-			testutil.AssertBoolPtr(t, settings.CanApprovePullRequestReviews, false, tt.wantCanApprove, "can_approve_pull_request_reviews")
+			testutil.AssertPtr(t, settings.HasWiki, false, tt.wantWiki, "has_wiki")
+			testutil.AssertPtr(t, settings.HasDiscussions, false, tt.wantDisc, "has_discussions")
+			testutil.AssertPtr(t, settings.HasProjects, false, tt.wantProj, "has_projects")
+			testutil.AssertPtr(t, settings.HasIssues, false, tt.wantIssues, "has_issues")
+			testutil.AssertPtr(t, settings.AllowMergeCommit, false, tt.wantMerge, "allow_merge_commit")
+			testutil.AssertPtr(t, settings.AllowSquashMerge, false, tt.wantSquash, "allow_squash_merge")
+			testutil.AssertPtr(t, settings.AllowRebaseMerge, false, tt.wantRebase, "allow_rebase_merge")
+			testutil.AssertPtr(t, settings.DeleteBranchOnMerge, false, tt.wantDelete, "delete_branch_on_merge")
+			testutil.AssertPtr(t, settings.AllowUpdateBranch, false, tt.wantUpdate, "allow_update_branch")
+			testutil.AssertPtr(t, settings.AllowAutoMerge, false, tt.wantAuto, "allow_auto_merge")
+			testutil.AssertPtr(t, settings.WebCommitSignoffRequired, false, tt.wantSignoff, "web_commit_signoff_required")
+			testutil.AssertPtr(t, settings.CanApprovePullRequestReviews, false, tt.wantCanApprove, "can_approve_pull_request_reviews")
 
 			// string fields (always non-nil)
-			testutil.AssertStringPtr(t, settings.DefaultWorkflowPermissions, false, tt.wantWfPerms, "default_workflow_permissions")
-			testutil.AssertStringPtr(t, settings.SquashMergeCommitTitle, false, tt.wantSqTitle, "squash_merge_commit_title")
-			testutil.AssertStringPtr(t, settings.SquashMergeCommitMessage, false, tt.wantSqMsg, "squash_merge_commit_message")
-			testutil.AssertStringPtr(t, settings.MergeCommitTitle, false, tt.wantMcTitle, "merge_commit_title")
-			testutil.AssertStringPtr(t, settings.MergeCommitMessage, false, tt.wantMcMsg, "merge_commit_message")
+			testutil.AssertPtr(t, settings.DefaultWorkflowPermissions, false, tt.wantWfPerms, "default_workflow_permissions")
+			testutil.AssertPtr(t, settings.SquashMergeCommitTitle, false, tt.wantSqTitle, "squash_merge_commit_title")
+			testutil.AssertPtr(t, settings.SquashMergeCommitMessage, false, tt.wantSqMsg, "squash_merge_commit_message")
+			testutil.AssertPtr(t, settings.MergeCommitTitle, false, tt.wantMcTitle, "merge_commit_title")
+			testutil.AssertPtr(t, settings.MergeCommitMessage, false, tt.wantMcMsg, "merge_commit_message")
 
 			// topics
 			if tt.wantTopics == nil {
@@ -274,13 +274,13 @@ func TestReadRepoSettingsIgnoresGitHubActionsEnvironment(t *testing.T) {
 		t.Errorf("ReadRepoSettings() warnings = %v, want none", warnings)
 	}
 
-	testutil.AssertBoolPtr(t, settings.AllowAutoMerge, false, false, "allow_auto_merge")
-	testutil.AssertBoolPtr(t, settings.AllowRebaseMerge, false, false, "allow_rebase_merge")
-	testutil.AssertBoolPtr(t, settings.AllowSquashMerge, false, false, "allow_squash_merge")
-	testutil.AssertBoolPtr(t, settings.AllowUpdateBranch, false, false, "allow_update_branch")
-	testutil.AssertBoolPtr(t, settings.DeleteBranchOnMerge, false, false, "delete_branch_on_merge")
-	testutil.AssertStringPtr(t, settings.SquashMergeCommitMessage, false, "", "squash_merge_commit_message")
-	testutil.AssertStringPtr(t, settings.SquashMergeCommitTitle, false, "", "squash_merge_commit_title")
+	testutil.AssertPtr(t, settings.AllowAutoMerge, false, false, "allow_auto_merge")
+	testutil.AssertPtr(t, settings.AllowRebaseMerge, false, false, "allow_rebase_merge")
+	testutil.AssertPtr(t, settings.AllowSquashMerge, false, false, "allow_squash_merge")
+	testutil.AssertPtr(t, settings.AllowUpdateBranch, false, false, "allow_update_branch")
+	testutil.AssertPtr(t, settings.DeleteBranchOnMerge, false, false, "delete_branch_on_merge")
+	testutil.AssertPtr(t, settings.SquashMergeCommitMessage, false, "", "squash_merge_commit_message")
+	testutil.AssertPtr(t, settings.SquashMergeCommitTitle, false, "", "squash_merge_commit_title")
 }
 
 func TestReadRepoSettingsRepoAPIError(t *testing.T) {
@@ -325,7 +325,7 @@ func TestReadRepoSettingsWFPerms403GracefulDegradation(t *testing.T) {
 		t.Errorf("CanApprovePullRequestReviews = %v, want nil", *settings.CanApprovePullRequestReviews)
 	}
 	// Other fields should be populated.
-	testutil.AssertStringPtr(t, settings.Description, false, "A tailor for your repos", "description")
+	testutil.AssertPtr(t, settings.Description, false, "A tailor for your repos", "description")
 }
 
 func TestReadRepoSettingsAll403GracefulDegradation(t *testing.T) {
@@ -361,8 +361,8 @@ func TestReadRepoSettingsAll403GracefulDegradation(t *testing.T) {
 		t.Errorf("expected 4 warnings, got %d", len(warnings))
 	}
 	// Core repo fields should still be populated.
-	testutil.AssertStringPtr(t, settings.Description, false, "A tailor for your repos", "description")
-	testutil.AssertBoolPtr(t, settings.HasWiki, false, false, "has_wiki")
+	testutil.AssertPtr(t, settings.Description, false, "A tailor for your repos", "description")
+	testutil.AssertPtr(t, settings.HasWiki, false, false, "has_wiki")
 }
 
 func TestReadRepoSettingsNon403StillFails(t *testing.T) {
@@ -412,9 +412,9 @@ func TestReadRepoSettingsSecurityFeatures(t *testing.T) {
 	if len(warnings) != 0 {
 		t.Fatalf("warnings = %v, want none", warnings)
 	}
-	testutil.AssertBoolPtr(t, settings.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertBoolPtr(t, settings.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertBoolPtr(t, settings.AutomatedSecurityFixesEnabled, false, false, "automated_security_fixes_enabled")
+	testutil.AssertPtr(t, settings.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
+	testutil.AssertPtr(t, settings.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
+	testutil.AssertPtr(t, settings.AutomatedSecurityFixesEnabled, false, false, "automated_security_fixes_enabled")
 }
 
 func TestReadRepoSettingsSecurityFeature404HandlingForAdmin(t *testing.T) {
@@ -438,9 +438,9 @@ func TestReadRepoSettingsSecurityFeature404HandlingForAdmin(t *testing.T) {
 	if len(warnings) != 1 {
 		t.Fatalf("warnings = %v, want private reporting access warning", warnings)
 	}
-	testutil.AssertBoolPtr(t, settings.PrivateVulnerabilityReportEnabled, true, false, "private_vulnerability_reporting_enabled")
-	testutil.AssertBoolPtr(t, settings.VulnerabilityAlertsEnabled, false, false, "vulnerability_alerts_enabled")
-	testutil.AssertBoolPtr(t, settings.AutomatedSecurityFixesEnabled, false, false, "automated_security_fixes_enabled")
+	testutil.AssertPtr(t, settings.PrivateVulnerabilityReportEnabled, true, false, "private_vulnerability_reporting_enabled")
+	testutil.AssertPtr(t, settings.VulnerabilityAlertsEnabled, false, false, "vulnerability_alerts_enabled")
+	testutil.AssertPtr(t, settings.AutomatedSecurityFixesEnabled, false, false, "automated_security_fixes_enabled")
 }
 
 func TestReadRepoSettingsSecurityFeature404UnknownWithoutConfirmedAdminAccess(t *testing.T) {

--- a/internal/measure/format_test.go
+++ b/internal/measure/format_test.go
@@ -1,7 +1,6 @@
 package measure
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -68,33 +67,6 @@ func TestFormatOutputWithConfig(t *testing.T) {
 	}
 }
 
-func TestFormatOutputPaddingWidth(t *testing.T) {
-	// Every category label produces exactly 16 characters before the destination.
-	tests := []struct {
-		label string
-		width int
-	}{
-		{"missing:", 16},
-		{"warning:", 16},
-		{"present:", 16},
-		{"not-configured:", 16},
-		{"config-only:", 16},
-		{"mode-differs:", 16},
-	}
-
-	for _, tt := range tests {
-		formatted := formatLabel(tt.label, tt.width)
-		if len(formatted) != tt.width {
-			t.Errorf("label %q padded to %d chars, want %d", tt.label, len(formatted), tt.width)
-		}
-	}
-}
-
-// formatLabel pads label to the given width, matching the production format logic.
-func formatLabel(label string, width int) string {
-	return fmt.Sprintf("%-*s", width, label)
-}
-
 func TestFormatOutputEmptyResults(t *testing.T) {
 	got := FormatOutput(nil, nil, true)
 	if got != "" {
@@ -112,12 +84,5 @@ func TestFormatOutputHealthOnlyWithConfig(t *testing.T) {
 
 	if got != want {
 		t.Errorf("got: %q\nwant: %q", got, want)
-	}
-}
-
-func TestAdvisoryMessageContent(t *testing.T) {
-	want := "No .tailor.yml found. Run `tailor fit <path>` to initialise, or create `.tailor.yml` manually to enable configuration alignment checks."
-	if AdvisoryMessage != want {
-		t.Errorf("AdvisoryMessage =\n%q\nwant:\n%q", AdvisoryMessage, want)
 	}
 }

--- a/internal/measure/health.go
+++ b/internal/measure/health.go
@@ -74,17 +74,17 @@ func hasCompleteInlineLink(data []byte, offset int) bool {
 // token inside matching square or curly delimiters.
 func hasUnresolvedPlaceholders(data []byte) bool {
 	for start, open := range data {
-		var close byte
+		var closer byte
 		switch open {
 		case '[':
-			close = ']'
+			closer = ']'
 		case '{':
-			close = '}'
+			closer = '}'
 		default:
 			continue
 		}
 
-		end := bytes.IndexByte(data[start+1:], close)
+		end := bytes.IndexByte(data[start+1:], closer)
 		if end < 0 {
 			continue
 		}

--- a/internal/swatch/swatch_test.go
+++ b/internal/swatch/swatch_test.go
@@ -1,8 +1,11 @@
 package swatch_test
 
 import (
+	"io/fs"
+	"strings"
 	"testing"
 
+	"github.com/wimpysworld/tailor"
 	"github.com/wimpysworld/tailor/internal/swatch"
 )
 
@@ -24,6 +27,33 @@ func TestContentAvailableForAllRegisteredSwatches(t *testing.T) {
 				t.Fatalf("Content(%q) returned empty bytes", s.Path)
 			}
 		})
+	}
+}
+
+// TestAllEmbeddedFilesAreRegistered verifies the reverse: every file in the
+// embedded filesystem has a registry entry, so a stray file added under
+// swatches/ without registration fails the suite.
+func TestAllEmbeddedFilesAreRegistered(t *testing.T) {
+	registered := make(map[string]bool)
+	for _, p := range swatch.Paths() {
+		registered[p] = true
+	}
+
+	err := fs.WalkDir(tailor.SwatchFS, "swatches", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel := strings.TrimPrefix(path, "swatches/")
+		if !registered[rel] {
+			t.Errorf("embedded file %q has no registry entry", rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir returned error: %v", err)
 	}
 }
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -59,40 +59,21 @@ func WriteConfig(t *testing.T, dir, content string) {
 	}
 }
 
-// AssertBoolPtr checks a *bool field. When wantNil is true, it expects got to
+// AssertPtr checks a pointer field. When wantNil is true, it expects got to
 // be nil. Otherwise it expects got to be non-nil with value wantVal.
-func AssertBoolPtr(t *testing.T, got *bool, wantNil bool, wantVal bool, field string) {
+func AssertPtr[T comparable](t *testing.T, got *T, wantNil bool, wantVal T, field string) {
 	t.Helper()
 	if wantNil {
 		if got != nil {
-			t.Errorf("%s = %v, want nil", field, *got)
+			t.Errorf("%s = %#v, want nil", field, *got)
 		}
 		return
 	}
 	if got == nil {
-		t.Errorf("%s is nil, want %v", field, wantVal)
+		t.Errorf("%s is nil, want %#v", field, wantVal)
 		return
 	}
 	if *got != wantVal {
-		t.Errorf("%s = %v, want %v", field, *got, wantVal)
-	}
-}
-
-// AssertStringPtr checks a *string field. When wantNil is true, it expects got
-// to be nil. Otherwise it expects got to be non-nil with value wantVal.
-func AssertStringPtr(t *testing.T, got *string, wantNil bool, wantVal string, field string) {
-	t.Helper()
-	if wantNil {
-		if got != nil {
-			t.Errorf("%s = %q, want nil", field, *got)
-		}
-		return
-	}
-	if got == nil {
-		t.Errorf("%s is nil, want %q", field, wantVal)
-		return
-	}
-	if *got != wantVal {
-		t.Errorf("%s = %q, want %q", field, *got, wantVal)
+		t.Errorf("%s = %#v, want %#v", field, *got, wantVal)
 	}
 }

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -21,3 +21,15 @@ func TestWriteConfigCreatesFile(t *testing.T) {
 		t.Errorf("file content = %q, want %q", string(data), content)
 	}
 }
+
+func TestAssertPtrBool(t *testing.T) {
+	val := true
+	AssertPtr(t, &val, false, true, "bool_field")
+	AssertPtr[bool](t, nil, true, false, "bool_field")
+}
+
+func TestAssertPtrString(t *testing.T) {
+	val := "read"
+	AssertPtr(t, &val, false, "read", "string_field")
+	AssertPtr[string](t, nil, true, "", "string_field")
+}

--- a/justfile
+++ b/justfile
@@ -6,9 +6,12 @@ default:
 alter:
     @go run ./cmd/tailor alter
 
-# Build tailor binary and snapshot release packages
+# Build tailor binary
 build:
     @go build -ldflags "-s -w" -o tailor ./cmd/tailor
+
+# Build snapshot release packages
+snapshot:
     @goreleaser release --snapshot --clean --skip=sign
 
 # Check goreleaser config and nix flake

--- a/swatches/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/swatches/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,10 +16,6 @@ body:
         1. Run command: `...`
         2. Do something else: `...`
         3. Error occurs
-      value: |
-        1.
-        2.
-        3.
     validations:
       required: true
 


### PR DESCRIPTION
This branch works through a peer-review pass across the codebase. Config now propagates the default-config load error from MergeDefaults instead of swallowing it, gh bounds error text for settings, labels, and licence calls, and the bug report swatch no longer pre-fills the steps field. gh also centralises its operation-string constants, measure renames a shadowing close to closer, and just build splits into fast build and snapshot recipes. The remaining commits correct test names and messages, assert every embedded swatch file is registered, remove tests that duplicate production coverage, merge AssertBoolPtr and AssertStringPtr into one AssertPtr helper, and switch the docket tests to inject a REST client instead of swapping the default transport.

gofmt -l reported no files, go vet ./... was clean, and go test ./... -count=1 passed across all 10 packages.
