### PR TITLE
refactor: remove code smells from gh, alter, and config packages

### DIFF
--- a/internal/alter/actions.go
+++ b/internal/alter/actions.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/wimpysworld/tailor/internal/config"
 	"github.com/wimpysworld/tailor/internal/gh"
 	"github.com/wimpysworld/tailor/internal/model"
@@ -137,16 +136,16 @@ func actionsGroupSet(a *model.ActionsSettings, group actionsFieldGroup) bool {
 
 // ProcessActions compares the declared Actions policy against GitHub and
 // applies only endpoint groups that differ.
-func ProcessActions(cfg *config.Config, mode ApplyMode, client *api.RESTClient, owner, name string, hasRepo bool) ([]RepoSettingResult, error) {
+func ProcessActions(cfg *config.Config, mode ApplyMode, target RepoTarget) ([]RepoSettingResult, error) {
 	if cfg.Actions == nil || !actionsConfigured(cfg.Actions) {
 		return nil, nil
 	}
-	if !hasRepo {
+	if !target.HasRepo {
 		return nil, nil
 	}
 
 	selected := actionsGroupSet(cfg.Actions, actionsSelected)
-	live, warnings, err := gh.ReadActionsPolicy(client, owner, name, selected)
+	live, warnings, err := gh.ReadActionsPolicy(target.Client, target.Owner, target.Name, selected)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +154,7 @@ func ProcessActions(cfg *config.Config, mode ApplyMode, client *api.RESTClient, 
 
 	coreChanged, selectedChanged := actionsChanges(results)
 	if mode.ShouldWrite() && (coreChanged || selectedChanged) {
-		applied, err := gh.ApplyActionsPolicy(client, owner, name, cfg.Actions, live, coreChanged, selectedChanged)
+		applied, err := gh.ApplyActionsPolicy(target.Client, target.Owner, target.Name, cfg.Actions, live, coreChanged, selectedChanged)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/alter/actions.go
+++ b/internal/alter/actions.go
@@ -22,8 +22,8 @@ const (
 	actionsSelected
 )
 
-// writeOperation returns the gh write operation for the group.
-func (g actionsFieldGroup) writeOperation() string {
+// writeOperation returns the gh write operation kind for the group.
+func (g actionsFieldGroup) writeOperation() gh.OperationKind {
 	if g == actionsSelected {
 		return gh.OpSetSelectedActionsPermissions
 	}
@@ -194,7 +194,7 @@ func suppressActionsReadWarnings(results []RepoSettingResult, warnings []error, 
 			continue
 		}
 		fields := actionsFieldNames(actionsCore)
-		switch scopeErr.Operation {
+		switch scopeErr.Operation.Kind {
 		case gh.OpFetchActionsPermissions:
 			fields = actionsFieldNames(actionsCore, actionsSelected)
 		case gh.OpFetchSelectedActionsPermissions:

--- a/internal/alter/actions.go
+++ b/internal/alter/actions.go
@@ -12,6 +12,129 @@ import (
 	"github.com/wimpysworld/tailor/internal/model"
 )
 
+// actionsFieldGroup identifies the endpoint group an Actions policy field
+// belongs to: core fields write through the actions permissions endpoint,
+// selected fields through the selected-actions endpoint.
+type actionsFieldGroup int
+
+const (
+	actionsCore actionsFieldGroup = iota
+	actionsSelected
+)
+
+// writeOperation returns the gh write operation for the group.
+func (g actionsFieldGroup) writeOperation() string {
+	if g == actionsSelected {
+		return gh.OpSetSelectedActionsPermissions
+	}
+	return gh.OpSetActionsPermissions
+}
+
+// actionsFieldSpec ties one Actions policy field name to its endpoint group
+// and the logic that reads the field from an ActionsSettings value.
+type actionsFieldSpec struct {
+	name    string
+	group   actionsFieldGroup
+	set     func(*model.ActionsSettings) bool
+	compare func(declared, live *model.ActionsSettings) (display string, equal bool)
+}
+
+// actionsFieldTable is the single source of Actions field-to-group knowledge.
+// Entry order sets the comparison and skip output order.
+var actionsFieldTable = []actionsFieldSpec{
+	{
+		name:  "enabled",
+		group: actionsCore,
+		set:   func(a *model.ActionsSettings) bool { return a.Enabled != nil },
+		compare: func(declared, live *model.ActionsSettings) (string, bool) {
+			return fmt.Sprint(*declared.Enabled), live.Enabled != nil && *declared.Enabled == *live.Enabled
+		},
+	},
+	{
+		name:  "allowed_actions",
+		group: actionsCore,
+		set:   func(a *model.ActionsSettings) bool { return a.AllowedActions != nil },
+		compare: func(declared, live *model.ActionsSettings) (string, bool) {
+			return *declared.AllowedActions, live.AllowedActions != nil && *declared.AllowedActions == *live.AllowedActions
+		},
+	},
+	{
+		name:  "sha_pinning_required",
+		group: actionsCore,
+		set:   func(a *model.ActionsSettings) bool { return a.SHAPinningRequired != nil },
+		compare: func(declared, live *model.ActionsSettings) (string, bool) {
+			return fmt.Sprint(*declared.SHAPinningRequired), live.SHAPinningRequired != nil && *declared.SHAPinningRequired == *live.SHAPinningRequired
+		},
+	},
+	{
+		name:  "github_owned_allowed",
+		group: actionsSelected,
+		set:   func(a *model.ActionsSettings) bool { return a.GitHubOwnedAllowed != nil },
+		compare: func(declared, live *model.ActionsSettings) (string, bool) {
+			return fmt.Sprint(*declared.GitHubOwnedAllowed), live.GitHubOwnedAllowed != nil && *declared.GitHubOwnedAllowed == *live.GitHubOwnedAllowed
+		},
+	},
+	{
+		name:  "verified_allowed",
+		group: actionsSelected,
+		set:   func(a *model.ActionsSettings) bool { return a.VerifiedAllowed != nil },
+		compare: func(declared, live *model.ActionsSettings) (string, bool) {
+			return fmt.Sprint(*declared.VerifiedAllowed), live.VerifiedAllowed != nil && *declared.VerifiedAllowed == *live.VerifiedAllowed
+		},
+	},
+	{
+		name:  "patterns_allowed",
+		group: actionsSelected,
+		set:   func(a *model.ActionsSettings) bool { return a.PatternsAllowed != nil },
+		compare: func(declared, live *model.ActionsSettings) (string, bool) {
+			desired := slices.Clone(*declared.PatternsAllowed)
+			slices.Sort(desired)
+			equal := false
+			if live.PatternsAllowed != nil {
+				actual := slices.Clone(*live.PatternsAllowed)
+				slices.Sort(actual)
+				equal = slices.Equal(desired, actual)
+			}
+			display := strings.Join(desired, ", ")
+			if len(desired) == 0 {
+				display = "[]"
+			}
+			return display, equal
+		},
+	},
+}
+
+// actionsFieldGroupFor looks up the endpoint group for an Actions field name.
+func actionsFieldGroupFor(field string) (actionsFieldGroup, bool) {
+	for _, spec := range actionsFieldTable {
+		if spec.name == field {
+			return spec.group, true
+		}
+	}
+	return 0, false
+}
+
+// actionsFieldNames returns the field names in the given groups, in table order.
+func actionsFieldNames(groups ...actionsFieldGroup) []string {
+	var names []string
+	for _, spec := range actionsFieldTable {
+		if slices.Contains(groups, spec.group) {
+			names = append(names, spec.name)
+		}
+	}
+	return names
+}
+
+// actionsGroupSet reports whether any field in the group is declared.
+func actionsGroupSet(a *model.ActionsSettings, group actionsFieldGroup) bool {
+	for _, spec := range actionsFieldTable {
+		if spec.group == group && spec.set(a) {
+			return true
+		}
+	}
+	return false
+}
+
 // ProcessActions compares the declared Actions policy against GitHub and
 // applies only endpoint groups that differ.
 func ProcessActions(cfg *config.Config, mode ApplyMode, client *api.RESTClient, owner, name string, hasRepo bool) ([]RepoSettingResult, error) {
@@ -22,7 +145,7 @@ func ProcessActions(cfg *config.Config, mode ApplyMode, client *api.RESTClient, 
 		return nil, nil
 	}
 
-	selected := cfg.Actions.GitHubOwnedAllowed != nil || cfg.Actions.VerifiedAllowed != nil || cfg.Actions.PatternsAllowed != nil
+	selected := actionsGroupSet(cfg.Actions, actionsSelected)
 	live, warnings, err := gh.ReadActionsPolicy(client, owner, name, selected)
 	if err != nil {
 		return nil, err
@@ -45,48 +168,21 @@ func ProcessActions(cfg *config.Config, mode ApplyMode, client *api.RESTClient, 
 }
 
 func actionsConfigured(a *model.ActionsSettings) bool {
-	return a.Enabled != nil || a.AllowedActions != nil || a.SHAPinningRequired != nil ||
-		a.GitHubOwnedAllowed != nil || a.VerifiedAllowed != nil || a.PatternsAllowed != nil
+	return actionsGroupSet(a, actionsCore) || actionsGroupSet(a, actionsSelected)
 }
 
 func compareActions(declared, live *model.ActionsSettings) []RepoSettingResult {
 	var results []RepoSettingResult
-	add := func(field, display string, equal bool) {
+	for _, spec := range actionsFieldTable {
+		if !spec.set(declared) {
+			continue
+		}
+		display, equal := spec.compare(declared, live)
 		category := WouldSet
 		if equal {
 			category = RepoNoChange
 		}
-		results = append(results, RepoSettingResult{Section: "actions", Field: field, Category: category, Value: display})
-	}
-	if declared.Enabled != nil {
-		add("enabled", fmt.Sprint(*declared.Enabled), live.Enabled != nil && *declared.Enabled == *live.Enabled)
-	}
-	if declared.AllowedActions != nil {
-		add("allowed_actions", *declared.AllowedActions, live.AllowedActions != nil && *declared.AllowedActions == *live.AllowedActions)
-	}
-	if declared.SHAPinningRequired != nil {
-		add("sha_pinning_required", fmt.Sprint(*declared.SHAPinningRequired), live.SHAPinningRequired != nil && *declared.SHAPinningRequired == *live.SHAPinningRequired)
-	}
-	if declared.GitHubOwnedAllowed != nil {
-		add("github_owned_allowed", fmt.Sprint(*declared.GitHubOwnedAllowed), live.GitHubOwnedAllowed != nil && *declared.GitHubOwnedAllowed == *live.GitHubOwnedAllowed)
-	}
-	if declared.VerifiedAllowed != nil {
-		add("verified_allowed", fmt.Sprint(*declared.VerifiedAllowed), live.VerifiedAllowed != nil && *declared.VerifiedAllowed == *live.VerifiedAllowed)
-	}
-	if declared.PatternsAllowed != nil {
-		desired := slices.Clone(*declared.PatternsAllowed)
-		slices.Sort(desired)
-		equal := false
-		if live.PatternsAllowed != nil {
-			actual := slices.Clone(*live.PatternsAllowed)
-			slices.Sort(actual)
-			equal = slices.Equal(desired, actual)
-		}
-		display := strings.Join(desired, ", ")
-		if len(desired) == 0 {
-			display = "[]"
-		}
-		add("patterns_allowed", display, equal)
+		results = append(results, RepoSettingResult{Section: "actions", Field: spec.name, Category: category, Value: display})
 	}
 	return results
 }
@@ -97,12 +193,12 @@ func suppressActionsReadWarnings(results []RepoSettingResult, warnings []error, 
 		if !errors.As(warning, &scopeErr) {
 			continue
 		}
-		fields := []string{"enabled", "allowed_actions", "sha_pinning_required"}
+		fields := actionsFieldNames(actionsCore)
 		switch scopeErr.Operation {
 		case gh.OpFetchActionsPermissions:
-			fields = []string{"enabled", "allowed_actions", "sha_pinning_required", "github_owned_allowed", "verified_allowed", "patterns_allowed"}
+			fields = actionsFieldNames(actionsCore, actionsSelected)
 		case gh.OpFetchSelectedActionsPermissions:
-			fields = []string{"github_owned_allowed", "verified_allowed", "patterns_allowed"}
+			fields = actionsFieldNames(actionsSelected)
 			for _, result := range results {
 				if actionsCoreBroadening(result, declared, live) {
 					fields = append(fields, result.Field)
@@ -143,10 +239,14 @@ func actionsChanges(results []RepoSettingResult) (core, selected bool) {
 		if result.Category != WouldSet {
 			continue
 		}
-		switch result.Field {
-		case "enabled", "allowed_actions", "sha_pinning_required":
+		group, ok := actionsFieldGroupFor(result.Field)
+		if !ok {
+			continue
+		}
+		switch group {
+		case actionsCore:
 			core = true
-		case "github_owned_allowed", "verified_allowed", "patterns_allowed":
+		case actionsSelected:
 			selected = true
 		}
 	}

--- a/internal/alter/actions_test.go
+++ b/internal/alter/actions_test.go
@@ -39,7 +39,7 @@ func actionsServer(t *testing.T, writes *atomic.Int32, forbidden bool) *httptest
 }
 
 func TestProcessActionsAbsentMakesNoCalls(t *testing.T) {
-	results, err := alter.ProcessActions(&config.Config{}, alter.Apply, nil, "acme", "widget", true)
+	results, err := alter.ProcessActions(&config.Config{}, alter.Apply, repoTarget(nil, "acme", "widget", true))
 	if err != nil || results != nil {
 		t.Fatalf("ProcessActions() = %v, %v", results, err)
 	}
@@ -54,7 +54,7 @@ func TestProcessActionsCanonicalNoChange(t *testing.T) {
 		Enabled: new(true), AllowedActions: new("selected"), SHAPinningRequired: new(true),
 		GitHubOwnedAllowed: new(true), VerifiedAllowed: new(false), PatternsAllowed: &patterns,
 	}}
-	results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
+	results, err := alter.ProcessActions(cfg, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "acme", "widget", true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,11 +74,11 @@ func TestProcessActionsDryRunAndApply(t *testing.T) {
 	t.Cleanup(server.Close)
 	cfg := &config.Config{Actions: &model.ActionsSettings{Enabled: new(false)}}
 	client := testutil.NewTestClient(t, server)
-	results, err := alter.ProcessActions(cfg, alter.DryRun, client, "acme", "widget", true)
+	results, err := alter.ProcessActions(cfg, alter.DryRun, repoTarget(client, "acme", "widget", true))
 	if err != nil || len(results) != 1 || results[0].Category != alter.WouldSet || writes.Load() != 0 {
 		t.Fatalf("dry run = %+v, %v, writes %d", results, err, writes.Load())
 	}
-	if _, err := alter.ProcessActions(cfg, alter.Apply, client, "acme", "widget", true); err != nil {
+	if _, err := alter.ProcessActions(cfg, alter.Apply, repoTarget(client, "acme", "widget", true)); err != nil {
 		t.Fatal(err)
 	}
 	if writes.Load() != 1 {
@@ -118,7 +118,7 @@ func TestProcessActionsTransitionsToSelectedInOneApply(t *testing.T) {
 		AllowedActions:  new("selected"),
 		PatternsAllowed: &patterns,
 	}}
-	results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
+	results, err := alter.ProcessActions(cfg, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "acme", "widget", true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestProcessActionsAccessErrorProducesSkip(t *testing.T) {
 	server := actionsServer(t, &writes, true)
 	t.Cleanup(server.Close)
 	cfg := &config.Config{Actions: &model.ActionsSettings{Enabled: new(true)}}
-	results, err := alter.ProcessActions(cfg, alter.DryRun, testutil.NewTestClient(t, server), "acme", "widget", true)
+	results, err := alter.ProcessActions(cfg, alter.DryRun, repoTarget(testutil.NewTestClient(t, server), "acme", "widget", true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestProcessActionsUnknownCoreSkipsAllDeclaredPolicyFields(t *testing.T) {
 	cfg := &config.Config{Actions: &model.ActionsSettings{
 		AllowedActions: new("selected"), PatternsAllowed: &patterns,
 	}}
-	results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
+	results, err := alter.ProcessActions(cfg, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "acme", "widget", true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func TestProcessActionsUnknownSelectedPolicyBlocksEnable(t *testing.T) {
 		Enabled: new(true), AllowedActions: new("selected"), SHAPinningRequired: new(false),
 		GitHubOwnedAllowed: new(true), VerifiedAllowed: new(true), PatternsAllowed: &patterns,
 	}}
-	results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
+	results, err := alter.ProcessActions(cfg, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "acme", "widget", true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,7 +243,7 @@ func TestProcessActionsDisablesBeforeChangingSelectedPolicyAndRelaxingSHAPinning
 		Enabled: new(true), AllowedActions: new("selected"), SHAPinningRequired: new(false),
 		GitHubOwnedAllowed: new(true), VerifiedAllowed: new(true), PatternsAllowed: &patterns,
 	}}
-	if _, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true); err != nil {
+	if _, err := alter.ProcessActions(cfg, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "acme", "widget", true)); err != nil {
 		t.Fatal(err)
 	}
 	want := []string{
@@ -285,7 +285,7 @@ func TestProcessActionsSelectedOnlyWriteAccessError(t *testing.T) {
 		Enabled: new(true), AllowedActions: new("selected"), SHAPinningRequired: new(false),
 		GitHubOwnedAllowed: new(true), VerifiedAllowed: new(true), PatternsAllowed: &patterns,
 	}}
-	results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
+	results, err := alter.ProcessActions(cfg, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "acme", "widget", true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +318,7 @@ func TestProcessActionsWriteAccessErrorProducesClearOutput(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 	cfg := &config.Config{Actions: &model.ActionsSettings{Enabled: new(false)}}
-	results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
+	results, err := alter.ProcessActions(cfg, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "acme", "widget", true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -352,7 +352,7 @@ func TestProcessActionsStopsSelectedWriteAfterCoreFailure(t *testing.T) {
 			cfg := &config.Config{Actions: &model.ActionsSettings{
 				Enabled: new(false), AllowedActions: new("selected"), PatternsAllowed: &patterns,
 			}}
-			results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
+			results, err := alter.ProcessActions(cfg, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "acme", "widget", true))
 			if status == http.StatusForbidden && err != nil {
 				t.Fatalf("ProcessActions() error = %v, want access skip", err)
 			}
@@ -392,7 +392,7 @@ func TestProcessActionsTightensSelectedPolicyBeforeEnabling(t *testing.T) {
 	cfg := &config.Config{Actions: &model.ActionsSettings{
 		Enabled: new(true), AllowedActions: new("selected"), PatternsAllowed: &patterns,
 	}}
-	if _, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true); err != nil {
+	if _, err := alter.ProcessActions(cfg, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "acme", "widget", true)); err != nil {
 		t.Fatal(err)
 	}
 	want := []string{
@@ -422,7 +422,7 @@ func TestProcessActionsInitialTransitionSkipSuppressesUnattemptedWrites(t *testi
 	cfg := &config.Config{Actions: &model.ActionsSettings{
 		AllowedActions: new("selected"), PatternsAllowed: &patterns,
 	}}
-	results, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
+	results, err := alter.ProcessActions(cfg, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "acme", "widget", true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -472,7 +472,7 @@ func TestProcessActionsLocalOnlyTransitionFailsClosed(t *testing.T) {
 				t.Cleanup(server.Close)
 				patterns := []string{"acme/*"}
 				cfg := &config.Config{Actions: &model.ActionsSettings{AllowedActions: new("selected"), PatternsAllowed: &patterns}}
-				_, err := alter.ProcessActions(cfg, alter.Apply, testutil.NewTestClient(t, server), "acme", "widget", true)
+				_, err := alter.ProcessActions(cfg, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "acme", "widget", true))
 				if err == nil || !strings.Contains(err.Error(), "while actions are disabled") {
 					t.Fatalf("ProcessActions() error = %v, want explicit disabled transition failure", err)
 				}
@@ -495,7 +495,7 @@ func TestProcessActionsSelectedTransitionDryRunIsReadOnly(t *testing.T) {
 	t.Cleanup(server.Close)
 	patterns := []string{"acme/*"}
 	cfg := &config.Config{Actions: &model.ActionsSettings{AllowedActions: new("selected"), PatternsAllowed: &patterns}}
-	if _, err := alter.ProcessActions(cfg, alter.DryRun, testutil.NewTestClient(t, server), "acme", "widget", true); err != nil {
+	if _, err := alter.ProcessActions(cfg, alter.DryRun, repoTarget(testutil.NewTestClient(t, server), "acme", "widget", true)); err != nil {
 		t.Fatal(err)
 	}
 	if writes.Load() != 0 {

--- a/internal/alter/alter.go
+++ b/internal/alter/alter.go
@@ -84,18 +84,19 @@ func Run(cfg *config.Config, dir string, mode ApplyMode, client *api.RESTClient)
 		Owner:          owner,
 		Name:           name,
 	}
+	target := RepoTarget{Client: client, Owner: owner, Name: name, HasRepo: hasRepo}
 
-	repoResults, err := ProcessRepoSettings(cfg, mode, client, owner, name, hasRepo)
+	repoResults, err := ProcessRepoSettings(cfg, mode, target)
 	if err != nil {
 		return err
 	}
-	actionsResults, err := ProcessActions(cfg, mode, client, owner, name, hasRepo)
+	actionsResults, err := ProcessActions(cfg, mode, target)
 	if err != nil {
 		return err
 	}
 	repoResults = append(repoResults, actionsResults...)
 
-	labelResults, err := ProcessLabels(cfg, mode, client, owner, name, hasRepo)
+	labelResults, err := ProcessLabels(cfg, mode, target)
 	if err != nil {
 		return err
 	}

--- a/internal/alter/format.go
+++ b/internal/alter/format.go
@@ -71,12 +71,8 @@ func FormatOutput(repoResults []RepoSettingResult, labelResults []LabelResult, s
 }
 
 func isActionsPolicyField(field string) bool {
-	switch field {
-	case "enabled", "allowed_actions", "sha_pinning_required", "github_owned_allowed", "verified_allowed", "patterns_allowed":
-		return true
-	default:
-		return false
-	}
+	_, ok := actionsFieldGroupFor(field)
+	return ok
 }
 
 func removeSkippedRepoResults(results []RepoSettingResult) []RepoSettingResult {
@@ -101,11 +97,8 @@ func removeSkippedRepoResults(results []RepoSettingResult) []RepoSettingResult {
 
 func repoSettingOperation(result RepoSettingResult) string {
 	if result.Section == "actions" {
-		switch result.Field {
-		case "enabled", "allowed_actions", "sha_pinning_required":
-			return gh.OpSetActionsPermissions
-		case "github_owned_allowed", "verified_allowed", "patterns_allowed":
-			return gh.OpSetSelectedActionsPermissions
+		if group, ok := actionsFieldGroupFor(result.Field); ok {
+			return group.writeOperation()
 		}
 	}
 	switch result.Field {

--- a/internal/alter/format.go
+++ b/internal/alter/format.go
@@ -42,9 +42,12 @@ func FormatOutput(repoResults []RepoSettingResult, labelResults []LabelResult, s
 		case RepoNoChange:
 			fmt.Fprintf(&b, "%-*s%s.%s (already %s)\n", width, label, section, r.Field, r.Value)
 		case WouldSkipScope:
-			if r.Section == "actions" && isActionsPolicyField(r.Field) {
+			switch {
+			case r.Field == "":
+				fmt.Fprintf(&b, "%-*s%s\n", width, label, r.Operation)
+			case r.Section == "actions" && isActionsPolicyField(r.Field):
 				fmt.Fprintf(&b, "%-*sactions.%s\n", width, label, r.Field)
-			} else {
+			default:
 				fmt.Fprintf(&b, "%-*s%s\n", width, label, r.Field)
 			}
 		}
@@ -58,7 +61,7 @@ func FormatOutput(repoResults []RepoSettingResult, labelResults []LabelResult, s
 		case LabelNoChange:
 			fmt.Fprintf(&b, "%-*slabel.%s (already %s)\n", width, label, r.Name, r.Value)
 		case LabelSkipScope:
-			fmt.Fprintf(&b, "%-*s%s\n", width, label, r.Name)
+			fmt.Fprintf(&b, "%-*s%s\n", width, label, r.Operation)
 		}
 	}
 
@@ -76,10 +79,10 @@ func isActionsPolicyField(field string) bool {
 }
 
 func removeSkippedRepoResults(results []RepoSettingResult) []RepoSettingResult {
-	skipped := make(map[string]bool)
+	skipped := make(map[gh.OperationKind]bool)
 	for _, result := range results {
-		if result.Category == WouldSkipScope {
-			skipped[result.Field] = true
+		if result.Category == WouldSkipScope && result.Operation.Kind != gh.OpNone {
+			skipped[result.Operation.Kind] = true
 		}
 	}
 	if len(skipped) == 0 {
@@ -88,14 +91,16 @@ func removeSkippedRepoResults(results []RepoSettingResult) []RepoSettingResult {
 
 	filtered := make([]RepoSettingResult, 0, len(results))
 	for _, result := range results {
-		if result.Category != WouldSet || !skipped[repoSettingOperation(result)] {
+		if result.Category != WouldSet || !skipped[repoSettingWriteKind(result)] {
 			filtered = append(filtered, result)
 		}
 	}
 	return filtered
 }
 
-func repoSettingOperation(result RepoSettingResult) string {
+// repoSettingWriteKind returns the kind of the write operation that applies
+// the result's field.
+func repoSettingWriteKind(result RepoSettingResult) gh.OperationKind {
 	if result.Section == "actions" {
 		if group, ok := actionsFieldGroupFor(result.Field); ok {
 			return group.writeOperation()
@@ -103,11 +108,11 @@ func repoSettingOperation(result RepoSettingResult) string {
 	}
 	switch result.Field {
 	case "private_vulnerability_reporting_enabled":
-		return gh.SecurityFeatureOp(result.Value == "true", gh.FeaturePrivateVulnerabilityReporting)
+		return gh.OpSetPrivateVulnerabilityReporting
 	case "vulnerability_alerts_enabled":
-		return gh.SecurityFeatureOp(result.Value == "true", gh.FeatureVulnerabilityAlerts)
+		return gh.OpSetVulnerabilityAlerts
 	case "automated_security_fixes_enabled":
-		return gh.SecurityFeatureOp(result.Value == "true", gh.FeatureAutomatedSecurityFixes)
+		return gh.OpSetAutomatedSecurityFixes
 	case "topics":
 		return gh.OpSetTopics
 	case "default_workflow_permissions", "can_approve_pull_request_reviews":
@@ -121,7 +126,7 @@ func removeSkippedLabelResults(results []LabelResult) []LabelResult {
 	skipped := make(map[string]bool)
 	for _, result := range results {
 		if result.Category == LabelSkipScope {
-			skipped[result.Name] = true
+			skipped[result.Operation.Label] = true
 		}
 	}
 	if len(skipped) == 0 {
@@ -130,14 +135,8 @@ func removeSkippedLabelResults(results []LabelResult) []LabelResult {
 
 	filtered := make([]LabelResult, 0, len(results))
 	for _, result := range results {
-		operation := ""
-		switch result.Category {
-		case WouldCreate:
-			operation = gh.CreateLabelOp(result.Name)
-		case WouldUpdate:
-			operation = gh.UpdateLabelOp(result.Name)
-		}
-		if !skipped[operation] {
+		actionable := result.Category == WouldCreate || result.Category == WouldUpdate
+		if !actionable || !skipped[result.Name] {
 			filtered = append(filtered, result)
 		}
 	}
@@ -225,14 +224,23 @@ func labelWidth(repos []RepoSettingResult, labels []LabelResult, swatches []Swat
 }
 
 // sortRepoResults returns a sorted copy: actionable (WouldSet) before
-// informational (RepoNoChange), lexicographic by field within each group.
+// informational (RepoNoChange), lexicographic by sort key within each group.
 func sortRepoResults(results []RepoSettingResult) []RepoSettingResult {
 	return slices.SortedStableFunc(slices.Values(results), func(a, b RepoSettingResult) int {
 		if c := cmp.Compare(repoOrder(a.Category), repoOrder(b.Category)); c != 0 {
 			return c
 		}
-		return cmp.Compare(a.Field, b.Field)
+		return cmp.Compare(repoSortKey(a), repoSortKey(b))
 	})
+}
+
+// repoSortKey returns the field name, or the skipped operation text for
+// write-skip results, which have no field name.
+func repoSortKey(r RepoSettingResult) string {
+	if r.Field != "" {
+		return r.Field
+	}
+	return r.Operation.String()
 }
 
 // repoOrder returns the sort priority for a RepoSettingCategory.
@@ -261,14 +269,23 @@ func sortSwatchResults(results []SwatchResult) []SwatchResult {
 }
 
 // sortLabelResults returns a sorted copy: actionable (WouldCreate, WouldUpdate)
-// before informational (LabelNoChange), lexicographic by name within each group.
+// before informational (LabelNoChange), lexicographic by sort key within each group.
 func sortLabelResults(results []LabelResult) []LabelResult {
 	return slices.SortedStableFunc(slices.Values(results), func(a, b LabelResult) int {
 		if c := cmp.Compare(labelOrder(a.Category), labelOrder(b.Category)); c != 0 {
 			return c
 		}
-		return cmp.Compare(a.Name, b.Name)
+		return cmp.Compare(labelSortKey(a), labelSortKey(b))
 	})
+}
+
+// labelSortKey returns the label name, or the skipped operation text for
+// skip results, which have no label name.
+func labelSortKey(r LabelResult) string {
+	if r.Name != "" {
+		return r.Name
+	}
+	return r.Operation.String()
 }
 
 // labelOrder returns the sort priority for a LabelCategory.

--- a/internal/alter/format_test.go
+++ b/internal/alter/format_test.go
@@ -3,6 +3,8 @@ package alter
 import (
 	"fmt"
 	"testing"
+
+	"github.com/wimpysworld/tailor/internal/gh"
 )
 
 func TestFormatOutputSwatchesOnly(t *testing.T) {
@@ -271,7 +273,7 @@ func TestFormatOutputSkipCategories(t *testing.T) {
 	repos := []RepoSettingResult{
 		{Field: "has_wiki", Category: WouldSet, Value: "false"},
 		{Field: "has_issues", Category: RepoNoChange, Value: "true"},
-		{Field: "patch repo settings", Category: WouldSkipScope, Value: "insufficient scope"},
+		{Operation: gh.Op(gh.OpPatchRepoSettings), Category: WouldSkipScope, Value: "insufficient scope"},
 	}
 
 	got := FormatOutput(repos, nil, nil, DryRun)
@@ -287,11 +289,11 @@ func TestFormatOutputSkipCategories(t *testing.T) {
 func TestFormatOutputActionsSkipOperationHasNoSectionPrefix(t *testing.T) {
 	repos := []RepoSettingResult{
 		{Section: "actions", Field: "enabled", Category: WouldSkipScope},
-		{Section: "actions", Field: "disable actions for fail-closed policy update", Category: WouldSkipScope},
+		{Section: "actions", Operation: gh.Op(gh.OpDisableActionsForPolicyUpdate), Category: WouldSkipScope},
 	}
 
 	got := FormatOutput(repos, nil, nil, DryRun)
-	want := "would skip (insufficient scope):     disable actions for fail-closed policy update\n" +
+	want := "would skip (insufficient scope):     disable actions for selected policy update\n" +
 		"would skip (insufficient scope):     actions.enabled\n"
 	if got != want {
 		t.Errorf("FormatOutput actions skip operations:\ngot:\n%s\nwant:\n%s", got, want)
@@ -302,7 +304,7 @@ func TestFormatOutputSkipSorting(t *testing.T) {
 	repos := []RepoSettingResult{
 		{Field: "has_wiki", Category: RepoNoChange, Value: "false"},
 		{Field: "description", Category: WouldSet, Value: "My project"},
-		{Field: "patch repo settings", Category: WouldSkipScope, Value: "scope error"},
+		{Operation: gh.Op(gh.OpPatchRepoSettings), Category: WouldSkipScope, Value: "scope error"},
 	}
 
 	got := FormatOutput(repos, nil, nil, DryRun)
@@ -371,13 +373,13 @@ func TestFormatOutputDynamicWidthWithSkippedSwatches(t *testing.T) {
 func TestFormatOutputLabelSkipAnnotations(t *testing.T) {
 	labels := []LabelResult{
 		{Name: "bug", Category: WouldCreate, Value: "#d73a4a"},
-		{Name: "enhancement", Category: LabelSkipScope, Annotation: "token missing required scope"},
+		{Operation: gh.CreateLabelOp("enhancement"), Category: LabelSkipScope, Annotation: "token missing required scope"},
 	}
 
 	got := FormatOutput(nil, labels, nil, DryRun)
 	// Widest label is "would skip (insufficient scope: token missing required scope):" = 62 + 1 = 63.
 	want := "would create:                                                  label.bug = #d73a4a\n" +
-		"would skip (insufficient scope: token missing required scope): enhancement\n"
+		"would skip (insufficient scope: token missing required scope): create label \"enhancement\"\n"
 
 	if got != want {
 		t.Errorf("FormatOutput label skip annotations:\ngot:\n%s\nwant:\n%s", got, want)
@@ -406,7 +408,7 @@ func TestFormatOutputSkipAnnotationColumnWidth(t *testing.T) {
 func TestFormatOutputSkipWithoutAnnotation(t *testing.T) {
 	// Skip results without annotations still render with the base label.
 	repos := []RepoSettingResult{
-		{Field: "patch repo settings", Category: WouldSkipScope},
+		{Operation: gh.Op(gh.OpPatchRepoSettings), Category: WouldSkipScope},
 	}
 
 	got := FormatOutput(repos, nil, nil, DryRun)
@@ -481,11 +483,11 @@ func TestFormatOutputApplyModes(t *testing.T) {
 func TestFormatOutputWriteModesOmitSkippedActions(t *testing.T) {
 	repos := []RepoSettingResult{
 		{Field: "topics", Category: WouldSet, Value: "go, cli"},
-		{Field: "set topics", Category: WouldSkipScope, Annotation: "token missing required scope"},
+		{Operation: gh.Op(gh.OpSetTopics), Category: WouldSkipScope, Annotation: "token missing required scope"},
 	}
 	labels := []LabelResult{
 		{Name: "bug", Category: WouldCreate, Value: "#d73a4a"},
-		{Name: "create label \"bug\"", Category: LabelSkipScope, Annotation: "token missing required scope"},
+		{Operation: gh.CreateLabelOp("bug"), Category: LabelSkipScope, Annotation: "token missing required scope"},
 	}
 	want := "would skip (insufficient scope: token missing required scope): set topics\n" +
 		"would skip (insufficient scope: token missing required scope): create label \"bug\"\n"
@@ -503,11 +505,11 @@ func TestFormatOutputWriteModesOmitSkippedActions(t *testing.T) {
 func TestFormatOutputWriteModesOmitSkippedSecuritySettings(t *testing.T) {
 	repos := []RepoSettingResult{
 		{Field: "private_vulnerability_reporting_enabled", Category: WouldSet, Value: "true"},
-		{Field: "enable private vulnerability reporting", Category: WouldSkipScope, Annotation: "token missing required scope"},
+		{Operation: gh.SecurityFeatureOp(true, gh.OpSetPrivateVulnerabilityReporting), Category: WouldSkipScope, Annotation: "token missing required scope"},
 		{Field: "vulnerability_alerts_enabled", Category: WouldSet, Value: "false"},
-		{Field: "disable vulnerability alerts", Category: WouldSkipScope, Annotation: "token missing required scope"},
+		{Operation: gh.SecurityFeatureOp(false, gh.OpSetVulnerabilityAlerts), Category: WouldSkipScope, Annotation: "token missing required scope"},
 		{Field: "automated_security_fixes_enabled", Category: WouldSet, Value: "true"},
-		{Field: "enable automated security fixes", Category: WouldSkipScope, Annotation: "token missing required scope"},
+		{Operation: gh.SecurityFeatureOp(true, gh.OpSetAutomatedSecurityFixes), Category: WouldSkipScope, Annotation: "token missing required scope"},
 	}
 	want := "would skip (insufficient scope: token missing required scope): disable vulnerability alerts\n" +
 		"would skip (insufficient scope: token missing required scope): enable automated security fixes\n" +

--- a/internal/alter/labels.go
+++ b/internal/alter/labels.go
@@ -22,13 +22,15 @@ const (
 )
 
 // LabelResult records the label name, category, and display value for one
-// label entry. Annotation carries optional context for skip categories,
-// embedded in the label (e.g. "token missing required scope").
+// label entry. Skip results leave Name empty and carry the skipped Operation
+// instead. Annotation carries optional context for skip categories, embedded
+// in the label (e.g. "token missing required scope").
 type LabelResult struct {
 	Name       string
 	Category   LabelCategory
 	Value      string
 	Annotation string
+	Operation  gh.Operation
 }
 
 // ProcessLabels compares declared labels against live labels and optionally
@@ -70,7 +72,7 @@ func labelSkippedToResults(ar *gh.ApplyResult) []LabelResult {
 	var results []LabelResult
 	for _, sk := range ar.Skipped {
 		results = append(results, LabelResult{
-			Name:       sk.Operation,
+			Operation:  sk.Operation,
 			Category:   LabelSkipScope,
 			Annotation: skipAnnotation,
 		})

--- a/internal/alter/labels.go
+++ b/internal/alter/labels.go
@@ -2,10 +2,8 @@ package alter
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
-	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/wimpysworld/tailor/internal/config"
 	"github.com/wimpysworld/tailor/internal/gh"
 	"github.com/wimpysworld/tailor/internal/model"
@@ -35,17 +33,16 @@ type LabelResult struct {
 
 // ProcessLabels compares declared labels against live labels and optionally
 // applies them. Returns results for output formatting.
-func ProcessLabels(cfg *config.Config, mode ApplyMode, client *api.RESTClient, owner, name string, hasRepo bool) ([]LabelResult, error) {
+func ProcessLabels(cfg *config.Config, mode ApplyMode, target RepoTarget) ([]LabelResult, error) {
 	if len(cfg.Labels) == 0 {
 		return nil, nil
 	}
 
-	if !hasRepo {
-		fmt.Fprintln(os.Stderr, "No GitHub repository context found. Labels will be applied once a remote is configured.")
+	if target.missingRepo("Labels") {
 		return nil, nil
 	}
 
-	current, err := gh.ReadLabels(client, owner, name)
+	current, err := gh.ReadLabels(target.Client, target.Owner, target.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +50,7 @@ func ProcessLabels(cfg *config.Config, mode ApplyMode, client *api.RESTClient, o
 	results := compareLabels(cfg.Labels, current)
 
 	if mode.ShouldWrite() && hasLabelChanges(results) {
-		applyResult, err := gh.ApplyLabels(client, owner, name, cfg.Labels, current)
+		applyResult, err := gh.ApplyLabels(target.Client, target.Owner, target.Name, cfg.Labels, current)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/alter/labels_test.go
+++ b/internal/alter/labels_test.go
@@ -64,7 +64,7 @@ func failingLabelsServer() *httptest.Server {
 
 func TestProcessLabelsNoLabels(t *testing.T) {
 	cfg := &config.Config{}
-	results, err := alter.ProcessLabels(cfg, alter.DryRun, nil, "", "", false)
+	results, err := alter.ProcessLabels(cfg, alter.DryRun, repoTarget(nil, "", "", false))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestProcessLabelsNoRepoContext(t *testing.T) {
 	var err error
 
 	output := captureStderr(t, func() {
-		results, err = alter.ProcessLabels(cfg, alter.DryRun, nil, "", "", false)
+		results, err = alter.ProcessLabels(cfg, alter.DryRun, repoTarget(nil, "", "", false))
 	})
 
 	if err != nil {
@@ -116,7 +116,7 @@ func TestProcessLabelsWouldCreate(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessLabels(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessLabels(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestProcessLabelsWouldUpdate(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessLabels(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessLabels(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestProcessLabelsNoChange(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessLabels(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessLabels(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestProcessLabelsCaseInsensitiveMatch(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessLabels(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessLabels(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestProcessLabelsApplyCallsAPI(t *testing.T) {
 		},
 	}
 
-	_, err := alter.ProcessLabels(cfg, alter.Apply, client, "testowner", "testrepo", true)
+	_, err := alter.ProcessLabels(cfg, alter.Apply, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestProcessLabelsRecutCallsAPI(t *testing.T) {
 		},
 	}
 
-	_, err := alter.ProcessLabels(cfg, alter.Recut, client, "testowner", "testrepo", true)
+	_, err := alter.ProcessLabels(cfg, alter.Recut, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestProcessLabelsDryRunDoesNotCallAPI(t *testing.T) {
 		},
 	}
 
-	_, err := alter.ProcessLabels(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	_, err := alter.ProcessLabels(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -306,7 +306,7 @@ func TestProcessLabelsNoApplyWhenAllMatch(t *testing.T) {
 		},
 	}
 
-	_, err := alter.ProcessLabels(cfg, alter.Apply, client, "testowner", "testrepo", true)
+	_, err := alter.ProcessLabels(cfg, alter.Apply, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -328,7 +328,7 @@ func TestProcessLabelsErrorPropagated(t *testing.T) {
 		},
 	}
 
-	_, err := alter.ProcessLabels(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	_, err := alter.ProcessLabels(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err == nil {
 		t.Fatal("expected error from API failure, got nil")
 	}
@@ -353,7 +353,7 @@ func TestProcessLabelsMixedResults(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessLabels(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessLabels(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -388,7 +388,7 @@ func TestProcessLabelsUpdateDescriptionOnly(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessLabels(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessLabels(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -416,7 +416,7 @@ func TestProcessLabelsColorCaseInsensitive(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessLabels(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessLabels(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -445,7 +445,7 @@ func TestProcessLabelsCasingOnlyApplyCallsAPI(t *testing.T) {
 		},
 	}
 
-	_, err := alter.ProcessLabels(cfg, alter.Apply, client, "testowner", "testrepo", true)
+	_, err := alter.ProcessLabels(cfg, alter.Apply, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -471,7 +471,7 @@ func TestProcessLabelsExactNameNoChange(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessLabels(cfg, alter.Apply, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessLabels(cfg, alter.Apply, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -536,7 +536,7 @@ func TestProcessLabelsPartialApplicationWithSkipped(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessLabels(cfg, alter.Apply, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessLabels(cfg, alter.Apply, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -604,7 +604,7 @@ func TestProcessLabelsSkipDoesNotAbort(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessLabels(cfg, alter.Apply, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessLabels(cfg, alter.Apply, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/alter/settings.go
+++ b/internal/alter/settings.go
@@ -24,14 +24,16 @@ const (
 )
 
 // RepoSettingResult records the field name, category, and display value for one
-// repository setting. Annotation carries optional context for skip categories,
-// embedded in the label (e.g. "token missing required scope").
+// repository setting. Skip results for write operations leave Field empty and
+// carry the skipped Operation instead. Annotation carries optional context for
+// skip categories, embedded in the label (e.g. "token missing required scope").
 type RepoSettingResult struct {
 	Section    string
 	Field      string
 	Category   RepoSettingCategory
 	Value      string
 	Annotation string
+	Operation  gh.Operation
 }
 
 // ProcessRepoSettings compares declared settings against live settings
@@ -125,7 +127,7 @@ func skippedToResults(ar *gh.ApplyResult) []RepoSettingResult {
 	var results []RepoSettingResult
 	for _, sk := range ar.Skipped {
 		results = append(results, RepoSettingResult{
-			Field:      sk.Operation,
+			Operation:  sk.Operation,
 			Category:   WouldSkipScope,
 			Annotation: skipAnnotation,
 		})
@@ -178,9 +180,9 @@ func compareSettings(declared, live *model.RepositorySettings) []RepoSettingResu
 	return results
 }
 
-// readWarningOperationFields maps read-path operation names from
+// readWarningOperationFields maps read-path operation kinds from
 // ErrInsufficientScope to the config field names they affect.
-var readWarningOperationFields = map[string][]string{
+var readWarningOperationFields = map[gh.OperationKind][]string{
 	gh.OpFetchVulnerabilityAlerts:           {"vulnerability_alerts_enabled"},
 	gh.OpFetchAutomatedSecurityFixes:        {"automated_security_fixes_enabled"},
 	gh.OpFetchPrivateVulnerabilityReporting: {"private_vulnerability_reporting_enabled"},
@@ -262,13 +264,13 @@ func declaredFieldNames(s *model.RepositorySettings) map[string]bool {
 	return names
 }
 
-// warningOperation extracts the Operation field from a read-path warning.
-func warningOperation(err error) string {
+// warningOperation extracts the operation kind from a read-path warning.
+func warningOperation(err error) gh.OperationKind {
 	var scopeErr *gh.ErrInsufficientScope
 	if errors.As(err, &scopeErr) {
-		return scopeErr.Operation
+		return scopeErr.Operation.Kind
 	}
-	return ""
+	return gh.OpNone
 }
 
 // hasChanges returns true if any result is WouldSet.

--- a/internal/alter/settings.go
+++ b/internal/alter/settings.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/wimpysworld/tailor/internal/config"
 	"github.com/wimpysworld/tailor/internal/gh"
 	"github.com/wimpysworld/tailor/internal/model"
@@ -38,17 +37,16 @@ type RepoSettingResult struct {
 
 // ProcessRepoSettings compares declared settings against live settings
 // and optionally applies them. Returns results for output formatting.
-func ProcessRepoSettings(cfg *config.Config, mode ApplyMode, client *api.RESTClient, owner, name string, hasRepo bool) ([]RepoSettingResult, error) {
+func ProcessRepoSettings(cfg *config.Config, mode ApplyMode, target RepoTarget) ([]RepoSettingResult, error) {
 	if cfg.Repository == nil {
 		return nil, nil
 	}
 
-	if !hasRepo {
-		fmt.Fprintln(os.Stderr, "No GitHub repository context found. Repository settings will be applied once a remote is configured.")
+	if target.missingRepo("Repository settings") {
 		return nil, nil
 	}
 
-	live, warnings, err := gh.ReadRepoSettings(client, owner, name)
+	live, warnings, err := gh.ReadRepoSettings(target.Client, target.Owner, target.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +81,7 @@ func ProcessRepoSettings(cfg *config.Config, mode ApplyMode, client *api.RESTCli
 	results = append(results, skipResults...)
 
 	if mode.ShouldWrite() && hasChanges(results) {
-		applyResult, err := gh.ApplyRepoSettingsWithCurrent(client, owner, name, settingsForApply(cfg.Repository, results), live)
+		applyResult, err := gh.ApplyRepoSettingsWithCurrent(target.Client, target.Owner, target.Name, settingsForApply(cfg.Repository, results), live)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/alter/settings_test.go
+++ b/internal/alter/settings_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/wimpysworld/tailor/internal/alter"
 	"github.com/wimpysworld/tailor/internal/config"
+	"github.com/wimpysworld/tailor/internal/gh"
 	"github.com/wimpysworld/tailor/internal/ghfake"
 	"github.com/wimpysworld/tailor/internal/model"
 	"github.com/wimpysworld/tailor/internal/testutil"
@@ -970,7 +971,7 @@ func TestProcessRepoSettingsPatch403ScopeProducesSkipScope(t *testing.T) {
 
 	var foundScopeSkip bool
 	for _, r := range results {
-		if r.Category == alter.WouldSkipScope && r.Field == "patch repo settings" {
+		if r.Category == alter.WouldSkipScope && r.Operation == gh.Op(gh.OpPatchRepoSettings) {
 			foundScopeSkip = true
 		}
 	}

--- a/internal/alter/settings_test.go
+++ b/internal/alter/settings_test.go
@@ -97,7 +97,7 @@ func failingSettingsServer() *httptest.Server {
 
 func TestProcessRepoSettingsNilRepository(t *testing.T) {
 	cfg := &config.Config{}
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, nil, "", "", false)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(nil, "", "", false))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestProcessRepoSettingsNoRepoContext(t *testing.T) {
 	var err error
 
 	output := captureStderr(t, func() {
-		results, err = alter.ProcessRepoSettings(cfg, alter.DryRun, nil, "", "", false)
+		results, err = alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(nil, "", "", false))
 	})
 
 	if err != nil {
@@ -149,7 +149,7 @@ func TestProcessRepoSettingsWouldSetWhenDiffer(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestProcessRepoSettingsNoChangeWhenMatch(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestProcessRepoSettingsApplyCallsAPI(t *testing.T) {
 		},
 	}
 
-	_, err := alter.ProcessRepoSettings(cfg, alter.Apply, client, "testowner", "testrepo", true)
+	_, err := alter.ProcessRepoSettings(cfg, alter.Apply, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestProcessRepoSettingsRecutCallsAPI(t *testing.T) {
 		},
 	}
 
-	_, err := alter.ProcessRepoSettings(cfg, alter.Recut, client, "testowner", "testrepo", true)
+	_, err := alter.ProcessRepoSettings(cfg, alter.Recut, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestProcessRepoSettingsDryRunDoesNotCallAPI(t *testing.T) {
 		},
 	}
 
-	_, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	_, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -287,7 +287,7 @@ func TestProcessRepoSettingsNoApplyWhenAllMatch(t *testing.T) {
 		},
 	}
 
-	_, err := alter.ProcessRepoSettings(cfg, alter.Apply, client, "testowner", "testrepo", true)
+	_, err := alter.ProcessRepoSettings(cfg, alter.Apply, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestProcessRepoSettingsErrorPropagated(t *testing.T) {
 		},
 	}
 
-	_, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	_, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err == nil {
 		t.Fatal("expected error from API failure, got nil")
 	}
@@ -337,7 +337,7 @@ func TestProcessRepoSettingsMixedResults(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -372,7 +372,7 @@ func TestProcessRepoSettingsStringFieldValues(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -417,7 +417,7 @@ func TestProcessRepoSettingsTopicsNoChange(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -450,7 +450,7 @@ func TestProcessRepoSettingsTopicsWouldSet(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -486,7 +486,7 @@ func TestProcessRepoSettingsTopicsEmptyVsNil(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -520,7 +520,7 @@ func TestProcessRepoSettingsTopicsEmptyMatchesEmpty(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -547,7 +547,7 @@ func TestProcessRepoSettingsDefaultWorkflowPermissionsNoChange(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -580,7 +580,7 @@ func TestProcessRepoSettingsDefaultWorkflowPermissionsWouldSet(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -613,7 +613,7 @@ func TestProcessRepoSettingsCanApprovePullRequestReviewsNoChange(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -641,7 +641,7 @@ func TestProcessRepoSettingsSecurityFeaturesDryRun(t *testing.T) {
 		AutomatedSecurityFixesEnabled:     new(true),
 	}}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("ProcessRepoSettings() error: %v", err)
 	}
@@ -691,7 +691,7 @@ func TestProcessRepoSettingsAppliesOnlyChangedSecurityEndpoints(t *testing.T) {
 		VulnerabilityAlertsEnabled:        new(true),
 		AutomatedSecurityFixesEnabled:     new(true),
 	}}
-	if _, err := alter.ProcessRepoSettings(cfg, alter.Apply, testutil.NewTestClient(t, server), "testowner", "testrepo", true); err != nil {
+	if _, err := alter.ProcessRepoSettings(cfg, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "testowner", "testrepo", true)); err != nil {
 		t.Fatal(err)
 	}
 	if patchWrites.Load() != 1 || securityWrites.Load() != 0 {
@@ -740,7 +740,7 @@ func TestProcessRepoSettingsAutomatedFixesPrerequisiteWarning(t *testing.T) {
 			}}
 			var err error
 			output := captureStderr(t, func() {
-				_, err = alter.ProcessRepoSettings(cfg, alter.DryRun, testutil.NewTestClient(t, server), "testowner", "testrepo", true)
+				_, err = alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(testutil.NewTestClient(t, server), "testowner", "testrepo", true))
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -774,7 +774,7 @@ func TestProcessRepoSettingsSecurityReadAccessWarning(t *testing.T) {
 		PrivateVulnerabilityReportEnabled: new(true),
 	}}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("ProcessRepoSettings() error: %v", err)
 	}
@@ -840,7 +840,7 @@ func TestProcessRepoSettingsUnknownSecurityPrerequisiteSkipsDependent(t *testing
 			}))
 			t.Cleanup(server.Close)
 
-			results, err := alter.ProcessRepoSettings(&config.Config{Repository: tt.settings}, alter.Apply, testutil.NewTestClient(t, server), "testowner", "testrepo", true)
+			results, err := alter.ProcessRepoSettings(&config.Config{Repository: tt.settings}, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "testowner", "testrepo", true))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -910,7 +910,7 @@ func TestProcessRepoSettingsSkippedSecurityWriteSkipsDependentOutput(t *testing.
 			}))
 			t.Cleanup(server.Close)
 
-			results, err := alter.ProcessRepoSettings(&config.Config{Repository: tt.settings}, alter.Apply, testutil.NewTestClient(t, server), "testowner", "testrepo", true)
+			results, err := alter.ProcessRepoSettings(&config.Config{Repository: tt.settings}, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "testowner", "testrepo", true))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -964,7 +964,7 @@ func TestProcessRepoSettingsPatch403ScopeProducesSkipScope(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.Apply, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.Apply, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1024,7 +1024,7 @@ func TestProcessRepoSettingsReadPath403WorkflowProducesSkipScope(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1054,7 +1054,7 @@ func TestProcessRepoSettingsReadPath403DoesNotProduceWouldSet(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1092,7 +1092,7 @@ func TestProcessRepoSettingsCanApprovePullRequestReviewsWouldSet(t *testing.T) {
 		},
 	}
 
-	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, client, "testowner", "testrepo", true)
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1136,7 +1136,7 @@ func TestProcessRepoSettingsDoesNotRewriteDisabledSecurityFixes(t *testing.T) {
 		VulnerabilityAlertsEnabled:    new(false),
 		AutomatedSecurityFixesEnabled: new(false),
 	}
-	if _, err := alter.ProcessRepoSettings(&config.Config{Repository: settings}, alter.Apply, testutil.NewTestClient(t, server), "testowner", "testrepo", true); err != nil {
+	if _, err := alter.ProcessRepoSettings(&config.Config{Repository: settings}, alter.Apply, repoTarget(testutil.NewTestClient(t, server), "testowner", "testrepo", true)); err != nil {
 		t.Fatal(err)
 	}
 	if len(paths) != 1 || paths[0] != "/repos/testowner/testrepo/vulnerability-alerts" {

--- a/internal/alter/target.go
+++ b/internal/alter/target.go
@@ -1,0 +1,29 @@
+package alter
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+)
+
+// RepoTarget identifies the GitHub repository that the alter processors act
+// on: the API client, the owner and name, and whether a repository context
+// exists.
+type RepoTarget struct {
+	Client  *api.RESTClient
+	Owner   string
+	Name    string
+	HasRepo bool
+}
+
+// missingRepo reports whether no repository context exists. When the context
+// is missing it warns that the named subject is deferred until a remote is
+// configured.
+func (t RepoTarget) missingRepo(subject string) bool {
+	if t.HasRepo {
+		return false
+	}
+	fmt.Fprintf(os.Stderr, "No GitHub repository context found. %s will be applied once a remote is configured.\n", subject)
+	return true
+}

--- a/internal/alter/target_test.go
+++ b/internal/alter/target_test.go
@@ -1,0 +1,11 @@
+package alter_test
+
+import (
+	"github.com/cli/go-gh/v2/pkg/api"
+	"github.com/wimpysworld/tailor/internal/alter"
+)
+
+// repoTarget builds the RepoTarget that the Process functions take.
+func repoTarget(client *api.RESTClient, owner, name string, hasRepo bool) alter.RepoTarget {
+	return alter.RepoTarget{Client: client, Owner: owner, Name: name, HasRepo: hasRepo}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -80,7 +80,9 @@ func ValidateActions(cfg *Config) error {
 	}
 	if len(cfg.Actions.Extra) > 0 {
 		keys := slices.Sorted(maps.Keys(cfg.Actions.Extra))
-		return fmt.Errorf("unrecognised actions setting %q in config; valid settings: allowed_actions, enabled, github_owned_allowed, patterns_allowed, sha_pinning_required, verified_allowed", keys[0])
+		valid := settingNames(model.ActionsSettingFields(nil))
+		return fmt.Errorf("unrecognised actions setting %q in config; valid settings: %s",
+			keys[0], strings.Join(valid, ", "))
 	}
 
 	a := cfg.Actions
@@ -167,7 +169,11 @@ func ValidateLabels(cfg *Config) error {
 // repoSettingNames returns the sorted list of recognised yaml tag names from
 // RepositorySettings, excluding the inline Extra field.
 func repoSettingNames() []string {
-	fields := model.RepositorySettingFields(nil)
+	return settingNames(model.RepositorySettingFields(nil))
+}
+
+// settingNames returns the sorted yaml tag names for fields.
+func settingNames(fields []model.RepositorySettingField) []string {
 	names := make([]string, 0, len(fields))
 	for _, field := range fields {
 		names = append(names, field.YAMLKey)

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -4,20 +4,73 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 	"text/template"
+
+	"github.com/wimpysworld/tailor/internal/model"
 )
 
 // yamlSpecial lists characters that require quoting in YAML values.
 const yamlSpecial = ":{}[]#&*!|>'\"%@`\n"
 
+// yamlVal quotes v when it contains YAML special characters, surrounding
+// whitespace, or is empty.
+func yamlVal(v string) string {
+	if strings.ContainsAny(v, yamlSpecial) || v != strings.TrimSpace(v) || v == "" {
+		return fmt.Sprintf("%q", v)
+	}
+	return v
+}
+
+// settingLines renders one "  key: value" line per set field. Scalar fields
+// keep struct order; list fields follow them, preserving the output order
+// that places topics last. Homepage stays unquoted because yamlVal would
+// quote the ":" in URLs.
+func settingLines(fields []model.RepositorySettingField) []string {
+	var lines, lists []string
+	for _, field := range fields {
+		if !field.Set {
+			continue
+		}
+		v := field.Value.Elem()
+		switch v.Kind() {
+		case reflect.String:
+			val := v.String()
+			if field.YAMLKey != "homepage" {
+				val = yamlVal(val)
+			}
+			lines = append(lines, fmt.Sprintf("  %s: %s", field.YAMLKey, val))
+		case reflect.Bool:
+			lines = append(lines, fmt.Sprintf("  %s: %t", field.YAMLKey, v.Bool()))
+		case reflect.Slice:
+			lists = append(lists, listLines(field.YAMLKey, v))
+		}
+	}
+	return append(lines, lists...)
+}
+
+// listLines renders a string-list field as a block sequence, or [] when empty.
+func listLines(key string, v reflect.Value) string {
+	if v.Len() == 0 {
+		return fmt.Sprintf("  %s: []", key)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "  %s:", key)
+	for i := range v.Len() {
+		fmt.Fprintf(&b, "\n    - %s", yamlVal(v.Index(i).String()))
+	}
+	return b.String()
+}
+
 // templateFuncs provides helpers for the config template.
 var templateFuncs = template.FuncMap{
-	"yamlVal": func(v string) string {
-		if strings.ContainsAny(v, yamlSpecial) || v != strings.TrimSpace(v) || v == "" {
-			return fmt.Sprintf("%q", v)
-		}
-		return v
+	"yamlVal": yamlVal,
+	"repositoryLines": func(r *model.RepositorySettings) []string {
+		return settingLines(model.RepositorySettingFields(r))
+	},
+	"actionsLines": func(a *model.ActionsSettings) []string {
+		return settingLines(model.ActionsSettingFields(a))
 	},
 }
 
@@ -31,102 +84,15 @@ license: {{ .License }}
 {{- if .Repository }}
 
 repository:
-{{- if .Repository.Description }}
-  description: {{ yamlVal .Repository.Description }}
-{{- end }}
-{{- if .Repository.Homepage }}
-  homepage: {{ .Repository.Homepage }}
-{{- end }}
-{{- if .Repository.HasWiki }}
-  has_wiki: {{ .Repository.HasWiki }}
-{{- end }}
-{{- if .Repository.HasDiscussions }}
-  has_discussions: {{ .Repository.HasDiscussions }}
-{{- end }}
-{{- if .Repository.HasProjects }}
-  has_projects: {{ .Repository.HasProjects }}
-{{- end }}
-{{- if .Repository.HasIssues }}
-  has_issues: {{ .Repository.HasIssues }}
-{{- end }}
-{{- if .Repository.AllowMergeCommit }}
-  allow_merge_commit: {{ .Repository.AllowMergeCommit }}
-{{- end }}
-{{- if .Repository.AllowSquashMerge }}
-  allow_squash_merge: {{ .Repository.AllowSquashMerge }}
-{{- end }}
-{{- if .Repository.AllowRebaseMerge }}
-  allow_rebase_merge: {{ .Repository.AllowRebaseMerge }}
-{{- end }}
-{{- if .Repository.SquashMergeCommitTitle }}
-  squash_merge_commit_title: {{ yamlVal .Repository.SquashMergeCommitTitle }}
-{{- end }}
-{{- if .Repository.SquashMergeCommitMessage }}
-  squash_merge_commit_message: {{ yamlVal .Repository.SquashMergeCommitMessage }}
-{{- end }}
-{{- if .Repository.MergeCommitTitle }}
-  merge_commit_title: {{ yamlVal .Repository.MergeCommitTitle }}
-{{- end }}
-{{- if .Repository.MergeCommitMessage }}
-  merge_commit_message: {{ yamlVal .Repository.MergeCommitMessage }}
-{{- end }}
-{{- if .Repository.DeleteBranchOnMerge }}
-  delete_branch_on_merge: {{ .Repository.DeleteBranchOnMerge }}
-{{- end }}
-{{- if .Repository.AllowUpdateBranch }}
-  allow_update_branch: {{ .Repository.AllowUpdateBranch }}
-{{- end }}
-{{- if .Repository.AllowAutoMerge }}
-  allow_auto_merge: {{ .Repository.AllowAutoMerge }}
-{{- end }}
-{{- if .Repository.WebCommitSignoffRequired }}
-  web_commit_signoff_required: {{ .Repository.WebCommitSignoffRequired }}
-{{- end }}
-{{- if .Repository.PrivateVulnerabilityReportEnabled }}
-  private_vulnerability_reporting_enabled: {{ .Repository.PrivateVulnerabilityReportEnabled }}
-{{- end }}
-{{- if .Repository.VulnerabilityAlertsEnabled }}
-  vulnerability_alerts_enabled: {{ .Repository.VulnerabilityAlertsEnabled }}
-{{- end }}
-{{- if .Repository.AutomatedSecurityFixesEnabled }}
-  automated_security_fixes_enabled: {{ .Repository.AutomatedSecurityFixesEnabled }}
-{{- end }}
-{{- if .Repository.DefaultWorkflowPermissions }}
-  default_workflow_permissions: {{ .Repository.DefaultWorkflowPermissions }}
-{{- end }}
-{{- if .Repository.CanApprovePullRequestReviews }}
-  can_approve_pull_request_reviews: {{ .Repository.CanApprovePullRequestReviews }}
-{{- end }}
-{{- if .Repository.Topics }}
-  topics:{{ if eq (len .Repository.Topics) 0 }} []{{ else }}
-{{- range .Repository.Topics }}
-    - {{ yamlVal . }}
-{{- end }}{{ end }}
+{{- range repositoryLines .Repository }}
+{{ . }}
 {{- end }}
 {{- end }}
 {{- if .Actions }}
 
 actions:
-{{- if .Actions.Enabled }}
-  enabled: {{ .Actions.Enabled }}
-{{- end }}
-{{- if .Actions.AllowedActions }}
-  allowed_actions: {{ .Actions.AllowedActions }}
-{{- end }}
-{{- if .Actions.SHAPinningRequired }}
-  sha_pinning_required: {{ .Actions.SHAPinningRequired }}
-{{- end }}
-{{- if .Actions.GitHubOwnedAllowed }}
-  github_owned_allowed: {{ .Actions.GitHubOwnedAllowed }}
-{{- end }}
-{{- if .Actions.VerifiedAllowed }}
-  verified_allowed: {{ .Actions.VerifiedAllowed }}
-{{- end }}
-{{- if .Actions.PatternsAllowed }}
-  patterns_allowed:{{ if eq (len .Actions.PatternsAllowed) 0 }} []{{ else }}
-{{- range .Actions.PatternsAllowed }}
-    - {{ yamlVal . }}
-{{- end }}{{ end }}
+{{- range actionsLines .Actions }}
+{{ . }}
 {{- end }}
 {{- end }}
 {{- if .Labels }}

--- a/internal/gh/actions.go
+++ b/internal/gh/actions.go
@@ -33,7 +33,7 @@ func ReadActionsPolicy(client *api.RESTClient, owner, name string, selected bool
 	var permissions actionsPermissionsResponse
 	coreKnown := false
 	if err := boundedHTTPError(client.Get(base, &permissions)); err != nil {
-		classified := classifyHTTPError(err, OpFetchActionsPermissions)
+		classified := classifyHTTPError(err, Op(OpFetchActionsPermissions))
 		if isAccessError(classified) {
 			warnings = append(warnings, classified)
 		} else {
@@ -52,7 +52,7 @@ func ReadActionsPolicy(client *api.RESTClient, owner, name string, selected bool
 	if selected && coreKnown && permissions.AllowedActions == "selected" {
 		var policy selectedActionsResponse
 		if err := boundedHTTPError(client.Get(base+"/selected-actions", &policy)); err != nil {
-			classified := classifyHTTPError(err, OpFetchSelectedActionsPermissions)
+			classified := classifyHTTPError(err, Op(OpFetchSelectedActionsPermissions))
 			if isAccessError(classified) {
 				warnings = append(warnings, classified)
 			} else {
@@ -130,12 +130,12 @@ func applyRestrictAllThenSelected(client *api.RESTClient, base string, desired, 
 		initialCoreBody = maps.Clone(coreBody)
 		initialCoreBody["sha_pinning_required"] = true
 	}
-	applied, err := applyActionsWrite(client, base, initialCoreBody, OpSetActionsPermissions, result)
+	applied, err := applyActionsWrite(client, base, initialCoreBody, Op(OpSetActionsPermissions), result)
 	if err != nil {
 		return nil, err
 	}
 	if !applied {
-		appendSkippedDependency(result, OpSetSelectedActionsPermissions)
+		appendSkippedDependency(result, Op(OpSetSelectedActionsPermissions))
 		return result, nil
 	}
 	if err := putActionsPolicy(client, base+"/selected-actions", selectedBody); err != nil {
@@ -149,20 +149,20 @@ func applyRestrictAllThenSelected(client *api.RESTClient, base string, desired, 
 	return result, nil
 }
 
-// disableActionsStep returns the pre-update disable write and its operation
-// name, or nil when the selected policy can change while Actions keep their
+// disableActionsStep returns the pre-update disable write and its operation,
+// or nil when the selected policy can change while Actions keep their
 // current state.
-func disableActionsStep(desired, current *model.ActionsSettings) (map[string]any, string) {
+func disableActionsStep(desired, current *model.ActionsSettings) (map[string]any, Operation) {
 	if current.AllowedActions != nil && *current.AllowedActions != "selected" {
 		return map[string]any{
 			"enabled":         false,
 			"allowed_actions": "selected",
-		}, "disable actions for selected policy transition"
+		}, Op(OpDisableActionsForPolicyTransition)
 	}
 	if isTrue(current.Enabled) && (isFalse(desired.Enabled) || selectedPolicyBroadens(desired, current)) {
-		return map[string]any{"enabled": false}, "disable actions for selected policy update"
+		return map[string]any{"enabled": false}, Op(OpDisableActionsForPolicyUpdate)
 	}
-	return nil, ""
+	return nil, Operation{}
 }
 
 // applySelectedThenCore writes the selected policy before the final core
@@ -176,8 +176,8 @@ func applySelectedThenCore(client *api.RESTClient, base string, desired, current
 			return result, err
 		}
 		if !applied {
-			appendSkippedDependency(result, OpSetSelectedActionsPermissions)
-			appendSkippedDependency(result, OpSetActionsPermissions)
+			appendSkippedDependency(result, Op(OpSetSelectedActionsPermissions))
+			appendSkippedDependency(result, Op(OpSetActionsPermissions))
 			return result, nil
 		}
 		actionsDisabled = true
@@ -186,8 +186,8 @@ func applySelectedThenCore(client *api.RESTClient, base string, desired, current
 		if actionsDisabled {
 			return nil, fmt.Errorf("setting selected actions permissions failed while actions are disabled: %w", err)
 		}
-		if recordAccessError(result, OpSetSelectedActionsPermissions, err) {
-			appendSkippedDependency(result, OpSetActionsPermissions)
+		if recordAccessError(result, Op(OpSetSelectedActionsPermissions), err) {
+			appendSkippedDependency(result, Op(OpSetActionsPermissions))
 			return result, nil
 		}
 		return nil, fmt.Errorf("setting selected actions permissions: %w", err)
@@ -198,7 +198,7 @@ func applySelectedThenCore(client *api.RESTClient, base string, desired, current
 		}
 		return result, nil
 	}
-	_, err := applyActionsWrite(client, base, coreBody, OpSetActionsPermissions, result)
+	_, err := applyActionsWrite(client, base, coreBody, Op(OpSetActionsPermissions), result)
 	return result, err
 }
 
@@ -208,17 +208,17 @@ func applyCoreThenSelected(client *api.RESTClient, base string, coreBody, select
 	coreApplied := true
 	if core {
 		var err error
-		coreApplied, err = applyActionsWrite(client, base, coreBody, OpSetActionsPermissions, result)
+		coreApplied, err = applyActionsWrite(client, base, coreBody, Op(OpSetActionsPermissions), result)
 		if err != nil {
 			return nil, err
 		}
 		if !coreApplied && selected {
-			appendSkippedDependency(result, OpSetSelectedActionsPermissions)
+			appendSkippedDependency(result, Op(OpSetSelectedActionsPermissions))
 		}
 	}
 	if selected && coreApplied {
 		if err := putActionsPolicy(client, base+"/selected-actions", selectedBody); err != nil {
-			if !recordAccessError(result, OpSetSelectedActionsPermissions, err) {
+			if !recordAccessError(result, Op(OpSetSelectedActionsPermissions), err) {
 				return nil, fmt.Errorf("setting selected actions permissions: %w", err)
 			}
 		}
@@ -311,7 +311,7 @@ func actionsSelectedBody(desired *model.ActionsSettings) map[string]any {
 	return body
 }
 
-func applyActionsWrite(client *api.RESTClient, path string, body map[string]any, operation string, result *ApplyResult) (bool, error) {
+func applyActionsWrite(client *api.RESTClient, path string, body map[string]any, operation Operation, result *ApplyResult) (bool, error) {
 	if err := putActionsPolicy(client, path, body); err != nil {
 		if recordAccessError(result, operation, err) {
 			return false, nil

--- a/internal/gh/actions.go
+++ b/internal/gh/actions.go
@@ -67,6 +67,23 @@ func ReadActionsPolicy(client *api.RESTClient, owner, name string, selected bool
 	return settings, warnings, nil
 }
 
+// actionsWriteOrder names the write-ordering strategy for one Actions policy
+// update. The fail-closed orderings keep a partial write from widening the
+// policy while Actions can run.
+type actionsWriteOrder int
+
+const (
+	// coreThenSelected writes the core policy, then the selected policy, with
+	// no fail-closed ordering.
+	coreThenSelected actionsWriteOrder = iota
+	// restrictAllThenSelected narrows an enabled "all" policy to "selected"
+	// through the core endpoint before the selected policy exists.
+	restrictAllThenSelected
+	// selectedThenCore writes the selected policy before the final core
+	// policy, disabling Actions first when the update could widen access.
+	selectedThenCore
+)
+
 // ApplyActionsPolicy writes only the Actions policy endpoint groups that differ.
 func ApplyActionsPolicy(client *api.RESTClient, owner, name string, desired, current *model.ActionsSettings, core, selected bool) (*ApplyResult, error) {
 	base := fmt.Sprintf("repos/%s/%s/actions/permissions", owner, name)
@@ -76,93 +93,125 @@ func ApplyActionsPolicy(client *api.RESTClient, owner, name string, desired, cur
 		return nil, err
 	}
 	selectedBody := actionsSelectedBody(desired)
-	desiredSelected := desired.AllowedActions != nil && *desired.AllowedActions == "selected" ||
-		desired.AllowedActions == nil && current.AllowedActions != nil && *current.AllowedActions == "selected"
-	policyTransition := desiredSelected && selected && current.AllowedActions != nil && *current.AllowedActions != "selected"
-	orderedUpdate := desiredSelected && selected && core
-	if orderedUpdate {
-		restrictAllToSelected := policyTransition && current.Enabled != nil && *current.Enabled &&
-			current.AllowedActions != nil && *current.AllowedActions == "all" && coreBody["enabled"] == true
-		if restrictAllToSelected {
-			initialCoreBody := coreBody
-			relaxesSHAPinning := current.SHAPinningRequired != nil && *current.SHAPinningRequired &&
-				desired.SHAPinningRequired != nil && !*desired.SHAPinningRequired
-			if relaxesSHAPinning {
-				initialCoreBody = maps.Clone(coreBody)
-				initialCoreBody["sha_pinning_required"] = true
-			}
-			applied, err := applyActionsWrite(client, base, initialCoreBody, OpSetActionsPermissions, result)
-			if err != nil {
-				return nil, err
-			}
-			if !applied {
-				appendSkippedDependency(result, OpSetSelectedActionsPermissions)
-				return result, nil
-			}
-			if err := putActionsPolicy(client, base+"/selected-actions", selectedBody); err != nil {
-				return nil, fmt.Errorf("setting selected actions permissions failed after actions were restricted to selected: %w", err)
-			}
-			if relaxesSHAPinning {
-				if err := putActionsPolicy(client, base, coreBody); err != nil {
-					return nil, fmt.Errorf("relaxing SHA pinning failed after selected actions restrictions were applied: %w", err)
-				}
-			}
-			return result, nil
-		}
-
-		actionsDisabled := current.Enabled != nil && !*current.Enabled
-		disableBeforeUpdate := current.Enabled != nil && *current.Enabled &&
-			desired.Enabled != nil && !*desired.Enabled
-		failClosedUpdate := current.Enabled != nil && *current.Enabled &&
-			selectedPolicyBroadens(desired, current)
-		if policyTransition {
-			applied, err := applyActionsWrite(client, base, map[string]any{
-				"enabled":         false,
-				"allowed_actions": "selected",
-			}, "disable actions for selected policy transition", result)
-			if err != nil {
-				return result, err
-			}
-			if !applied {
-				appendSkippedDependency(result, OpSetSelectedActionsPermissions)
-				appendSkippedDependency(result, OpSetActionsPermissions)
-				return result, nil
-			}
-			actionsDisabled = true
-		} else if disableBeforeUpdate || failClosedUpdate {
-			applied, err := applyActionsWrite(client, base, map[string]any{"enabled": false}, "disable actions for selected policy update", result)
-			if err != nil {
-				return result, err
-			}
-			if !applied {
-				appendSkippedDependency(result, OpSetSelectedActionsPermissions)
-				appendSkippedDependency(result, OpSetActionsPermissions)
-				return result, nil
-			}
-			actionsDisabled = true
-		}
-		if err := putActionsPolicy(client, base+"/selected-actions", selectedBody); err != nil {
-			if actionsDisabled {
-				return nil, fmt.Errorf("setting selected actions permissions failed while actions are disabled: %w", err)
-			}
-			if recordAccessError(result, OpSetSelectedActionsPermissions, err) {
-				appendSkippedDependency(result, OpSetActionsPermissions)
-				return result, nil
-			}
-			return nil, fmt.Errorf("setting selected actions permissions: %w", err)
-		}
-		if actionsDisabled {
-			if err := putActionsPolicy(client, base, coreBody); err != nil {
-				return nil, fmt.Errorf("setting final actions permissions failed while actions are disabled: %w", err)
-			}
-			return result, nil
-		}
-		_, err := applyActionsWrite(client, base, coreBody, OpSetActionsPermissions, result)
-		return result, err
+	switch planActionsWriteOrder(desired, current, core, selected, coreBody) {
+	case restrictAllThenSelected:
+		return applyRestrictAllThenSelected(client, base, desired, current, coreBody, selectedBody, result)
+	case selectedThenCore:
+		return applySelectedThenCore(client, base, desired, current, coreBody, selectedBody, result)
+	default:
+		return applyCoreThenSelected(client, base, coreBody, selectedBody, core, selected, result)
 	}
+}
 
+// planActionsWriteOrder picks the write ordering. Fail-closed orderings apply
+// only when both endpoint groups are written and the target policy, desired or
+// carried over from current, is "selected".
+func planActionsWriteOrder(desired, current *model.ActionsSettings, core, selected bool, coreBody map[string]any) actionsWriteOrder {
+	targetsSelected := desired.AllowedActions != nil && *desired.AllowedActions == "selected" ||
+		desired.AllowedActions == nil && current.AllowedActions != nil && *current.AllowedActions == "selected"
+	if !targetsSelected || !core || !selected {
+		return coreThenSelected
+	}
+	enabledAllPolicy := current.Enabled != nil && *current.Enabled &&
+		current.AllowedActions != nil && *current.AllowedActions == "all"
+	if enabledAllPolicy && coreBody["enabled"] == true {
+		return restrictAllThenSelected
+	}
+	return selectedThenCore
+}
+
+// applyRestrictAllThenSelected narrows an enabled "all" policy: the core write
+// switches to "selected" first, then the selected policy lands. When the
+// update also relaxes SHA pinning, the initial core write keeps pinning
+// required and a final core write relaxes it after the selected policy exists.
+func applyRestrictAllThenSelected(client *api.RESTClient, base string, desired, current *model.ActionsSettings, coreBody, selectedBody map[string]any, result *ApplyResult) (*ApplyResult, error) {
+	initialCoreBody := coreBody
+	relaxesSHAPinning := current.SHAPinningRequired != nil && *current.SHAPinningRequired &&
+		desired.SHAPinningRequired != nil && !*desired.SHAPinningRequired
+	if relaxesSHAPinning {
+		initialCoreBody = maps.Clone(coreBody)
+		initialCoreBody["sha_pinning_required"] = true
+	}
+	applied, err := applyActionsWrite(client, base, initialCoreBody, OpSetActionsPermissions, result)
+	if err != nil {
+		return nil, err
+	}
+	if !applied {
+		appendSkippedDependency(result, OpSetSelectedActionsPermissions)
+		return result, nil
+	}
+	if err := putActionsPolicy(client, base+"/selected-actions", selectedBody); err != nil {
+		return nil, fmt.Errorf("setting selected actions permissions failed after actions were restricted to selected: %w", err)
+	}
+	if relaxesSHAPinning {
+		if err := putActionsPolicy(client, base, coreBody); err != nil {
+			return nil, fmt.Errorf("relaxing SHA pinning failed after selected actions restrictions were applied: %w", err)
+		}
+	}
+	return result, nil
+}
+
+// disableActionsStep returns the pre-update disable write and its operation
+// name, or nil when the selected policy can change while Actions keep their
+// current state.
+func disableActionsStep(desired, current *model.ActionsSettings) (map[string]any, string) {
+	if current.AllowedActions != nil && *current.AllowedActions != "selected" {
+		return map[string]any{
+			"enabled":         false,
+			"allowed_actions": "selected",
+		}, "disable actions for selected policy transition"
+	}
+	currentlyEnabled := current.Enabled != nil && *current.Enabled
+	desiredDisabled := desired.Enabled != nil && !*desired.Enabled
+	if currentlyEnabled && (desiredDisabled || selectedPolicyBroadens(desired, current)) {
+		return map[string]any{"enabled": false}, "disable actions for selected policy update"
+	}
+	return nil, ""
+}
+
+// applySelectedThenCore writes the selected policy before the final core
+// policy. When the update could widen access, a disable write runs first so a
+// partial failure leaves Actions disabled rather than over-permitted.
+func applySelectedThenCore(client *api.RESTClient, base string, desired, current *model.ActionsSettings, coreBody, selectedBody map[string]any, result *ApplyResult) (*ApplyResult, error) {
+	actionsDisabled := current.Enabled != nil && !*current.Enabled
+	if disableBody, disableOp := disableActionsStep(desired, current); disableBody != nil {
+		applied, err := applyActionsWrite(client, base, disableBody, disableOp, result)
+		if err != nil {
+			return result, err
+		}
+		if !applied {
+			appendSkippedDependency(result, OpSetSelectedActionsPermissions)
+			appendSkippedDependency(result, OpSetActionsPermissions)
+			return result, nil
+		}
+		actionsDisabled = true
+	}
+	if err := putActionsPolicy(client, base+"/selected-actions", selectedBody); err != nil {
+		if actionsDisabled {
+			return nil, fmt.Errorf("setting selected actions permissions failed while actions are disabled: %w", err)
+		}
+		if recordAccessError(result, OpSetSelectedActionsPermissions, err) {
+			appendSkippedDependency(result, OpSetActionsPermissions)
+			return result, nil
+		}
+		return nil, fmt.Errorf("setting selected actions permissions: %w", err)
+	}
+	if actionsDisabled {
+		if err := putActionsPolicy(client, base, coreBody); err != nil {
+			return nil, fmt.Errorf("setting final actions permissions failed while actions are disabled: %w", err)
+		}
+		return result, nil
+	}
+	_, err := applyActionsWrite(client, base, coreBody, OpSetActionsPermissions, result)
+	return result, err
+}
+
+// applyCoreThenSelected writes the requested endpoint groups in the plain
+// order: core first, then the selected policy if the core write applied.
+func applyCoreThenSelected(client *api.RESTClient, base string, coreBody, selectedBody map[string]any, core, selected bool, result *ApplyResult) (*ApplyResult, error) {
 	coreApplied := true
 	if core {
+		var err error
 		coreApplied, err = applyActionsWrite(client, base, coreBody, OpSetActionsPermissions, result)
 		if err != nil {
 			return nil, err

--- a/internal/gh/actions.go
+++ b/internal/gh/actions.go
@@ -107,13 +107,12 @@ func ApplyActionsPolicy(client *api.RESTClient, owner, name string, desired, cur
 // only when both endpoint groups are written and the target policy, desired or
 // carried over from current, is "selected".
 func planActionsWriteOrder(desired, current *model.ActionsSettings, core, selected bool, coreBody map[string]any) actionsWriteOrder {
-	targetsSelected := desired.AllowedActions != nil && *desired.AllowedActions == "selected" ||
-		desired.AllowedActions == nil && current.AllowedActions != nil && *current.AllowedActions == "selected"
+	targetsSelected := strEq(desired.AllowedActions, "selected") ||
+		desired.AllowedActions == nil && strEq(current.AllowedActions, "selected")
 	if !targetsSelected || !core || !selected {
 		return coreThenSelected
 	}
-	enabledAllPolicy := current.Enabled != nil && *current.Enabled &&
-		current.AllowedActions != nil && *current.AllowedActions == "all"
+	enabledAllPolicy := isTrue(current.Enabled) && strEq(current.AllowedActions, "all")
 	if enabledAllPolicy && coreBody["enabled"] == true {
 		return restrictAllThenSelected
 	}
@@ -126,8 +125,7 @@ func planActionsWriteOrder(desired, current *model.ActionsSettings, core, select
 // required and a final core write relaxes it after the selected policy exists.
 func applyRestrictAllThenSelected(client *api.RESTClient, base string, desired, current *model.ActionsSettings, coreBody, selectedBody map[string]any, result *ApplyResult) (*ApplyResult, error) {
 	initialCoreBody := coreBody
-	relaxesSHAPinning := current.SHAPinningRequired != nil && *current.SHAPinningRequired &&
-		desired.SHAPinningRequired != nil && !*desired.SHAPinningRequired
+	relaxesSHAPinning := isTrue(current.SHAPinningRequired) && isFalse(desired.SHAPinningRequired)
 	if relaxesSHAPinning {
 		initialCoreBody = maps.Clone(coreBody)
 		initialCoreBody["sha_pinning_required"] = true
@@ -161,9 +159,7 @@ func disableActionsStep(desired, current *model.ActionsSettings) (map[string]any
 			"allowed_actions": "selected",
 		}, "disable actions for selected policy transition"
 	}
-	currentlyEnabled := current.Enabled != nil && *current.Enabled
-	desiredDisabled := desired.Enabled != nil && !*desired.Enabled
-	if currentlyEnabled && (desiredDisabled || selectedPolicyBroadens(desired, current)) {
+	if isTrue(current.Enabled) && (isFalse(desired.Enabled) || selectedPolicyBroadens(desired, current)) {
 		return map[string]any{"enabled": false}, "disable actions for selected policy update"
 	}
 	return nil, ""
@@ -173,7 +169,7 @@ func disableActionsStep(desired, current *model.ActionsSettings) (map[string]any
 // policy. When the update could widen access, a disable write runs first so a
 // partial failure leaves Actions disabled rather than over-permitted.
 func applySelectedThenCore(client *api.RESTClient, base string, desired, current *model.ActionsSettings, coreBody, selectedBody map[string]any, result *ApplyResult) (*ApplyResult, error) {
-	actionsDisabled := current.Enabled != nil && !*current.Enabled
+	actionsDisabled := isFalse(current.Enabled)
 	if disableBody, disableOp := disableActionsStep(desired, current); disableBody != nil {
 		applied, err := applyActionsWrite(client, base, disableBody, disableOp, result)
 		if err != nil {
@@ -235,12 +231,10 @@ func applyCoreThenSelected(client *api.RESTClient, base string, coreBody, select
 // exclusion pattern. ApplyActionsPolicy disables Actions before a broadening
 // update so a partial write cannot widen the policy while Actions run.
 func selectedPolicyBroadens(desired, current *model.ActionsSettings) bool {
-	if desired.GitHubOwnedAllowed != nil && *desired.GitHubOwnedAllowed &&
-		current.GitHubOwnedAllowed != nil && !*current.GitHubOwnedAllowed {
+	if isTrue(desired.GitHubOwnedAllowed) && isFalse(current.GitHubOwnedAllowed) {
 		return true
 	}
-	if desired.VerifiedAllowed != nil && *desired.VerifiedAllowed &&
-		current.VerifiedAllowed != nil && !*current.VerifiedAllowed {
+	if isTrue(desired.VerifiedAllowed) && isFalse(current.VerifiedAllowed) {
 		return true
 	}
 	if desired.PatternsAllowed == nil || current.PatternsAllowed == nil {

--- a/internal/gh/errors.go
+++ b/internal/gh/errors.go
@@ -18,7 +18,7 @@ type ErrInsufficientScope struct {
 	NeedScopes  []string // parsed from X-Accepted-OAuth-Scopes
 	Message     string   // from JSON body
 	DocumentURL string   // from JSON body
-	Operation   string   // e.g. "enable vulnerability alerts"
+	Operation   Operation
 }
 
 func (e *ErrInsufficientScope) Error() string {
@@ -57,7 +57,7 @@ func parseCSVScopes(header string) []string {
 // classifyHTTPError inspects err for a *api.HTTPError and, on 403 or 404,
 // returns an *ErrInsufficientScope. Non-HTTP errors
 // and non-403/404 HTTP errors pass through unchanged.
-func classifyHTTPError(err error, operation string) error {
+func classifyHTTPError(err error, operation Operation) error {
 	if err == nil {
 		return nil
 	}

--- a/internal/gh/errors_test.go
+++ b/internal/gh/errors_test.go
@@ -18,7 +18,7 @@ func TestErrInsufficientScope_Error(t *testing.T) {
 		NeedScopes:  []string{"repo"},
 		Message:     "Must have admin rights to Repository.",
 		DocumentURL: "https://docs.github.com/rest/repos/repos#update-a-repository",
-		Operation:   "enable vulnerability alerts",
+		Operation:   SecurityFeatureOp(true, OpSetVulnerabilityAlerts),
 	}
 
 	want := "enable vulnerability alerts: insufficient scope (have: [public_repo], need: [repo]): Must have admin rights to Repository. (see https://docs.github.com/rest/repos/repos#update-a-repository)"
@@ -33,7 +33,7 @@ func TestErrInsufficientScope_ErrorEmptyScopes(t *testing.T) {
 		HaveScopes: nil,
 		NeedScopes: nil,
 		Message:    "Resource not accessible by integration",
-		Operation:  "enable vulnerability alerts",
+		Operation:  SecurityFeatureOp(true, OpSetVulnerabilityAlerts),
 	}
 
 	want := "enable vulnerability alerts: insufficient scope (have: [], need: []): Resource not accessible by integration"
@@ -48,10 +48,10 @@ func TestErrInsufficientScope_ErrorWithoutDocURL(t *testing.T) {
 		HaveScopes: []string{"public_repo"},
 		NeedScopes: []string{"repo"},
 		Message:    "Forbidden",
-		Operation:  "update repository settings",
+		Operation:  Op(OpPatchRepoSettings),
 	}
 
-	want := "update repository settings: insufficient scope (have: [public_repo], need: [repo]): Forbidden"
+	want := "patch repo settings: insufficient scope (have: [public_repo], need: [repo]): Forbidden"
 	if got := err.Error(); got != want {
 		t.Errorf("Error() =\n  %q\nwant:\n  %q", got, want)
 	}
@@ -60,7 +60,7 @@ func TestErrInsufficientScope_ErrorWithoutDocURL(t *testing.T) {
 func TestErrInsufficientScope_SatisfiesErrorInterface(t *testing.T) {
 	var err error = &ErrInsufficientScope{
 		StatusCode: 403,
-		Operation:  "test",
+		Operation:  Op(OpSetTopics),
 		Message:    "test message",
 	}
 	if err.Error() == "" {
@@ -74,7 +74,7 @@ func TestErrInsufficientScope_ErrorsAs(t *testing.T) {
 		HaveScopes: []string{"public_repo"},
 		NeedScopes: []string{"repo"},
 		Message:    "forbidden",
-		Operation:  "enable vulnerability alerts",
+		Operation:  SecurityFeatureOp(true, OpSetVulnerabilityAlerts),
 	}
 
 	wrapped := fmt.Errorf("applying settings: %w", original)
@@ -83,8 +83,8 @@ func TestErrInsufficientScope_ErrorsAs(t *testing.T) {
 	if !errors.As(wrapped, &target) {
 		t.Fatal("errors.As failed to unwrap ErrInsufficientScope")
 	}
-	if target.Operation != "enable vulnerability alerts" {
-		t.Errorf("Operation = %q, want %q", target.Operation, "enable vulnerability alerts")
+	if target.Operation.String() != "enable vulnerability alerts" {
+		t.Errorf("Operation = %q, want %q", target.Operation.String(), "enable vulnerability alerts")
 	}
 	if target.StatusCode != http.StatusForbidden {
 		t.Errorf("StatusCode = %d, want %d", target.StatusCode, http.StatusForbidden)
@@ -101,14 +101,14 @@ func newHTTPError(statusCode int, message string, headers http.Header) *api.HTTP
 }
 
 func TestClassifyHTTPError_NilError(t *testing.T) {
-	if err := classifyHTTPError(nil, "test"); err != nil {
+	if err := classifyHTTPError(nil, Op(OpPatchRepoSettings)); err != nil {
 		t.Errorf("classifyHTTPError(nil) = %v, want nil", err)
 	}
 }
 
 func TestClassifyHTTPError_NonHTTPError(t *testing.T) {
 	original := fmt.Errorf("network timeout")
-	got := classifyHTTPError(original, "test")
+	got := classifyHTTPError(original, Op(OpPatchRepoSettings))
 	if !errors.Is(got, original) {
 		t.Errorf("classifyHTTPError returned %v, want original error %v", got, original)
 	}
@@ -116,7 +116,7 @@ func TestClassifyHTTPError_NonHTTPError(t *testing.T) {
 
 func TestClassifyHTTPError_Non403Non404(t *testing.T) {
 	httpErr := newHTTPError(http.StatusInternalServerError, "Internal Server Error", http.Header{})
-	got := classifyHTTPError(httpErr, "test")
+	got := classifyHTTPError(httpErr, Op(OpPatchRepoSettings))
 
 	var target *api.HTTPError
 	if !errors.As(got, &target) {
@@ -133,7 +133,7 @@ func TestClassifyHTTPError_403ScopeError(t *testing.T) {
 	headers.Set("X-Accepted-OAuth-Scopes", "repo")
 	httpErr := newHTTPError(http.StatusForbidden, "Must have admin rights to Repository.", headers)
 
-	got := classifyHTTPError(httpErr, "update repository settings")
+	got := classifyHTTPError(httpErr, Op(OpPatchRepoSettings))
 
 	var scopeErr *ErrInsufficientScope
 	if !errors.As(got, &scopeErr) {
@@ -142,8 +142,8 @@ func TestClassifyHTTPError_403ScopeError(t *testing.T) {
 	if scopeErr.StatusCode != http.StatusForbidden {
 		t.Errorf("StatusCode = %d, want %d", scopeErr.StatusCode, http.StatusForbidden)
 	}
-	if scopeErr.Operation != "update repository settings" {
-		t.Errorf("Operation = %q, want %q", scopeErr.Operation, "update repository settings")
+	if scopeErr.Operation != Op(OpPatchRepoSettings) {
+		t.Errorf("Operation = %v, want %v", scopeErr.Operation, Op(OpPatchRepoSettings))
 	}
 	if len(scopeErr.HaveScopes) != 2 || scopeErr.HaveScopes[0] != "public_repo" || scopeErr.HaveScopes[1] != "read:org" {
 		t.Errorf("HaveScopes = %v, want [public_repo read:org]", scopeErr.HaveScopes)
@@ -159,7 +159,7 @@ func TestClassifyHTTPError_403ScopeError(t *testing.T) {
 func TestClassifyHTTPError_404ClassifiedAsScopeError(t *testing.T) {
 	httpErr := newHTTPError(http.StatusNotFound, "Not Found", http.Header{})
 
-	got := classifyHTTPError(httpErr, "update repository settings")
+	got := classifyHTTPError(httpErr, Op(OpPatchRepoSettings))
 
 	var scopeErr *ErrInsufficientScope
 	if !errors.As(got, &scopeErr) {
@@ -176,21 +176,21 @@ func TestClassifyHTTPError_WrappedHTTPError(t *testing.T) {
 	httpErr := newHTTPError(http.StatusForbidden, "Forbidden", headers)
 	wrapped := fmt.Errorf("applying settings: %w", httpErr)
 
-	got := classifyHTTPError(wrapped, "update repository settings")
+	got := classifyHTTPError(wrapped, Op(OpPatchRepoSettings))
 
 	var scopeErr *ErrInsufficientScope
 	if !errors.As(got, &scopeErr) {
 		t.Fatalf("expected *ErrInsufficientScope from wrapped error, got %T: %v", got, got)
 	}
-	if scopeErr.Operation != "update repository settings" {
-		t.Errorf("Operation = %q, want %q", scopeErr.Operation, "update repository settings")
+	if scopeErr.Operation != Op(OpPatchRepoSettings) {
+		t.Errorf("Operation = %v, want %v", scopeErr.Operation, Op(OpPatchRepoSettings))
 	}
 }
 
 func TestClassifyHTTPError_EmptyScopeHeaders(t *testing.T) {
 	httpErr := newHTTPError(http.StatusForbidden, "Resource not accessible by integration", http.Header{})
 
-	got := classifyHTTPError(httpErr, "update repository settings")
+	got := classifyHTTPError(httpErr, Op(OpPatchRepoSettings))
 
 	var scopeErr *ErrInsufficientScope
 	if !errors.As(got, &scopeErr) {

--- a/internal/gh/labels_test.go
+++ b/internal/gh/labels_test.go
@@ -558,8 +558,8 @@ func TestApplyLabelsCreate403SkipsAndContinues(t *testing.T) {
 	if len(result.Skipped) != 1 {
 		t.Fatalf("expected 1 skipped, got %d", len(result.Skipped))
 	}
-	if result.Skipped[0].Operation != `create label "alpha"` {
-		t.Errorf("skipped operation = %q, want %q", result.Skipped[0].Operation, `create label "alpha"`)
+	if result.Skipped[0].Operation.String() != `create label "alpha"` {
+		t.Errorf("skipped operation = %q, want %q", result.Skipped[0].Operation.String(), `create label "alpha"`)
 	}
 	if !isAccessError(result.Skipped[0].Err) {
 		t.Errorf("skipped error is not an access error: %v", result.Skipped[0].Err)
@@ -605,8 +605,8 @@ func TestApplyLabelsUpdate403SkipsAndContinues(t *testing.T) {
 	if len(result.Skipped) != 1 {
 		t.Fatalf("expected 1 skipped, got %d", len(result.Skipped))
 	}
-	if result.Skipped[0].Operation != `update label "alpha"` {
-		t.Errorf("skipped operation = %q, want %q", result.Skipped[0].Operation, `update label "alpha"`)
+	if result.Skipped[0].Operation.String() != `update label "alpha"` {
+		t.Errorf("skipped operation = %q, want %q", result.Skipped[0].Operation.String(), `update label "alpha"`)
 	}
 	if !isAccessError(result.Skipped[0].Err) {
 		t.Errorf("skipped error is not an access error: %v", result.Skipped[0].Err)
@@ -674,7 +674,7 @@ func TestApplyLabelsMixed403AndSuccess(t *testing.T) {
 	if len(result.Skipped) != 1 {
 		t.Fatalf("expected 1 skipped, got %d", len(result.Skipped))
 	}
-	if result.Skipped[0].Operation != `create label "new-label"` {
-		t.Errorf("skipped = %q, want %q", result.Skipped[0].Operation, `create label "new-label"`)
+	if result.Skipped[0].Operation.String() != `create label "new-label"` {
+		t.Errorf("skipped = %q, want %q", result.Skipped[0].Operation.String(), `create label "new-label"`)
 	}
 }

--- a/internal/gh/operations.go
+++ b/internal/gh/operations.go
@@ -2,45 +2,112 @@ package gh
 
 import "fmt"
 
-// Operation names recorded in ErrInsufficientScope warnings and ApplyResult
-// skip records. internal/alter matches these strings to map skips back to
-// config fields, so both ends must use these shared definitions.
+// OperationKind identifies a GitHub API operation recorded in
+// ErrInsufficientScope warnings and ApplyResult skip records. internal/alter
+// maps skips back to config fields by kind; user-facing text comes only from
+// Operation.String.
+type OperationKind int
+
 const (
-	OpFetchActionsPermissions            = "fetch actions permissions"
-	OpFetchSelectedActionsPermissions    = "fetch selected actions permissions"
-	OpSetActionsPermissions              = "set actions permissions"
-	OpSetSelectedActionsPermissions      = "set selected actions permissions"
-	OpFetchWorkflowPermissions           = "fetch workflow permissions"
-	OpSetWorkflowPermissions             = "set workflow permissions"
-	OpFetchPrivateVulnerabilityReporting = "fetch private vulnerability reporting"
-	OpFetchVulnerabilityAlerts           = "fetch vulnerability alerts"
-	OpFetchAutomatedSecurityFixes        = "fetch automated security fixes"
-	OpPatchRepoSettings                  = "patch repo settings"
-	OpSetTopics                          = "set topics"
+	OpNone OperationKind = iota
+	OpFetchActionsPermissions
+	OpFetchSelectedActionsPermissions
+	OpSetActionsPermissions
+	OpSetSelectedActionsPermissions
+	OpDisableActionsForPolicyTransition
+	OpDisableActionsForPolicyUpdate
+	OpFetchWorkflowPermissions
+	OpSetWorkflowPermissions
+	OpFetchPrivateVulnerabilityReporting
+	OpFetchVulnerabilityAlerts
+	OpFetchAutomatedSecurityFixes
+	OpSetPrivateVulnerabilityReporting
+	OpSetVulnerabilityAlerts
+	OpSetAutomatedSecurityFixes
+	OpPatchRepoSettings
+	OpSetTopics
+	OpCreateLabel
+	OpUpdateLabel
 )
 
-// Security feature names embedded in enable/disable operation names.
-const (
-	FeaturePrivateVulnerabilityReporting = "private vulnerability reporting"
-	FeatureVulnerabilityAlerts           = "vulnerability alerts"
-	FeatureAutomatedSecurityFixes        = "automated security fixes"
-)
+// Operation identifies one GitHub API operation. Enable selects the enable or
+// disable description for the security feature kinds. Label carries the label
+// name for OpCreateLabel and OpUpdateLabel. The zero value means no operation.
+type Operation struct {
+	Kind   OperationKind
+	Enable bool
+	Label  string
+}
 
-// SecurityFeatureOp returns the operation name for enabling or disabling a
-// security feature, for example "enable vulnerability alerts".
-func SecurityFeatureOp(enable bool, feature string) string {
+// Op wraps a parameterless kind in an Operation.
+func Op(kind OperationKind) Operation {
+	return Operation{Kind: kind}
+}
+
+// SecurityFeatureOp returns the operation for enabling or disabling a
+// security feature, for example enabling vulnerability alerts.
+func SecurityFeatureOp(enable bool, kind OperationKind) Operation {
+	return Operation{Kind: kind, Enable: enable}
+}
+
+// CreateLabelOp returns the operation for creating the named label.
+func CreateLabelOp(name string) Operation {
+	return Operation{Kind: OpCreateLabel, Label: name}
+}
+
+// UpdateLabelOp returns the operation for updating the named label.
+func UpdateLabelOp(name string) Operation {
+	return Operation{Kind: OpUpdateLabel, Label: name}
+}
+
+// String returns the user-facing description of the operation, for example
+// "enable vulnerability alerts".
+func (o Operation) String() string {
+	switch o.Kind {
+	case OpFetchActionsPermissions:
+		return "fetch actions permissions"
+	case OpFetchSelectedActionsPermissions:
+		return "fetch selected actions permissions"
+	case OpSetActionsPermissions:
+		return "set actions permissions"
+	case OpSetSelectedActionsPermissions:
+		return "set selected actions permissions"
+	case OpDisableActionsForPolicyTransition:
+		return "disable actions for selected policy transition"
+	case OpDisableActionsForPolicyUpdate:
+		return "disable actions for selected policy update"
+	case OpFetchWorkflowPermissions:
+		return "fetch workflow permissions"
+	case OpSetWorkflowPermissions:
+		return "set workflow permissions"
+	case OpFetchPrivateVulnerabilityReporting:
+		return "fetch private vulnerability reporting"
+	case OpFetchVulnerabilityAlerts:
+		return "fetch vulnerability alerts"
+	case OpFetchAutomatedSecurityFixes:
+		return "fetch automated security fixes"
+	case OpSetPrivateVulnerabilityReporting:
+		return securityFeatureText(o.Enable, "private vulnerability reporting")
+	case OpSetVulnerabilityAlerts:
+		return securityFeatureText(o.Enable, "vulnerability alerts")
+	case OpSetAutomatedSecurityFixes:
+		return securityFeatureText(o.Enable, "automated security fixes")
+	case OpPatchRepoSettings:
+		return "patch repo settings"
+	case OpSetTopics:
+		return "set topics"
+	case OpCreateLabel:
+		return fmt.Sprintf("create label %q", o.Label)
+	case OpUpdateLabel:
+		return fmt.Sprintf("update label %q", o.Label)
+	default:
+		return ""
+	}
+}
+
+func securityFeatureText(enable bool, feature string) string {
 	if enable {
 		return "enable " + feature
 	}
 	return "disable " + feature
-}
-
-// CreateLabelOp returns the operation name for creating the named label.
-func CreateLabelOp(name string) string {
-	return fmt.Sprintf("create label %q", name)
-}
-
-// UpdateLabelOp returns the operation name for updating the named label.
-func UpdateLabelOp(name string) string {
-	return fmt.Sprintf("update label %q", name)
 }

--- a/internal/gh/ptr.go
+++ b/internal/gh/ptr.go
@@ -1,0 +1,16 @@
+package gh
+
+// isTrue reports whether p is a known true value.
+func isTrue(p *bool) bool {
+	return p != nil && *p
+}
+
+// isFalse reports whether p is a known false value.
+func isFalse(p *bool) bool {
+	return p != nil && !*p
+}
+
+// strEq reports whether p is a known value equal to want.
+func strEq(p *string, want string) bool {
+	return p != nil && *p == want
+}

--- a/internal/gh/settings.go
+++ b/internal/gh/settings.go
@@ -85,7 +85,7 @@ func ReadRepoSettings(client *api.RESTClient, owner, name string) (*model.Reposi
 	adminRead := false
 	var wfPerms workflowPermissionsResponse
 	if err := boundedHTTPError(client.Get(fmt.Sprintf("repos/%s/%s/actions/permissions/workflow", owner, name), &wfPerms)); err != nil {
-		classified := classifyHTTPError(err, OpFetchWorkflowPermissions)
+		classified := classifyHTTPError(err, Op(OpFetchWorkflowPermissions))
 		if isAccessError(classified) {
 			warnings = append(warnings, classified)
 		} else {
@@ -99,26 +99,26 @@ func ReadRepoSettings(client *api.RESTClient, owner, name string) (*model.Reposi
 
 	securityFeatures := []struct {
 		path             string
-		operation        string
+		operation        Operation
 		statusOnly       bool
 		allow404Disabled bool
 		set              func(bool)
 	}{
 		{
 			path:      fmt.Sprintf("repos/%s/%s/private-vulnerability-reporting", owner, name),
-			operation: OpFetchPrivateVulnerabilityReporting,
+			operation: Op(OpFetchPrivateVulnerabilityReporting),
 			set:       func(enabled bool) { s.PrivateVulnerabilityReportEnabled = new(enabled) },
 		},
 		{
 			path:             fmt.Sprintf("repos/%s/%s/vulnerability-alerts", owner, name),
-			operation:        OpFetchVulnerabilityAlerts,
+			operation:        Op(OpFetchVulnerabilityAlerts),
 			statusOnly:       true,
 			allow404Disabled: adminRead && repo.Permissions.Admin,
 			set:              func(enabled bool) { s.VulnerabilityAlertsEnabled = new(enabled) },
 		},
 		{
 			path:             fmt.Sprintf("repos/%s/%s/automated-security-fixes", owner, name),
-			operation:        OpFetchAutomatedSecurityFixes,
+			operation:        Op(OpFetchAutomatedSecurityFixes),
 			allow404Disabled: adminRead && repo.Permissions.Admin,
 			set:              func(enabled bool) { s.AutomatedSecurityFixesEnabled = new(enabled) },
 		},
@@ -170,8 +170,8 @@ func readSecurityFeature(client *api.RESTClient, path string, statusOnly, allow4
 // SkippedOperation records a sub-operation that was skipped due to
 // insufficient token scope.
 type SkippedOperation struct {
-	Operation string // e.g. "set workflow permissions"
-	Err       error  // *ErrInsufficientScope
+	Operation Operation
+	Err       error // *ErrInsufficientScope
 }
 
 // ApplyResult collects the outcome of ApplyRepoSettings. Skipped lists
@@ -183,7 +183,7 @@ type ApplyResult struct {
 // recordAccessError appends the operation to result.Skipped when err is an
 // access error, and reports whether it did. Other errors are left to the
 // caller to return as hard failures.
-func recordAccessError(result *ApplyResult, operation string, err error) bool {
+func recordAccessError(result *ApplyResult, operation Operation, err error) bool {
 	classified := classifyHTTPError(err, operation)
 	if !isAccessError(classified) {
 		return false
@@ -216,7 +216,7 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 			return nil, fmt.Errorf("marshalling repo settings: %w", err)
 		}
 		if err := boundedHTTPError(client.Patch(fmt.Sprintf("repos/%s/%s", owner, name), bytes.NewReader(payload), nil)); err != nil {
-			if !recordAccessError(result, OpPatchRepoSettings, err) {
+			if !recordAccessError(result, Op(OpPatchRepoSettings), err) {
 				return nil, fmt.Errorf("patching repo settings: %w", err)
 			}
 		}
@@ -248,7 +248,7 @@ func applyPrivateVulnerabilityReporting(client *api.RESTClient, owner, name stri
 		return nil
 	}
 	path := fmt.Sprintf("repos/%s/%s/private-vulnerability-reporting", owner, name)
-	_, err := applySecuritySetting(client, path, *p.PrivateVulnerabilityReporting, FeaturePrivateVulnerabilityReporting, result)
+	_, err := applySecuritySetting(client, path, *p.PrivateVulnerabilityReporting, OpSetPrivateVulnerabilityReporting, result)
 	return err
 }
 
@@ -264,7 +264,7 @@ func applyVulnerabilityAlertsAndFixes(client *api.RESTClient, owner, name string
 	fixesDisabled := current != nil && isFalse(current.AutomatedSecurityFixesEnabled)
 	if isFalse(p.AutomatedSecurityFixes) && !fixesDisabled {
 		var err error
-		fixesDisabled, err = applySecuritySetting(client, fixesPath, false, FeatureAutomatedSecurityFixes, result)
+		fixesDisabled, err = applySecuritySetting(client, fixesPath, false, OpSetAutomatedSecurityFixes, result)
 		if err != nil {
 			return err
 		}
@@ -273,21 +273,21 @@ func applyVulnerabilityAlertsAndFixes(client *api.RESTClient, owner, name string
 		if p.AutomatedSecurityFixes == nil {
 			return fmt.Errorf("cannot disable vulnerability alerts while automated security fixes are unmanaged")
 		}
-		appendSkippedDependency(result, SecurityFeatureOp(false, FeatureVulnerabilityAlerts))
+		appendSkippedDependency(result, SecurityFeatureOp(false, OpSetVulnerabilityAlerts))
 	}
 	alertsApplied := true
 	if p.VulnerabilityAlerts != nil && (*p.VulnerabilityAlerts || fixesDisabled) {
 		var err error
-		alertsApplied, err = applySecuritySetting(client, alertsPath, *p.VulnerabilityAlerts, FeatureVulnerabilityAlerts, result)
+		alertsApplied, err = applySecuritySetting(client, alertsPath, *p.VulnerabilityAlerts, OpSetVulnerabilityAlerts, result)
 		if err != nil {
 			return err
 		}
 		if !alertsApplied && isTrue(p.AutomatedSecurityFixes) {
-			appendSkippedDependency(result, SecurityFeatureOp(true, FeatureAutomatedSecurityFixes))
+			appendSkippedDependency(result, SecurityFeatureOp(true, OpSetAutomatedSecurityFixes))
 		}
 	}
 	if isTrue(p.AutomatedSecurityFixes) && alertsApplied {
-		if _, err := applySecuritySetting(client, fixesPath, true, FeatureAutomatedSecurityFixes, result); err != nil {
+		if _, err := applySecuritySetting(client, fixesPath, true, OpSetAutomatedSecurityFixes, result); err != nil {
 			return err
 		}
 	}
@@ -307,14 +307,14 @@ func applyTopics(client *api.RESTClient, owner, name string, p settingsPayload, 
 		return fmt.Errorf("marshalling topics: %w", err)
 	}
 	if err := boundedHTTPError(client.Put(fmt.Sprintf("repos/%s/%s/topics", owner, name), bytes.NewReader(payload), nil)); err != nil {
-		if !recordAccessError(result, OpSetTopics, err) {
+		if !recordAccessError(result, Op(OpSetTopics), err) {
 			return fmt.Errorf("setting topics: %w", err)
 		}
 	}
 	return nil
 }
 
-func applySecuritySetting(client *api.RESTClient, path string, enabled bool, feature string, result *ApplyResult) (bool, error) {
+func applySecuritySetting(client *api.RESTClient, path string, enabled bool, kind OperationKind, result *ApplyResult) (bool, error) {
 	var err error
 	if enabled {
 		err = boundedHTTPError(client.Put(path, bytes.NewReader([]byte("{}")), nil))
@@ -324,7 +324,7 @@ func applySecuritySetting(client *api.RESTClient, path string, enabled bool, fea
 	if err == nil {
 		return true, nil
 	}
-	operation := SecurityFeatureOp(enabled, feature)
+	operation := SecurityFeatureOp(enabled, kind)
 	if recordAccessError(result, operation, err) {
 		return false, nil
 	}
@@ -334,7 +334,7 @@ func applySecuritySetting(client *api.RESTClient, path string, enabled bool, fea
 // appendSkippedDependency records an operation that was not attempted because
 // a prerequisite operation was skipped, reusing the error from the most
 // recent skip. It does nothing when nothing was skipped.
-func appendSkippedDependency(result *ApplyResult, operation string) {
+func appendSkippedDependency(result *ApplyResult, operation Operation) {
 	if len(result.Skipped) == 0 {
 		return
 	}
@@ -354,7 +354,7 @@ func applyWorkflowPermissions(client *api.RESTClient, owner, name string, p sett
 		return nil
 	}
 	if err := putWorkflowPermissions(client, owner, name, p); err != nil {
-		if !recordAccessError(result, OpSetWorkflowPermissions, err) {
+		if !recordAccessError(result, Op(OpSetWorkflowPermissions), err) {
 			return err
 		}
 	}

--- a/internal/gh/settings.go
+++ b/internal/gh/settings.go
@@ -222,13 +222,43 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 		}
 	}
 
-	if p.PrivateVulnerabilityReporting != nil {
-		path := fmt.Sprintf("repos/%s/%s/private-vulnerability-reporting", owner, name)
-		if _, err := applySecuritySetting(client, path, *p.PrivateVulnerabilityReporting, FeaturePrivateVulnerabilityReporting, result); err != nil {
-			return nil, err
-		}
+	if err := applyPrivateVulnerabilityReporting(client, owner, name, p, result); err != nil {
+		return nil, err
 	}
 
+	if err := applyVulnerabilityAlertsAndFixes(client, owner, name, p, current, result); err != nil {
+		return nil, err
+	}
+
+	if err := applyWorkflowPermissions(client, owner, name, p, result); err != nil {
+		return nil, err
+	}
+
+	if err := applyTopics(client, owner, name, p, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// applyPrivateVulnerabilityReporting toggles the private vulnerability
+// reporting endpoint when the field is declared.
+func applyPrivateVulnerabilityReporting(client *api.RESTClient, owner, name string, p settingsPayload, result *ApplyResult) error {
+	if p.PrivateVulnerabilityReporting == nil {
+		return nil
+	}
+	path := fmt.Sprintf("repos/%s/%s/private-vulnerability-reporting", owner, name)
+	_, err := applySecuritySetting(client, path, *p.PrivateVulnerabilityReporting, FeaturePrivateVulnerabilityReporting, result)
+	return err
+}
+
+// applyVulnerabilityAlertsAndFixes sequences the vulnerability-alerts and
+// automated-security-fixes endpoints. GitHub couples the two features, so the
+// order is fixed: disable automated security fixes before disabling
+// vulnerability alerts, and enable vulnerability alerts before enabling
+// automated security fixes. current, when non-nil, supplies the live state so
+// an already disabled fixes feature is not disabled again.
+func applyVulnerabilityAlertsAndFixes(client *api.RESTClient, owner, name string, p settingsPayload, current *model.RepositorySettings, result *ApplyResult) error {
 	alertsPath := fmt.Sprintf("repos/%s/%s/vulnerability-alerts", owner, name)
 	fixesPath := fmt.Sprintf("repos/%s/%s/automated-security-fixes", owner, name)
 	fixesDisabled := current != nil && current.AutomatedSecurityFixesEnabled != nil && !*current.AutomatedSecurityFixesEnabled
@@ -236,12 +266,12 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 		var err error
 		fixesDisabled, err = applySecuritySetting(client, fixesPath, false, FeatureAutomatedSecurityFixes, result)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 	if !fixesDisabled && p.VulnerabilityAlerts != nil && !*p.VulnerabilityAlerts {
 		if p.AutomatedSecurityFixes == nil {
-			return nil, fmt.Errorf("cannot disable vulnerability alerts while automated security fixes are unmanaged")
+			return fmt.Errorf("cannot disable vulnerability alerts while automated security fixes are unmanaged")
 		}
 		appendSkippedDependency(result, SecurityFeatureOp(false, FeatureVulnerabilityAlerts))
 	}
@@ -250,7 +280,7 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 		var err error
 		alertsApplied, err = applySecuritySetting(client, alertsPath, *p.VulnerabilityAlerts, FeatureVulnerabilityAlerts, result)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if !alertsApplied && p.AutomatedSecurityFixes != nil && *p.AutomatedSecurityFixes {
 			appendSkippedDependency(result, SecurityFeatureOp(true, FeatureAutomatedSecurityFixes))
@@ -258,34 +288,30 @@ func applyRepoSettings(client *api.RESTClient, owner, name string, settings, cur
 	}
 	if p.AutomatedSecurityFixes != nil && *p.AutomatedSecurityFixes && alertsApplied {
 		if _, err := applySecuritySetting(client, fixesPath, true, FeatureAutomatedSecurityFixes, result); err != nil {
-			return nil, err
+			return err
 		}
 	}
+	return nil
+}
 
-	if p.DefaultWorkflowPermissions != nil || p.CanApprovePullRequestReviews != nil {
-		if err := applyWorkflowPermissions(client, owner, name, p); err != nil {
-			if !recordAccessError(result, OpSetWorkflowPermissions, err) {
-				return nil, err
-			}
+// applyTopics replaces the repository topics when the field is declared.
+func applyTopics(client *api.RESTClient, owner, name string, p settingsPayload, result *ApplyResult) error {
+	if p.Topics == nil {
+		return nil
+	}
+	topicsBody := struct {
+		Names []string `json:"names"`
+	}{Names: *p.Topics}
+	payload, err := json.Marshal(topicsBody)
+	if err != nil {
+		return fmt.Errorf("marshalling topics: %w", err)
+	}
+	if err := boundedHTTPError(client.Put(fmt.Sprintf("repos/%s/%s/topics", owner, name), bytes.NewReader(payload), nil)); err != nil {
+		if !recordAccessError(result, OpSetTopics, err) {
+			return fmt.Errorf("setting topics: %w", err)
 		}
 	}
-
-	if p.Topics != nil {
-		topicsBody := struct {
-			Names []string `json:"names"`
-		}{Names: *p.Topics}
-		payload, err := json.Marshal(topicsBody)
-		if err != nil {
-			return nil, fmt.Errorf("marshalling topics: %w", err)
-		}
-		if err := boundedHTTPError(client.Put(fmt.Sprintf("repos/%s/%s/topics", owner, name), bytes.NewReader(payload), nil)); err != nil {
-			if !recordAccessError(result, OpSetTopics, err) {
-				return nil, fmt.Errorf("setting topics: %w", err)
-			}
-		}
-	}
-
-	return result, nil
+	return nil
 }
 
 func applySecuritySetting(client *api.RESTClient, path string, enabled bool, feature string, result *ApplyResult) (bool, error) {
@@ -319,10 +345,24 @@ func appendSkippedDependency(result *ApplyResult, operation string) {
 }
 
 // applyWorkflowPermissions sends a PUT to the Actions workflow permissions
-// endpoint. The endpoint replaces both fields atomically, so when only one
-// field is declared in the config, the other is fetched from the current
-// repository state.
-func applyWorkflowPermissions(client *api.RESTClient, owner, name string, p settingsPayload) error {
+// endpoint when either field is declared. The endpoint replaces both fields
+// atomically, so when only one field is declared in the config, the other is
+// fetched from the current repository state. Access errors are recorded in
+// result rather than returned.
+func applyWorkflowPermissions(client *api.RESTClient, owner, name string, p settingsPayload, result *ApplyResult) error {
+	if p.DefaultWorkflowPermissions == nil && p.CanApprovePullRequestReviews == nil {
+		return nil
+	}
+	if err := putWorkflowPermissions(client, owner, name, p); err != nil {
+		if !recordAccessError(result, OpSetWorkflowPermissions, err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// putWorkflowPermissions builds the complete PUT body and sends it.
+func putWorkflowPermissions(client *api.RESTClient, owner, name string, p settingsPayload) error {
 	wfpPath := fmt.Sprintf("repos/%s/%s/actions/permissions/workflow", owner, name)
 
 	perms := p.DefaultWorkflowPermissions

--- a/internal/gh/settings.go
+++ b/internal/gh/settings.go
@@ -261,15 +261,15 @@ func applyPrivateVulnerabilityReporting(client *api.RESTClient, owner, name stri
 func applyVulnerabilityAlertsAndFixes(client *api.RESTClient, owner, name string, p settingsPayload, current *model.RepositorySettings, result *ApplyResult) error {
 	alertsPath := fmt.Sprintf("repos/%s/%s/vulnerability-alerts", owner, name)
 	fixesPath := fmt.Sprintf("repos/%s/%s/automated-security-fixes", owner, name)
-	fixesDisabled := current != nil && current.AutomatedSecurityFixesEnabled != nil && !*current.AutomatedSecurityFixesEnabled
-	if p.AutomatedSecurityFixes != nil && !*p.AutomatedSecurityFixes && !fixesDisabled {
+	fixesDisabled := current != nil && isFalse(current.AutomatedSecurityFixesEnabled)
+	if isFalse(p.AutomatedSecurityFixes) && !fixesDisabled {
 		var err error
 		fixesDisabled, err = applySecuritySetting(client, fixesPath, false, FeatureAutomatedSecurityFixes, result)
 		if err != nil {
 			return err
 		}
 	}
-	if !fixesDisabled && p.VulnerabilityAlerts != nil && !*p.VulnerabilityAlerts {
+	if !fixesDisabled && isFalse(p.VulnerabilityAlerts) {
 		if p.AutomatedSecurityFixes == nil {
 			return fmt.Errorf("cannot disable vulnerability alerts while automated security fixes are unmanaged")
 		}
@@ -282,11 +282,11 @@ func applyVulnerabilityAlertsAndFixes(client *api.RESTClient, owner, name string
 		if err != nil {
 			return err
 		}
-		if !alertsApplied && p.AutomatedSecurityFixes != nil && *p.AutomatedSecurityFixes {
+		if !alertsApplied && isTrue(p.AutomatedSecurityFixes) {
 			appendSkippedDependency(result, SecurityFeatureOp(true, FeatureAutomatedSecurityFixes))
 		}
 	}
-	if p.AutomatedSecurityFixes != nil && *p.AutomatedSecurityFixes && alertsApplied {
+	if isTrue(p.AutomatedSecurityFixes) && alertsApplied {
 		if _, err := applySecuritySetting(client, fixesPath, true, FeatureAutomatedSecurityFixes, result); err != nil {
 			return err
 		}

--- a/internal/gh/settings_test.go
+++ b/internal/gh/settings_test.go
@@ -740,8 +740,8 @@ func TestApplyRepoSettingsPatch403Skipped(t *testing.T) {
 	if len(result.Skipped) != 1 {
 		t.Fatalf("expected 1 skipped operation, got %d", len(result.Skipped))
 	}
-	if result.Skipped[0].Operation != "patch repo settings" {
-		t.Errorf("skipped operation = %q, want %q", result.Skipped[0].Operation, "patch repo settings")
+	if result.Skipped[0].Operation.String() != "patch repo settings" {
+		t.Errorf("skipped operation = %q, want %q", result.Skipped[0].Operation.String(), "patch repo settings")
 	}
 }
 
@@ -879,8 +879,8 @@ func TestApplyRepoSettingsWorkflowPermsGetError(t *testing.T) {
 	if len(result.Skipped) != 1 {
 		t.Fatalf("expected 1 skipped operation, got %d", len(result.Skipped))
 	}
-	if result.Skipped[0].Operation != "set workflow permissions" {
-		t.Errorf("skipped operation = %q, want %q", result.Skipped[0].Operation, "set workflow permissions")
+	if result.Skipped[0].Operation.String() != "set workflow permissions" {
+		t.Errorf("skipped operation = %q, want %q", result.Skipped[0].Operation.String(), "set workflow permissions")
 	}
 }
 
@@ -1057,7 +1057,7 @@ func TestApplyRepoSettingsPartialTopics403(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected hard error: %v", err)
 	}
-	if len(result.Skipped) != 1 || result.Skipped[0].Operation != "set topics" {
+	if len(result.Skipped) != 1 || result.Skipped[0].Operation.String() != "set topics" {
 		t.Errorf("Skipped = %v, want [{set topics ...}]", result.Skipped)
 	}
 }
@@ -1197,7 +1197,7 @@ func TestApplyRepoSettingsSecurityFeatureAccessErrorIsSkipped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ApplyRepoSettings() error: %v", err)
 	}
-	if len(result.Skipped) != 1 || result.Skipped[0].Operation != "enable vulnerability alerts" {
+	if len(result.Skipped) != 1 || result.Skipped[0].Operation.String() != "enable vulnerability alerts" {
 		t.Errorf("Skipped = %v, want enable vulnerability alerts", result.Skipped)
 	}
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -69,7 +69,8 @@ type RepositorySettings struct {
 	Extra map[string]interface{} `yaml:",inline"`
 }
 
-// RepositorySettingField describes one supported repository setting.
+// RepositorySettingField describes one supported setting field, keyed by its
+// yaml tag. ActionsSettingFields reuses this type for Actions settings.
 type RepositorySettingField struct {
 	YAMLKey string
 	Index   int
@@ -80,7 +81,18 @@ type RepositorySettingField struct {
 // RepositorySettingFields returns supported repository settings in struct order.
 // Extra is excluded because it stores unknown YAML keys.
 func RepositorySettingFields(settings *RepositorySettings) []RepositorySettingField {
-	t := reflect.TypeOf(RepositorySettings{})
+	return settingFields(settings)
+}
+
+// ActionsSettingFields returns supported Actions settings in struct order.
+// Extra is excluded because it stores unknown YAML keys.
+func ActionsSettingFields(settings *ActionsSettings) []RepositorySettingField {
+	return settingFields(settings)
+}
+
+// settingFields walks the yaml-tagged pointer fields of a settings struct.
+func settingFields[T any](settings *T) []RepositorySettingField {
+	t := reflect.TypeFor[T]()
 	var v reflect.Value
 	if settings != nil {
 		v = reflect.ValueOf(settings).Elem()

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -49,6 +49,31 @@ func TestRepositorySettingFieldsMetadata(t *testing.T) {
 	}
 }
 
+func TestActionsSettingFieldsMetadata(t *testing.T) {
+	fields := ActionsSettingFields(nil)
+
+	wantKeys := []string{
+		"enabled",
+		"allowed_actions",
+		"sha_pinning_required",
+		"github_owned_allowed",
+		"verified_allowed",
+		"patterns_allowed",
+	}
+
+	if len(fields) != len(wantKeys) {
+		t.Fatalf("got %d fields, want %d", len(fields), len(wantKeys))
+	}
+	for i, want := range wantKeys {
+		if fields[i].YAMLKey != want {
+			t.Errorf("field %d YAMLKey = %q, want %q", i, fields[i].YAMLKey, want)
+		}
+		if fields[i].Set {
+			t.Errorf("field %s Set = true for nil settings", fields[i].YAMLKey)
+		}
+	}
+}
+
 func TestRepositorySettingFieldsValues(t *testing.T) {
 	topics := []string{"go", "cli"}
 	settings := &RepositorySettings{


### PR DESCRIPTION
Addresses a code-smells review with seven behaviour-preserving refactors across the gh, alter, and config packages. Repository targets in alter now travel as one RepoTarget struct instead of four separate parameters; gh operations carry typed OperationKind identifiers instead of reconstructed prose strings; actions policy fields are grouped in one table instead of repeated field-name literals; pointer nil checks collapse into isTrue/isFalse/strEq helpers; config settings blocks render from field enumerators instead of 28 hand-written template blocks; ApplyActionsPolicy resolves its write order through named strategies instead of eight derived boolean flags; and applyRepoSettings splits into per-endpoint helpers. No user-visible output, API signature, or write order changes.

Verified with `go test ./...`; the golden config-spec tests confirm byte-identical output.
