### PR TITLE
fix: address peer review findings across config, alter, release tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .direnv/
+dist/
 result/
 /tailor
 # Override global gitignore `result*` pattern that excludes Go source files

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -99,7 +99,9 @@ homebrew_casks:
     license: BlueOak-1.0.0
 
 aurs:
-  - name: tailor-bin
+  - ids:
+      - compressed
+    name: tailor-bin
     description: "Ready-to-wear project templates for GitHub repositories."
     homepage: https://github.com/wimpysworld/tailor
     maintainers:

--- a/internal/alter/format.go
+++ b/internal/alter/format.go
@@ -14,6 +14,12 @@ import (
 // with padding.
 const defaultLabelWidth = 37
 
+// outputLine pairs a status label with the text that follows it.
+type outputLine struct {
+	label string
+	text  string
+}
+
 // FormatOutput produces the alter command output from repo settings results,
 // label results, and swatch results (including licence).
 func FormatOutput(repoResults []RepoSettingResult, labelResults []LabelResult, swatchResults []SwatchResult, mode ApplyMode) string {
@@ -21,56 +27,87 @@ func FormatOutput(repoResults []RepoSettingResult, labelResults []LabelResult, s
 		return ""
 	}
 	if mode.ShouldWrite() {
-		repoResults = removeSkippedRepoResults(repoResults)
-		labelResults = removeSkippedLabelResults(labelResults)
+		repoResults = removeSkipped(repoResults, repoSkippedKind, repoActionKind)
+		labelResults = removeSkipped(labelResults, labelSkippedName, labelActionName)
 	}
 
-	sortedSwatches := sortSwatchResults(swatchResults)
-	width := labelWidth(repoResults, labelResults, sortedSwatches, mode)
+	lines := slices.Concat(repoLines(repoResults, mode), labelLines(labelResults, mode), swatchLines(swatchResults, mode))
+
+	width := defaultLabelWidth
+	for _, line := range lines {
+		if w := len(line.label) + 1; w > width {
+			width = w
+		}
+	}
 
 	var b strings.Builder
+	for _, line := range lines {
+		fmt.Fprintf(&b, "%-*s%s\n", width, line.label, line.text)
+	}
+	return b.String()
+}
 
-	for _, r := range sortRepoResults(repoResults) {
-		label := repoLabel(r, mode)
-		section := r.Section
-		if section == "" {
-			section = "repository"
-		}
+// repoLines renders repo setting results as sorted output lines.
+func repoLines(results []RepoSettingResult, mode ApplyMode) []outputLine {
+	order := func(r RepoSettingResult) int { return repoOrder(r.Category) }
+	lines := make([]outputLine, 0, len(results))
+	for _, r := range sortResults(results, order, repoSortKey) {
+		section := cmp.Or(r.Section, "repository")
+		var text string
 		switch r.Category {
 		case WouldSet:
-			fmt.Fprintf(&b, "%-*s%s.%s = %s\n", width, label, section, r.Field, r.Value)
+			text = fmt.Sprintf("%s.%s = %s", section, r.Field, r.Value)
 		case RepoNoChange:
-			fmt.Fprintf(&b, "%-*s%s.%s (already %s)\n", width, label, section, r.Field, r.Value)
+			text = fmt.Sprintf("%s.%s (already %s)", section, r.Field, r.Value)
 		case WouldSkipScope:
 			switch {
 			case r.Field == "":
-				fmt.Fprintf(&b, "%-*s%s\n", width, label, r.Operation)
+				text = r.Operation.String()
 			case r.Section == "actions" && isActionsPolicyField(r.Field):
-				fmt.Fprintf(&b, "%-*sactions.%s\n", width, label, r.Field)
+				text = "actions." + r.Field
 			default:
-				fmt.Fprintf(&b, "%-*s%s\n", width, label, r.Field)
+				text = r.Field
 			}
+		default:
+			continue
 		}
+		label := resultLabel(string(r.Category), r.Annotation, r.Category == WouldSkipScope, mode)
+		lines = append(lines, outputLine{label, text})
 	}
+	return lines
+}
 
-	for _, r := range sortLabelResults(labelResults) {
-		label := labelResultLabel(r, mode)
+// labelLines renders label results as sorted output lines.
+func labelLines(results []LabelResult, mode ApplyMode) []outputLine {
+	order := func(r LabelResult) int { return labelOrder(r.Category) }
+	lines := make([]outputLine, 0, len(results))
+	for _, r := range sortResults(results, order, labelSortKey) {
+		var text string
 		switch r.Category {
 		case WouldCreate, WouldUpdate:
-			fmt.Fprintf(&b, "%-*slabel.%s = %s\n", width, label, r.Name, r.Value)
+			text = fmt.Sprintf("label.%s = %s", r.Name, r.Value)
 		case LabelNoChange:
-			fmt.Fprintf(&b, "%-*slabel.%s (already %s)\n", width, label, r.Name, r.Value)
+			text = fmt.Sprintf("label.%s (already %s)", r.Name, r.Value)
 		case LabelSkipScope:
-			fmt.Fprintf(&b, "%-*s%s\n", width, label, r.Operation)
+			text = r.Operation.String()
+		default:
+			continue
 		}
+		label := resultLabel(string(r.Category), r.Annotation, r.Category == LabelSkipScope, mode)
+		lines = append(lines, outputLine{label, text})
 	}
+	return lines
+}
 
-	for _, r := range sortedSwatches {
-		label := swatchLabel(r, mode)
-		fmt.Fprintf(&b, "%-*s%s%s\n", width, label, r.Path, swatchReason(r))
+// swatchLines renders swatch results as sorted output lines.
+func swatchLines(results []SwatchResult, mode ApplyMode) []outputLine {
+	key := func(r SwatchResult) string { return r.Path }
+	lines := make([]outputLine, 0, len(results))
+	for _, r := range sortResults(results, swatchOrder, key) {
+		label := resultLabel(string(r.Category), "", false, mode)
+		lines = append(lines, outputLine{label, r.Path + swatchReason(r)})
 	}
-
-	return b.String()
+	return lines
 }
 
 func isActionsPolicyField(field string) bool {
@@ -78,78 +115,79 @@ func isActionsPolicyField(field string) bool {
 	return ok
 }
 
-func removeSkippedRepoResults(results []RepoSettingResult) []RepoSettingResult {
-	skipped := make(map[gh.OperationKind]bool)
+// removeSkipped drops actionable results whose write operation was reported
+// as skipped. skipKey identifies the skipped operation a scope-skip result
+// records; actionKey identifies the operation an actionable result would
+// perform. Each returns false when the result is not of its kind.
+func removeSkipped[T any, K comparable](results []T, skipKey, actionKey func(T) (K, bool)) []T {
+	skipped := make(map[K]bool)
 	for _, result := range results {
-		if result.Category == WouldSkipScope && result.Operation.Kind != gh.OpNone {
-			skipped[result.Operation.Kind] = true
+		if key, ok := skipKey(result); ok {
+			skipped[key] = true
 		}
 	}
 	if len(skipped) == 0 {
 		return results
 	}
 
-	filtered := make([]RepoSettingResult, 0, len(results))
+	filtered := make([]T, 0, len(results))
 	for _, result := range results {
-		if result.Category != WouldSet || !skipped[repoSettingWriteKind(result)] {
+		if key, ok := actionKey(result); !ok || !skipped[key] {
 			filtered = append(filtered, result)
 		}
 	}
 	return filtered
 }
 
-// repoSettingWriteKind returns the kind of the write operation that applies
-// the result's field.
-func repoSettingWriteKind(result RepoSettingResult) gh.OperationKind {
-	if result.Section == "actions" {
-		if group, ok := actionsFieldGroupFor(result.Field); ok {
-			return group.writeOperation()
+// repoSkippedKind returns the operation kind a scope-skip result records.
+func repoSkippedKind(r RepoSettingResult) (gh.OperationKind, bool) {
+	return r.Operation.Kind, r.Category == WouldSkipScope && r.Operation.Kind != gh.OpNone
+}
+
+// repoActionKind returns the kind of the write operation that applies an
+// actionable result's field.
+func repoActionKind(r RepoSettingResult) (gh.OperationKind, bool) {
+	if r.Category != WouldSet {
+		return gh.OpNone, false
+	}
+	if r.Section == "actions" {
+		if group, ok := actionsFieldGroupFor(r.Field); ok {
+			return group.writeOperation(), true
 		}
 	}
-	switch result.Field {
+	switch r.Field {
 	case "private_vulnerability_reporting_enabled":
-		return gh.OpSetPrivateVulnerabilityReporting
+		return gh.OpSetPrivateVulnerabilityReporting, true
 	case "vulnerability_alerts_enabled":
-		return gh.OpSetVulnerabilityAlerts
+		return gh.OpSetVulnerabilityAlerts, true
 	case "automated_security_fixes_enabled":
-		return gh.OpSetAutomatedSecurityFixes
+		return gh.OpSetAutomatedSecurityFixes, true
 	case "topics":
-		return gh.OpSetTopics
+		return gh.OpSetTopics, true
 	case "default_workflow_permissions", "can_approve_pull_request_reviews":
-		return gh.OpSetWorkflowPermissions
+		return gh.OpSetWorkflowPermissions, true
 	default:
-		return gh.OpPatchRepoSettings
+		return gh.OpPatchRepoSettings, true
 	}
 }
 
-func removeSkippedLabelResults(results []LabelResult) []LabelResult {
-	skipped := make(map[string]bool)
-	for _, result := range results {
-		if result.Category == LabelSkipScope {
-			skipped[result.Operation.Label] = true
-		}
-	}
-	if len(skipped) == 0 {
-		return results
-	}
-
-	filtered := make([]LabelResult, 0, len(results))
-	for _, result := range results {
-		actionable := result.Category == WouldCreate || result.Category == WouldUpdate
-		if !actionable || !skipped[result.Name] {
-			filtered = append(filtered, result)
-		}
-	}
-	return filtered
+// labelSkippedName returns the label name a scope-skip result records.
+func labelSkippedName(r LabelResult) (string, bool) {
+	return r.Operation.Label, r.Category == LabelSkipScope
 }
 
-// formatAnnotatedLabel embeds an annotation into a skip-category label when
-// isSkip is true and annotation is non-empty. For example:
-// "would skip (insufficient scope: token missing required scope):".
-func formatAnnotatedLabel(category, annotation string, isSkip bool) string {
+// labelActionName returns the label name an actionable result would write.
+func labelActionName(r LabelResult) (string, bool) {
+	return r.Name, r.Category == WouldCreate || r.Category == WouldUpdate
+}
+
+// resultLabel formats a status label, translating dry-run categories to
+// write-mode wording and embedding a skip annotation when present. For
+// example: "would skip (insufficient scope: token missing required scope):".
+func resultLabel(category, annotation string, isSkip bool, mode ApplyMode) string {
+	category = outputCategory(category, mode)
 	if annotation != "" && isSkip {
-		base := strings.TrimSuffix(category, ")")
-		return base + ": " + annotation + "):"
+		return strings.TrimSuffix(category, ")") + ": " + annotation + "):"
 	}
 	return category + ":"
 }
@@ -177,22 +215,6 @@ func outputCategory(category string, mode ApplyMode) string {
 	}
 }
 
-// repoLabel returns the formatted label for a repo setting result.
-func repoLabel(r RepoSettingResult, mode ApplyMode) string {
-	isSkip := r.Category == WouldSkipScope
-	return formatAnnotatedLabel(outputCategory(string(r.Category), mode), r.Annotation, isSkip)
-}
-
-// labelResultLabel returns the formatted label for a label result.
-func labelResultLabel(r LabelResult, mode ApplyMode) string {
-	isSkip := r.Category == LabelSkipScope
-	return formatAnnotatedLabel(outputCategory(string(r.Category), mode), r.Annotation, isSkip)
-}
-
-func swatchLabel(r SwatchResult, mode ApplyMode) string {
-	return outputCategory(string(r.Category), mode) + ":"
-}
-
 func swatchReason(r SwatchResult) string {
 	if r.Reason == "" {
 		return ""
@@ -200,37 +222,14 @@ func swatchReason(r SwatchResult) string {
 	return " (" + string(r.Reason) + ")"
 }
 
-// labelWidth computes the column width needed to accommodate all labels. It
-// returns at least defaultLabelWidth, widening if any annotated label exceeds
-// that.
-func labelWidth(repos []RepoSettingResult, labels []LabelResult, swatches []SwatchResult, mode ApplyMode) int {
-	width := defaultLabelWidth
-	for _, r := range repos {
-		if w := len(repoLabel(r, mode)) + 1; w > width {
-			width = w
-		}
-	}
-	for _, r := range labels {
-		if w := len(labelResultLabel(r, mode)) + 1; w > width {
-			width = w
-		}
-	}
-	for _, r := range swatches {
-		if w := len(swatchLabel(r, mode)) + 1; w > width {
-			width = w
-		}
-	}
-	return width
-}
-
-// sortRepoResults returns a sorted copy: actionable (WouldSet) before
-// informational (RepoNoChange), lexicographic by sort key within each group.
-func sortRepoResults(results []RepoSettingResult) []RepoSettingResult {
-	return slices.SortedStableFunc(slices.Values(results), func(a, b RepoSettingResult) int {
-		if c := cmp.Compare(repoOrder(a.Category), repoOrder(b.Category)); c != 0 {
+// sortResults returns a sorted copy: actionable categories before
+// informational, lexicographic by sort key within each priority.
+func sortResults[T any](results []T, order func(T) int, key func(T) string) []T {
+	return slices.SortedStableFunc(slices.Values(results), func(a, b T) int {
+		if c := cmp.Compare(order(a), order(b)); c != 0 {
 			return c
 		}
-		return cmp.Compare(repoSortKey(a), repoSortKey(b))
+		return cmp.Compare(key(a), key(b))
 	})
 }
 
@@ -255,28 +254,6 @@ func repoOrder(c RepoSettingCategory) int {
 	default:
 		return 3
 	}
-}
-
-// sortSwatchResults returns a sorted copy with actionable results before
-// informational results and paths sorted within each category.
-func sortSwatchResults(results []SwatchResult) []SwatchResult {
-	return slices.SortedStableFunc(slices.Values(results), func(a, b SwatchResult) int {
-		if c := cmp.Compare(swatchOrder(a), swatchOrder(b)); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.Path, b.Path)
-	})
-}
-
-// sortLabelResults returns a sorted copy: actionable (WouldCreate, WouldUpdate)
-// before informational (LabelNoChange), lexicographic by sort key within each group.
-func sortLabelResults(results []LabelResult) []LabelResult {
-	return slices.SortedStableFunc(slices.Values(results), func(a, b LabelResult) int {
-		if c := cmp.Compare(labelOrder(a.Category), labelOrder(b.Category)); c != 0 {
-			return c
-		}
-		return cmp.Compare(labelSortKey(a), labelSortKey(b))
-	})
 }
 
 // labelSortKey returns the label name, or the skipped operation text for

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -35,6 +35,14 @@ func MergeDefaults(cfg *Config) (bool, error) {
 	return swatchesChanged || repoChanged || actionsChanged || labelsChanged, nil
 }
 
+// actionsSelectedOnlyFields lists ActionsSettings YAML keys merged only when
+// the effective allowed_actions policy is "selected".
+var actionsSelectedOnlyFields = map[string]bool{
+	"github_owned_allowed": true,
+	"verified_allowed":     true,
+	"patterns_allowed":     true,
+}
+
 // mergeRepoSettingsFrom fills nil pointer fields in cfg.Repository from the
 // provided defaults.
 func mergeRepoSettingsFrom(cfg *Config, defaults *Config) bool {
@@ -54,28 +62,18 @@ func mergeRepoSettingsFrom(cfg *Config, defaults *Config) bool {
 		if repoSettingsSkipFields[field.YAMLKey] {
 			continue
 		}
-		if !field.Set {
-			continue
+		if mergeSettingField(cv.Field(field.Index), field) {
+			changed = true
 		}
-
-		dfv := field.Value
-		cfv := cv.Field(field.Index)
-		if !cfv.IsNil() {
-			continue
-		}
-
-		// Allocate a new value and copy from the default.
-		newVal := reflect.New(dfv.Elem().Type())
-		newVal.Elem().Set(dfv.Elem())
-		cfv.Set(newVal)
-		changed = true
 	}
 
 	return changed
 }
 
 // mergeActionsFrom fills missing Actions policy fields from the defaults.
-// Selected-action fields apply only when the effective policy is selected.
+// Selected-action fields apply only when the effective policy is selected;
+// allowed_actions precedes them in struct order, so the policy check sees
+// the merged value.
 func mergeActionsFrom(cfg *Config, defaults *Config) bool {
 	if defaults.Actions == nil {
 		return false
@@ -84,39 +82,44 @@ func mergeActionsFrom(cfg *Config, defaults *Config) bool {
 		cfg.Actions = &model.ActionsSettings{}
 	}
 
+	cv := reflect.ValueOf(cfg.Actions).Elem()
+
 	changed := false
-	mergeBool := func(current **bool, fallback *bool) {
-		if *current == nil && fallback != nil {
-			value := *fallback
-			*current = &value
+
+	for _, field := range model.ActionsSettingFields(defaults.Actions) {
+		if actionsSelectedOnlyFields[field.YAMLKey] {
+			policy := cfg.Actions.AllowedActions
+			if policy == nil || *policy != "selected" {
+				continue
+			}
+		}
+		if mergeSettingField(cv.Field(field.Index), field) {
 			changed = true
 		}
-	}
-	mergeString := func(current **string, fallback *string) {
-		if *current == nil && fallback != nil {
-			value := *fallback
-			*current = &value
-			changed = true
-		}
-	}
-
-	mergeBool(&cfg.Actions.Enabled, defaults.Actions.Enabled)
-	mergeString(&cfg.Actions.AllowedActions, defaults.Actions.AllowedActions)
-	mergeBool(&cfg.Actions.SHAPinningRequired, defaults.Actions.SHAPinningRequired)
-
-	if cfg.Actions.AllowedActions == nil || *cfg.Actions.AllowedActions != "selected" {
-		return changed
-	}
-
-	mergeBool(&cfg.Actions.GitHubOwnedAllowed, defaults.Actions.GitHubOwnedAllowed)
-	mergeBool(&cfg.Actions.VerifiedAllowed, defaults.Actions.VerifiedAllowed)
-	if cfg.Actions.PatternsAllowed == nil && defaults.Actions.PatternsAllowed != nil {
-		patterns := slices.Clone(*defaults.Actions.PatternsAllowed)
-		cfg.Actions.PatternsAllowed = &patterns
-		changed = true
 	}
 
 	return changed
+}
+
+// mergeSettingField copies a set default field into cfv when cfv is nil,
+// reporting whether it changed anything. Slice values are cloned so cfg does
+// not share a backing array with the defaults.
+func mergeSettingField(cfv reflect.Value, field model.RepositorySettingField) bool {
+	if !field.Set || !cfv.IsNil() {
+		return false
+	}
+
+	dfv := field.Value.Elem()
+	newVal := reflect.New(dfv.Type())
+	if dfv.Kind() == reflect.Slice {
+		cloned := reflect.MakeSlice(dfv.Type(), dfv.Len(), dfv.Len())
+		reflect.Copy(cloned, dfv)
+		newVal.Elem().Set(cloned)
+	} else {
+		newVal.Elem().Set(dfv)
+	}
+	cfv.Set(newVal)
+	return true
 }
 
 // mergeLabelsFrom populates cfg.Labels from the provided defaults when the

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -378,6 +378,63 @@ func TestMergeRepoSettingsFullRepository(t *testing.T) {
 	}
 }
 
+func mergeActionsDefaultsForTest(t *testing.T, cfg *Config) bool {
+	t.Helper()
+	return mergeActionsFrom(cfg, defaultConfig(t))
+}
+
+func TestMergeActionsNilActions(t *testing.T) {
+	cfg := &Config{}
+
+	if !mergeActionsDefaultsForTest(t, cfg) {
+		t.Fatal("expected changed=true for nil Actions")
+	}
+
+	// The default policy is "selected", so selected-only fields merge too.
+	testutil.AssertPtr(t, cfg.Actions.Enabled, false, true, "enabled")
+	testutil.AssertPtr(t, cfg.Actions.AllowedActions, false, "selected", "allowed_actions")
+	testutil.AssertPtr(t, cfg.Actions.SHAPinningRequired, false, false, "sha_pinning_required")
+	testutil.AssertPtr(t, cfg.Actions.GitHubOwnedAllowed, false, true, "github_owned_allowed")
+	testutil.AssertPtr(t, cfg.Actions.VerifiedAllowed, false, true, "verified_allowed")
+	if cfg.Actions.PatternsAllowed == nil || len(*cfg.Actions.PatternsAllowed) == 0 {
+		t.Error("patterns_allowed should be set from defaults")
+	}
+}
+
+func TestMergeActionsSkipsSelectedFieldsForOtherPolicies(t *testing.T) {
+	policy := "all"
+	cfg := &Config{Actions: &model.ActionsSettings{AllowedActions: &policy}}
+
+	if !mergeActionsDefaultsForTest(t, cfg) {
+		t.Fatal("expected changed=true for missing non-selected fields")
+	}
+
+	testutil.AssertPtr(t, cfg.Actions.Enabled, false, true, "enabled")
+	testutil.AssertPtr(t, cfg.Actions.AllowedActions, false, "all", "allowed_actions")
+	testutil.AssertPtr(t, cfg.Actions.GitHubOwnedAllowed, true, false, "github_owned_allowed")
+	testutil.AssertPtr(t, cfg.Actions.VerifiedAllowed, true, false, "verified_allowed")
+	if cfg.Actions.PatternsAllowed != nil {
+		t.Error("patterns_allowed should remain nil for non-selected policy")
+	}
+}
+
+func TestMergeActionsClonesPatterns(t *testing.T) {
+	defaults := defaultConfig(t)
+	cfg := &Config{}
+
+	if !mergeActionsFrom(cfg, defaults) {
+		t.Fatal("expected changed=true for nil Actions")
+	}
+	if cfg.Actions.PatternsAllowed == nil || len(*cfg.Actions.PatternsAllowed) == 0 {
+		t.Fatal("patterns_allowed should be set from defaults")
+	}
+
+	(*cfg.Actions.PatternsAllowed)[0] = "mutated/*"
+	if (*defaults.Actions.PatternsAllowed)[0] == "mutated/*" {
+		t.Error("merged patterns_allowed shares a backing array with defaults")
+	}
+}
+
 // defaultLabelDefaults returns the default Labels from the embedded config.
 func defaultLabelDefaults(t *testing.T) []model.LabelEntry {
 	t.Helper()

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -12,12 +12,15 @@ import (
 )
 
 // yamlSpecial lists characters that require quoting in YAML values.
-const yamlSpecial = ":{}[]#&*!|>'\"%@`\n"
+const yamlSpecial = "{}[]#&*!|>'\"%@`\n"
 
-// yamlVal quotes v when it contains YAML special characters, surrounding
-// whitespace, or is empty.
+// yamlVal quotes v when it contains YAML special characters, a ":" that
+// reads as a mapping indicator (followed by whitespace or at the end),
+// surrounding whitespace, or is empty. A ":" inside a word, as in URLs,
+// needs no quoting.
 func yamlVal(v string) string {
-	if strings.ContainsAny(v, yamlSpecial) || v != strings.TrimSpace(v) || v == "" {
+	if strings.ContainsAny(v, yamlSpecial) || strings.Contains(v, ": ") ||
+		strings.HasSuffix(v, ":") || v != strings.TrimSpace(v) || v == "" {
 		return fmt.Sprintf("%q", v)
 	}
 	return v
@@ -25,8 +28,7 @@ func yamlVal(v string) string {
 
 // settingLines renders one "  key: value" line per set field. Scalar fields
 // keep struct order; list fields follow them, preserving the output order
-// that places topics last. Homepage stays unquoted because yamlVal would
-// quote the ":" in URLs.
+// that places topics last.
 func settingLines(fields []model.RepositorySettingField) []string {
 	var lines, lists []string
 	for _, field := range fields {
@@ -36,11 +38,7 @@ func settingLines(fields []model.RepositorySettingField) []string {
 		v := field.Value.Elem()
 		switch v.Kind() {
 		case reflect.String:
-			val := v.String()
-			if field.YAMLKey != "homepage" {
-				val = yamlVal(val)
-			}
-			lines = append(lines, fmt.Sprintf("  %s: %s", field.YAMLKey, val))
+			lines = append(lines, fmt.Sprintf("  %s: %s", field.YAMLKey, yamlVal(v.String())))
 		case reflect.Bool:
 			lines = append(lines, fmt.Sprintf("  %s: %t", field.YAMLKey, v.Bool()))
 		case reflect.Slice:

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -15,12 +15,13 @@ import (
 const yamlSpecial = "{}[]#&*!|>'\"%@`\n"
 
 // yamlVal quotes v when it contains YAML special characters, a ":" that
-// reads as a mapping indicator (followed by whitespace or at the end),
+// reads as a mapping indicator (followed by a space or tab, or at the end),
 // surrounding whitespace, or is empty. A ":" inside a word, as in URLs,
 // needs no quoting.
 func yamlVal(v string) string {
 	if strings.ContainsAny(v, yamlSpecial) || strings.Contains(v, ": ") ||
-		strings.HasSuffix(v, ":") || v != strings.TrimSpace(v) || v == "" {
+		strings.Contains(v, ":\t") || strings.HasSuffix(v, ":") ||
+		v != strings.TrimSpace(v) || v == "" {
 		return fmt.Sprintf("%q", v)
 	}
 	return v

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -431,6 +431,7 @@ func TestWriteHomepageRoundTrips(t *testing.T) {
 		{"plain URL", "https://example.com"},
 		{"contains space", "https://example.com/my page"},
 		{"contains space hash", "https://example.com #fragment"},
+		{"contains colon tab", "https://example.com/a:\tb"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -423,6 +423,53 @@ func TestWriteYAMLSpecialCharactersQuoted(t *testing.T) {
 	}
 }
 
+func TestWriteHomepageRoundTrips(t *testing.T) {
+	tests := []struct {
+		name     string
+		homepage string
+	}{
+		{"plain URL", "https://example.com"},
+		{"contains space", "https://example.com/my page"},
+		{"contains space hash", "https://example.com #fragment"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				License: "MIT",
+				Repository: &model.RepositorySettings{
+					Homepage: &tc.homepage,
+					HasWiki:  new(false),
+				},
+				Swatches: []SwatchEntry{
+					{Path: "justfile", Alteration: swatch.FirstFit},
+				},
+			}
+
+			dir := t.TempDir()
+			if err := Write(dir, cfg, "2026-03-04", "Initially fitted"); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+
+			got, err := os.ReadFile(filepath.Join(dir, ".tailor.yml"))
+			if err != nil {
+				t.Fatalf("ReadFile: %v", err)
+			}
+
+			var parsed Config
+			if err := yaml.Unmarshal(got, &parsed); err != nil {
+				t.Fatalf("output is not valid YAML: %v\n--- output ---\n%s", err, got)
+			}
+
+			if parsed.Repository == nil || parsed.Repository.Homepage == nil {
+				t.Fatal("parsed Repository.Homepage is nil")
+			}
+			if *parsed.Repository.Homepage != tc.homepage {
+				t.Errorf("round-tripped Homepage = %q, want %q", *parsed.Repository.Homepage, tc.homepage)
+			}
+		})
+	}
+}
+
 func TestWriteTopicsPreserved(t *testing.T) {
 	topics := []string{"go", "cli", "template"}
 	cfg := &Config{


### PR DESCRIPTION
Addresses feedback from a project peer review, combining two refactors with two fixes across unrelated areas. internal/alter/format.go collapses three near-duplicate category systems into one generic sort, label, and render pipeline; output is unchanged. internal/config/merge.go aligns mergeActionsFrom with the reflection-driven pattern already used for repository settings, sharing a mergeSettingField helper and cloning slice defaults to avoid sharing a backing array. internal/config/write.go routes the homepage setting through yamlVal like every other string setting, fixing YAML corruption when a homepage contains a space or a hash. .goreleaser.yaml restricts the aurs archive id to compressed, matching the existing homebrew_casks restriction, and dist/ is now ignored so a GoReleaser snapshot does not trip the just release clean-tree check.
