### PR TITLE
fix: address findings from full-project code review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ tailor/
 - Commands that call `gh` should have their external calls abstracted behind interfaces for testability
 - Test authentication through local `GH_TOKEN`, `GITHUB_TOKEN`, and `gh` credential paths only
 - `measure` is purely local and needs no mocking
-- `measure` emits `warning` results for two local health diagnostics: missing `README.md` (not managed by tailor) and `LICENSE` files containing unresolved placeholder tokens (e.g. `[year]`, `[fullname]`)
+- `measure` emits `warning` results for three local health diagnostics: missing `README.md` (not managed by tailor), `LICENSE` files containing unresolved placeholder tokens (e.g. `[year]`, `[fullname]`), and `LICENSE` files that exist but were not inspected (over 1 MiB or unreadable)
 - `README.md` is checked by exact path at the project root; it is a local diagnostic, not a swatch or config-diff item
 
 ## Key implementation details

--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -51,7 +51,8 @@ func (f *FitCmd) Run() error {
 		}
 	}
 
-	if err := gh.CheckAuth(repo.Host); err != nil {
+	host := gh.ResolveHost(repo.Host)
+	if err := gh.CheckAuth(host); err != nil {
 		return err
 	}
 
@@ -69,7 +70,7 @@ func (f *FitCmd) Run() error {
 	}
 
 	if ok {
-		client, err := gh.NewRESTClient(repo.Host)
+		client, err := gh.NewRESTClient(host)
 		if err != nil {
 			return err
 		}

--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -51,8 +51,10 @@ func (f *FitCmd) Run() error {
 		}
 	}
 
-	host := gh.ResolveHost(repo.Host)
-	if err := gh.CheckAuth(host); err != nil {
+	// Verify the token against the API before creating the project
+	// directory, so an invalid token cannot leave a partial fit behind.
+	client, _, err := gh.VerifyAuth(repo.Host)
+	if err != nil {
 		return err
 	}
 
@@ -70,10 +72,6 @@ func (f *FitCmd) Run() error {
 	}
 
 	if ok {
-		client, err := gh.NewRESTClient(host)
-		if err != nil {
-			return err
-		}
 		live, warnings, err := gh.ReadRepoSettings(client, repo.Owner, repo.Name)
 		if err != nil {
 			return err

--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -147,7 +147,7 @@ func runAlter(mode alter.ApplyMode) error {
 
 	cfg, err := config.Load(dir)
 	if err != nil {
-		return fmt.Errorf(".tailor.yml is missing or malformed. Run 'tailor fit <path>' to create a valid configuration, or edit .tailor.yml directly to correct it")
+		return fmt.Errorf(".tailor.yml is missing or malformed: %w. Run 'tailor fit <path>' to create a valid configuration, or edit .tailor.yml directly to correct it", err)
 	}
 
 	return alter.Run(cfg, dir, mode, nil)

--- a/cmd/tailor/main.go
+++ b/cmd/tailor/main.go
@@ -98,7 +98,7 @@ func (f *FitCmd) Run() error {
 
 // AlterCmd applies swatch templates to the current project.
 type AlterCmd struct {
-	Recut bool `help:"Overwrite all files regardless of mode or existence." name:"recut"`
+	Recut bool `help:"Overwrite existing first-fit swatches and merge missing .tailor.yml defaults (never swatches and the licence stay untouched)." name:"recut"`
 	run   func(alter.ApplyMode) error
 }
 

--- a/cmd/tailor/main_test.go
+++ b/cmd/tailor/main_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestFitNewDirectoryDefaultConfig(t *testing.T) {
 	ghfake.FakeAuth(t, "gho_test")
+	ghfake.FakeUserAPI(t, http.StatusOK, "octocat")
 	ghfake.FakeNoRepo(t)
 
 	dir := filepath.Join(t.TempDir(), "new-project")
@@ -78,6 +79,7 @@ func TestFitNewDirectoryDefaultConfig(t *testing.T) {
 
 func TestFitExistingDirectoryWithoutConfig(t *testing.T) {
 	ghfake.FakeAuth(t, "gho_test")
+	ghfake.FakeUserAPI(t, http.StatusOK, "octocat")
 	ghfake.FakeNoRepo(t)
 
 	dir := t.TempDir()
@@ -95,6 +97,7 @@ func TestFitExistingDirectoryWithoutConfig(t *testing.T) {
 
 func TestFitExistingDirectoryWithConfigError(t *testing.T) {
 	ghfake.FakeAuth(t, "gho_test")
+	ghfake.FakeUserAPI(t, http.StatusOK, "octocat")
 	ghfake.FakeNoRepo(t)
 
 	dir := t.TempDir()
@@ -121,6 +124,7 @@ func TestFitExistingDirectoryWithConfigError(t *testing.T) {
 
 func TestFitLicenseNone(t *testing.T) {
 	ghfake.FakeAuth(t, "gho_test")
+	ghfake.FakeUserAPI(t, http.StatusOK, "octocat")
 	ghfake.FakeNoRepo(t)
 
 	dir := filepath.Join(t.TempDir(), "license-none")
@@ -142,6 +146,7 @@ func TestFitLicenseNone(t *testing.T) {
 
 func TestFitDescriptionNoRepoContext(t *testing.T) {
 	ghfake.FakeAuth(t, "gho_test")
+	ghfake.FakeUserAPI(t, http.StatusOK, "octocat")
 	ghfake.FakeNoRepo(t)
 
 	dir := filepath.Join(t.TempDir(), "with-desc")
@@ -163,6 +168,7 @@ func TestFitDescriptionNoRepoContext(t *testing.T) {
 
 func TestFitNoRepoContextUsesDefaults(t *testing.T) {
 	ghfake.FakeAuth(t, "gho_test")
+	ghfake.FakeUserAPI(t, http.StatusOK, "octocat")
 	ghfake.FakeNoRepo(t)
 
 	dir := filepath.Join(t.TempDir(), "defaults")
@@ -375,5 +381,26 @@ func TestFitAuthFailure(t *testing.T) {
 	// Auth failure stops before project directory creation.
 	if _, statErr := os.Stat(dir); statErr == nil {
 		t.Error("directory was created despite auth failure")
+	}
+}
+
+func TestFitInvalidTokenFailure(t *testing.T) {
+	ghfake.FakeAuth(t, "gho_invalid")
+	ghfake.FakeUserAPI(t, http.StatusUnauthorized, "")
+
+	dir := filepath.Join(t.TempDir(), "invalid-token")
+
+	cmd := FitCmd{Path: dir, License: "BlueOak-1.0.0"}
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("Run() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "verifying GitHub authentication") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "verifying GitHub authentication")
+	}
+
+	// Token verification failure stops before project directory creation.
+	if _, statErr := os.Stat(dir); statErr == nil {
+		t.Error("directory was created despite invalid token")
 	}
 }

--- a/cmd/tailor/main_test.go
+++ b/cmd/tailor/main_test.go
@@ -331,6 +331,28 @@ func TestAlterCmdRunRecut(t *testing.T) {
 	requireFileContent(t, filepath.Join(dir, "SUPPORT.md"), string(wantSupport))
 }
 
+func TestRunAlterMalformedConfigError(t *testing.T) {
+	ghfake.FakeAuth(t, "gho_test")
+	ghfake.FakeNoRepo(t)
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".tailor.yml"), []byte("unknown: true\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Chdir(dir)
+
+	err := runAlter(alter.DryRun)
+	if err == nil {
+		t.Fatal("runAlter() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `unrecognised top-level setting "unknown"`) {
+		t.Errorf("error = %q, want underlying config error", err.Error())
+	}
+	if !strings.Contains(err.Error(), "Run 'tailor fit <path>' to create a valid configuration") {
+		t.Errorf("error = %q, want fit guidance", err.Error())
+	}
+}
+
 func TestDocketAuthenticated(t *testing.T) {
 	ghfake.FakeAuth(t, "gho_test")
 	ghfake.FakeRepo(t, "octocat", "my-project")

--- a/docs/LINTING.md
+++ b/docs/LINTING.md
@@ -23,6 +23,8 @@ Tailor's golangci-lint configuration targets three goals: catch real bugs (resou
 | usestdlibvars | Flags hardcoded HTTP status codes and methods that should use `net/http` constants |
 | wastedassign | Detects assignments to variables that are never subsequently used |
 
+The configuration does not override the golangci-lint v2 default set, so the defaults `errcheck`, `govet`, `ineffassign`, `staticcheck`, and `unused` also run. In total 18 linters are enabled.
+
 ## Configuration Choices
 
 ### govet: enable-all minus fieldalignment and shadow
@@ -81,7 +83,6 @@ All configs examined were golangci-lint v2 format unless noted. "Linters enabled
 | testpackage, paralleltest, tparallel | Test structure linters. Traefik disables them ("Not relevant"). |
 | ireturn, wrapcheck, varnamelen | Traefik disables all three as too strict. |
 | modernize | Suggests modern Go idioms. Useful but flags existing code that contributors did not write, creating churn in unrelated PRs. |
-| errcheck | Most projects enable it with exclusions for common false positives. Tailor's govet and errorlint coverage catches the high-value error handling issues. |
 
 ## Dependency Review Security Gate
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -494,7 +494,7 @@ auth:           not authenticated
 Behaviour:
 - `user` is resolved via `GET /user` if authenticated. It displays `(none)` if not authenticated.
 - `repository` displays the `owner/repo` derived from the GitHub remote in the current directory; displays `(none)` if no GitHub remote exists.
-- `auth` displays `authenticated` or `not authenticated` based on whether a valid token can be resolved for the host of the detected repository, or for `github.com` when no repository context exists.
+- `auth` displays `authenticated` or `not authenticated` based on whether a valid token can be resolved for the host of the detected repository, or for the `go-gh` default host (`GH_HOST`, falling back to `github.com`) when no repository context exists.
 - Does not read `.tailor.yml` and does not require it to be present.
 
 ## Error Handling
@@ -517,7 +517,7 @@ Behaviour:
 
 **Duplicate path in `.tailor.yml`**: `alter` and `baste` remove retired entries before duplicate validation. If active entries share a path, the command identifies the conflict and exits before disk changes.
 
-**Not authenticated**: if no valid authentication token can be resolved for the host of the detected repository, or for `github.com` when no repository context exists (neither `GH_TOKEN`/`GITHUB_TOKEN` environment variable, `gh` config file, nor `gh` keyring), `fit`, `alter`, and `baste` exit with: "tailor requires GitHub authentication. Set the GH_TOKEN or GITHUB_TOKEN environment variable, or run `gh auth login`."
+**Not authenticated**: if no valid authentication token can be resolved for the host of the detected repository, or for the `go-gh` default host (`GH_HOST`, falling back to `github.com`) when no repository context exists (neither `GH_TOKEN`/`GITHUB_TOKEN` environment variable, `gh` config file, nor `gh` keyring), `fit`, `alter`, and `baste` exit with: "tailor requires GitHub authentication. Set the GH_TOKEN or GITHUB_TOKEN environment variable, or run `gh auth login`."
 
 **`{{GITHUB_USERNAME}}` resolution failed**: `{{GITHUB_USERNAME}}` is resolved via `GET /user`. If this call fails, `alter` exits with the API error. Unlike repo-context tokens, `{{GITHUB_USERNAME}}` depends on the authenticated user, not the repository, so it cannot be deferred.
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -11,7 +11,7 @@ Tailor requires a valid GitHub authentication token. This can be provided in two
 1. **Environment variable**: Set `GH_TOKEN` or `GITHUB_TOKEN`. This works without the `gh` binary installed.
 2. **GitHub CLI**: Install and authenticate the [GitHub CLI](https://cli.github.com/) (`gh`). Run `gh auth login` to authenticate. The `gh` binary is also used as a fallback for keyring-based token access when no environment variable is set.
 
-The `fit`, `alter`, and `baste` commands verify that a valid authentication token exists at startup and exit with an error if no token is available.
+The `fit`, `alter`, and `baste` commands verify the authentication token at startup: a token must exist and the effective host must accept it (`GET /user`). If the token is missing or rejected, the command exits with an error before any local file change.
 
 `measure` and `docket` are exempt from the authentication requirement. `measure` performs purely local file inspection and needs no network access or authentication. `docket` can report unauthenticated state without erroring - it displays the auth state rather than requiring it.
 
@@ -243,7 +243,7 @@ Generates:
 
 Applies swatch alterations to the local project.
 
-`alter` verifies that a valid authentication token exists at startup and exits with an error if no token is available. It then reads `.tailor.yml` in the current working directory. No upward traversal is performed.
+`alter` verifies the authentication token at startup and exits with an error if the token is missing or the effective host rejects it. The API verification happens before any local file change. It then reads `.tailor.yml` in the current working directory. No upward traversal is performed.
 
 ```bash
 tailor alter              # Apply changes
@@ -280,7 +280,7 @@ Behaviour:
 
 Previews what `alter` would do without making any changes.
 
-`baste` verifies that a valid authentication token exists at startup and exits with an error if no token is available. It then reads `.tailor.yml` in the current working directory. No upward traversal is performed.
+`baste` verifies the authentication token at startup and exits with an error if the token is missing or the effective host rejects it. It then reads `.tailor.yml` in the current working directory. No upward traversal is performed.
 
 ```bash
 tailor baste
@@ -517,7 +517,9 @@ Behaviour:
 
 **Duplicate path in `.tailor.yml`**: `alter` and `baste` remove retired entries before duplicate validation. If active entries share a path, the command identifies the conflict and exits before disk changes.
 
-**Not authenticated**: if no valid authentication token can be resolved for the host of the detected repository, or for the `go-gh` default host (`GH_HOST`, falling back to `github.com`) when no repository context exists (neither `GH_TOKEN`/`GITHUB_TOKEN` environment variable, `gh` config file, nor `gh` keyring), `fit`, `alter`, and `baste` exit with: "tailor requires GitHub authentication. Set the GH_TOKEN or GITHUB_TOKEN environment variable, or run `gh auth login`."
+**Not authenticated**: if no authentication token can be resolved for the host of the detected repository, or for the `go-gh` default host (`GH_HOST`, falling back to `github.com`) when no repository context exists (neither `GH_TOKEN`/`GITHUB_TOKEN` environment variable, `gh` config file, nor `gh` keyring), `fit`, `alter`, and `baste` exit with: "tailor requires GitHub authentication. Set the GH_TOKEN or GITHUB_TOKEN environment variable, or run `gh auth login`."
+
+**Token rejected**: if a token is present but the effective host rejects the `GET /user` verification request, `fit`, `alter`, and `baste` exit with the API error before any local file change.
 
 **`{{GITHUB_USERNAME}}` resolution failed**: `{{GITHUB_USERNAME}}` is resolved via `GET /user`. If this call fails, `alter` exits with the API error. Unlike repo-context tokens, `{{GITHUB_USERNAME}}` depends on the authenticated user, not the repository, so it cannot be deferred.
 
@@ -760,7 +762,7 @@ measure:
 3. **No versioning**: No swatch versions, always uses swatches from current tailor binary. Upgrading tailor will cause all `always` swatches to be re-evaluated against the new embedded content; files whose swatch content has changed will be overwritten on the next `alter` run.
 4. **No global state**: All state is per-project in `.tailor.yml`
 5. **No project registry**: Tailor has no awareness of its consumers. Projects pull from tailor, tailor does not track projects.
-6. **Authentication via `go-gh`**: All project metadata, user metadata, licence content, and repository settings are resolved via `go-gh` (`github.com/cli/go-gh/v2`), the official Go library for GitHub CLI extensions. Token resolution follows the `go-gh` precedence order: `GH_TOKEN` environment variable, `GITHUB_TOKEN` environment variable, `gh` config file, `gh` keyring (via the `gh` binary). When `GH_TOKEN` or `GITHUB_TOKEN` is set, the `gh` binary is not required. The `gh` binary is needed only for `gh auth login` (establishing credentials) and as a fallback for keyring-based token access when no environment variable is set. Repository context detection reads git remotes via `go-gh`, so `git` must be present when a GitHub remote exists - but any directory with a GitHub remote already has `git` installed. If no valid token can be resolved, `fit`, `alter`, and `baste` exit immediately with an error.
+6. **Authentication via `go-gh`**: All project metadata, user metadata, licence content, and repository settings are resolved via `go-gh` (`github.com/cli/go-gh/v2`), the official Go library for GitHub CLI extensions. Token resolution follows the `go-gh` precedence order: `GH_TOKEN` environment variable, `GITHUB_TOKEN` environment variable, `gh` config file, `gh` keyring (via the `gh` binary). When `GH_TOKEN` or `GITHUB_TOKEN` is set, the `gh` binary is not required. The `gh` binary is needed only for `gh auth login` (establishing credentials) and as a fallback for keyring-based token access when no environment variable is set. Repository context detection reads git remotes via `go-gh`, so `git` must be present when a GitHub remote exists - but any directory with a GitHub remote already has `git` installed. If no token can be resolved, or the effective host rejects the token, `fit`, `alter`, and `baste` exit immediately with an error.
 7. **CLI parsing**: [Kong](https://github.com/alecthomas/kong) is used as the command line parser.
 8. **Repository settings via API**: Repository settings are applied via `PATCH /repos/{owner}/{repo}` with a JSON body constructed from the `repository` section of `.tailor.yml`, plus separate API calls for security features, topics, and Actions workflow permissions. The top-level `actions` section uses the Actions permissions and selected-actions endpoints. Field names map directly to the GitHub REST API without translation. Current settings are read via `GET /repos/{owner}/{repo}` and the relevant separate endpoints for `baste` comparison. All API calls use `go-gh`'s pre-authenticated REST client.
-9. **Execution order**: after authentication and config parsing, `alter` removes retired entries in memory. It then normalises the security prerequisite and emits its warning before validation. Next, it writes the changed config once and removes present retired workflow files. It then applies repository settings, Actions policy, labels, the licence, and active swatches in that order. `baste` uses `DryRun`; it performs the same planning and validation but writes and removes nothing. `alter` uses `Apply`, and `alter --recut` uses `Recut`.
+9. **Execution order**: after authentication and config parsing, `alter` removes retired entries in memory. It then normalises the security prerequisite and emits its warning before validation. Next, it verifies the token with `GET /user`, writes the changed config once, and removes present retired workflow files. The same `GET /user` response resolves `{{GITHUB_USERNAME}}`, so verification adds no extra API call. It then applies repository settings, Actions policy, labels, the licence, and active swatches in that order. `baste` uses `DryRun`; it performs the same planning and validation but writes and removes nothing. `alter` uses `Apply`, and `alter --recut` uses `Recut`.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -713,7 +713,7 @@ swatches/
 ├── flake.nix
 ├── justfile
 ├── .github/
-│   ├── dependabot.yml  # includes GitHub Actions and Nix ecosystem updates
+│   ├── dependabot.yml  # includes GitHub Actions, Go modules, and Nix ecosystem updates
 │   ├── FUNDING.yml
 │   ├── ISSUE_TEMPLATE/
 │   │   ├── bug_report.yml

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -445,7 +445,7 @@ mode-differs:   SECURITY.md          (config: first-fit, default: always)
 
 Category definitions:
 - `missing` - health file does not exist on disk
-- `warning` - health diagnostic that requires attention but is not a missing swatch. Two cases are recognised: `LICENSE` exists but contains known unresolved placeholder tokens (e.g. `[year]`, `[fullname]`, `{project}`), and `README.md` is absent from the project root. A warned path appears once in the output and does not also appear as `present`
+- `warning` - health diagnostic that requires attention but is not a missing swatch. Three cases are recognised: `LICENSE` exists but contains known unresolved placeholder tokens (e.g. `[year]`, `[fullname]`, `{project}`), `LICENSE` exists but was not inspected because it exceeds 1 MiB or could not be read (annotated `(not inspected: exceeds 1 MiB)` or `(not inspected: read failed)`), and `README.md` is absent from the project root. A warned path appears once in the output and does not also appear as `present`
 - `present` - health file exists on disk
 - `not-configured` - default swatch whose destination is not covered by any entry in `.tailor.yml`; the default swatch will not be applied until added
 - `config-only` - swatch in `.tailor.yml` whose destination is not covered by any entry in the built-in default set. This arises when a swatch is removed from the built-in defaults in a newer tailor release but the project's `.tailor.yml` still references it. `alter` rejects unrecognised paths, except that it automatically migrates the two fixed retired workflow paths

--- a/internal/alter/actions.go
+++ b/internal/alter/actions.go
@@ -88,12 +88,7 @@ var actionsFieldTable = []actionsFieldSpec{
 		compare: func(declared, live *model.ActionsSettings) (string, bool) {
 			desired := slices.Clone(*declared.PatternsAllowed)
 			slices.Sort(desired)
-			equal := false
-			if live.PatternsAllowed != nil {
-				actual := slices.Clone(*live.PatternsAllowed)
-				slices.Sort(actual)
-				equal = slices.Equal(desired, actual)
-			}
+			equal := live.PatternsAllowed != nil && equalStringSets(desired, *live.PatternsAllowed)
 			display := strings.Join(desired, ", ")
 			if len(desired) == 0 {
 				display = "[]"

--- a/internal/alter/alter.go
+++ b/internal/alter/alter.go
@@ -71,7 +71,7 @@ func Run(cfg *config.Config, dir string, mode ApplyMode, client *api.RESTClient)
 	}
 
 	if client == nil {
-		client, err = gh.NewRESTClient(repo.Host)
+		client, err = gh.NewRESTClient(gh.ResolveHost(repo.Host))
 		if err != nil {
 			return fmt.Errorf("creating GitHub API client: %w", err)
 		}

--- a/internal/alter/alter.go
+++ b/internal/alter/alter.go
@@ -23,8 +23,9 @@ const (
 // ShouldWrite reports whether the mode permits writing to disk.
 func (m ApplyMode) ShouldWrite() bool { return m == Apply || m == Recut }
 
-// Run executes the alter command. It validates the config, applies
-// repository settings, fetches the licence, and processes swatches.
+// Run executes the alter command. It validates the config, verifies the
+// token against the API before any local file change, applies repository
+// settings, fetches the licence, and processes swatches.
 // When client is nil, a default GitHub REST client is created.
 func Run(cfg *config.Config, dir string, mode ApplyMode, client *api.RESTClient) error {
 	configChanged := config.RemoveRetiredWorkflowEntries(cfg)
@@ -53,17 +54,6 @@ func Run(cfg *config.Config, dir string, mode ApplyMode, client *api.RESTClient)
 	if err := config.ValidateCompleteActions(cfg); err != nil {
 		return err
 	}
-	if configChanged && mode.ShouldWrite() {
-		todayDate := time.Now().Format("2006-01-02")
-		if err := config.Write(dir, cfg, todayDate, "Refitted"); err != nil {
-			return fmt.Errorf("writing refitted config: %w", err)
-		}
-	}
-
-	retiredResults, err := ProcessRetiredWorkflows(dir, mode)
-	if err != nil {
-		return err
-	}
 
 	repo, hasRepo, err := gh.RepoContextAt(dir)
 	if err != nil {
@@ -77,9 +67,23 @@ func Run(cfg *config.Config, dir string, mode ApplyMode, client *api.RESTClient)
 		}
 	}
 
+	// Verify the token against the API before any local file change. The
+	// same request resolves {{GITHUB_USERNAME}} for token substitution.
 	username, err := gh.FetchUsername(client)
 	if err != nil {
-		return fmt.Errorf("fetching GitHub username: %w", err)
+		return fmt.Errorf("verifying GitHub authentication: %w", err)
+	}
+
+	if configChanged && mode.ShouldWrite() {
+		todayDate := time.Now().Format("2006-01-02")
+		if err := config.Write(dir, cfg, todayDate, "Refitted"); err != nil {
+			return fmt.Errorf("writing refitted config: %w", err)
+		}
+	}
+
+	retiredResults, err := ProcessRetiredWorkflows(dir, mode)
+	if err != nil {
+		return err
 	}
 
 	tokens := TokenContext{

--- a/internal/alter/alter_integration_test.go
+++ b/internal/alter/alter_integration_test.go
@@ -1761,8 +1761,8 @@ swatches:
 	cfg := loadTestConfig(t, tc.Dir)
 	err := runAlterExpectError(t, cfg, tc.Dir, tc.Client)
 
-	if !strings.Contains(err.Error(), "username") && !strings.Contains(err.Error(), "user") {
-		t.Errorf("error = %q, want substring containing 'username' or 'user'", err)
+	if !strings.Contains(err.Error(), "verifying GitHub authentication") {
+		t.Errorf("error = %q, want substring 'verifying GitHub authentication'", err)
 	}
 
 	// No swatch files are written.
@@ -1773,6 +1773,46 @@ swatches:
 	// No mutating API calls are made.
 	if mc := tc.MutatingCalls(); len(mc) != 0 {
 		t.Errorf("expected no mutating calls, got %d: %v", len(mc), mc)
+	}
+}
+
+// TestAlterRunInvalidTokenExitsBeforeLocalChanges verifies that a present but
+// invalid token stops alter before config migration writes and retired
+// workflow cleanup touch any local file.
+func TestAlterRunInvalidTokenExitsBeforeLocalChanges(t *testing.T) {
+	configYAML := `license: none
+swatches:
+  - path: .github/workflows/tailor.yml
+    alteration: never
+  - path: .gitignore
+    alteration: first-fit
+`
+	tc := setupAlterTest(t, configYAML,
+		WithUserError(http.StatusUnauthorized),
+	)
+	retiredPath := filepath.Join(tc.Dir, ".github/workflows/tailor.yml")
+	writeOnDisk(t, tc.Dir, ".github/workflows/tailor.yml", []byte("retired"))
+
+	cfg := loadTestConfig(t, tc.Dir)
+	_ = runAlterExpectError(t, cfg, tc.Dir, tc.Client)
+
+	// The retired entry migration is not written back to .tailor.yml.
+	configData, err := os.ReadFile(filepath.Join(tc.Dir, ".tailor.yml"))
+	if err != nil {
+		t.Fatalf("ReadFile(.tailor.yml): %v", err)
+	}
+	if string(configData) != configYAML {
+		t.Errorf(".tailor.yml was rewritten despite invalid token:\n%s", configData)
+	}
+
+	// The retired workflow file is not removed.
+	if _, statErr := os.Stat(retiredPath); statErr != nil {
+		t.Errorf("retired workflow file was removed despite invalid token: %v", statErr)
+	}
+
+	// No swatch files are written.
+	if _, statErr := os.Stat(filepath.Join(tc.Dir, ".gitignore")); statErr == nil {
+		t.Error(".gitignore was written despite invalid token")
 	}
 }
 

--- a/internal/alter/alter_integration_test.go
+++ b/internal/alter/alter_integration_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 
 	"github.com/cli/go-gh/v2/pkg/api"
+	"gopkg.in/yaml.v3"
+
 	"github.com/wimpysworld/tailor/internal/alter"
 	"github.com/wimpysworld/tailor/internal/config"
 	"github.com/wimpysworld/tailor/internal/ghfake"
@@ -1937,6 +1939,55 @@ swatches:
 	}
 	if !strings.Contains(string(issueData), "{{SUPPORT_URL}}") {
 		t.Error(".github/ISSUE_TEMPLATE/config.yml does not contain raw {{SUPPORT_URL}} token; expected unsubstituted")
+	}
+
+	// Even unsubstituted, the file must parse as YAML with url as a string.
+	if got := issueContactURL(t, issueData); got != "{{SUPPORT_URL}}" {
+		t.Errorf("contact url = %q, want raw {{SUPPORT_URL}} token", got)
+	}
+}
+
+// issueContactURL parses issue template config data as YAML and returns the
+// first contact link URL, failing the test if the data is not valid YAML or
+// the URL is not a plain string.
+func issueContactURL(t *testing.T, data []byte) string {
+	t.Helper()
+	var parsed struct {
+		ContactLinks []struct {
+			URL string `yaml:"url"`
+		} `yaml:"contact_links"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf(".github/ISSUE_TEMPLATE/config.yml is not valid YAML with a string url: %v", err)
+	}
+	if len(parsed.ContactLinks) == 0 {
+		t.Fatal(".github/ISSUE_TEMPLATE/config.yml has no contact_links entries")
+	}
+	return parsed.ContactLinks[0].URL
+}
+
+// TestAlterRunConfigYmlSubstitutedValidYaml verifies that with repo context,
+// the written issue template config is valid YAML whose contact url is the
+// resolved support URL string.
+func TestAlterRunConfigYmlSubstitutedValidYaml(t *testing.T) {
+	configYAML := `license: none
+swatches:
+  - path: .github/ISSUE_TEMPLATE/config.yml
+    alteration: always
+`
+	tc := setupAlterTest(t, configYAML)
+	writeOnDisk(t, tc.Dir, "LICENSE", []byte("existing"))
+
+	cfg := loadTestConfig(t, tc.Dir)
+	_ = captureAlterRun(t, cfg, tc.Dir, alter.Apply, tc.Client)
+
+	issueData, err := os.ReadFile(filepath.Join(tc.Dir, ".github/ISSUE_TEMPLATE/config.yml"))
+	if err != nil {
+		t.Fatalf(".github/ISSUE_TEMPLATE/config.yml not written: %v", err)
+	}
+	want := "https://github.com/testowner/testrepo/blob/HEAD/SUPPORT.md"
+	if got := issueContactURL(t, issueData); got != want {
+		t.Errorf("contact url = %q, want %q", got, want)
 	}
 }
 

--- a/internal/alter/format.go
+++ b/internal/alter/format.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"unicode"
 
 	"github.com/wimpysworld/tailor/internal/gh"
+	"github.com/wimpysworld/tailor/internal/termtext"
 )
 
 // defaultLabelWidth is the minimum column width for status labels in formatted
@@ -35,8 +35,8 @@ func FormatOutput(repoResults []RepoSettingResult, labelResults []LabelResult, s
 	lines := slices.Concat(repoLines(repoResults, mode), labelLines(labelResults, mode), swatchLines(swatchResults, mode))
 
 	for i := range lines {
-		lines[i].label = escapeControlText(lines[i].label)
-		lines[i].text = escapeControlText(lines[i].text)
+		lines[i].label = termtext.EscapeControlText(lines[i].label)
+		lines[i].text = termtext.EscapeControlText(lines[i].text)
 	}
 
 	width := defaultLabelWidth
@@ -49,30 +49,6 @@ func FormatOutput(repoResults []RepoSettingResult, labelResults []LabelResult, s
 	var b strings.Builder
 	for _, line := range lines {
 		fmt.Fprintf(&b, "%-*s%s\n", width, line.label, line.text)
-	}
-	return b.String()
-}
-
-// escapeControlText renders control characters as visible escapes so that
-// values from config or the GitHub API cannot inject terminal control
-// sequences into output. C0 controls and DEL render as \xNN; C1 and other
-// Unicode controls render as \uNNNN. Text without control characters passes
-// through unchanged.
-func escapeControlText(input string) string {
-	if !strings.ContainsFunc(input, unicode.IsControl) {
-		return input
-	}
-	var b strings.Builder
-	b.Grow(len(input))
-	for _, r := range input {
-		switch {
-		case !unicode.IsControl(r):
-			b.WriteRune(r)
-		case r < 0x80:
-			fmt.Fprintf(&b, `\x%02x`, r)
-		default:
-			fmt.Fprintf(&b, `\u%04x`, r)
-		}
 	}
 	return b.String()
 }

--- a/internal/alter/settings.go
+++ b/internal/alter/settings.go
@@ -157,7 +157,7 @@ func compareSettings(declared, live *model.RepositorySettings) []RepoSettingResu
 			displayVal = strings.Join(dSlice, ", ")
 			if !lfv.IsNil() {
 				lSlice := lfv.Elem().Interface().([]string)
-				equal = slices.Equal(dSlice, lSlice)
+				equal = equalStringSets(dSlice, lSlice)
 			}
 		} else {
 			displayVal = fmt.Sprintf("%v", declaredVal)
@@ -176,6 +176,17 @@ func compareSettings(declared, live *model.RepositorySettings) []RepoSettingResu
 	}
 
 	return results
+}
+
+// equalStringSets reports whether a and b contain the same elements regardless
+// of order. GitHub imposes no meaning on list order for topics or
+// patterns_allowed. Sorts copies; neither input is mutated.
+func equalStringSets(a, b []string) bool {
+	as := slices.Clone(a)
+	bs := slices.Clone(b)
+	slices.Sort(as)
+	slices.Sort(bs)
+	return slices.Equal(as, bs)
 }
 
 // readWarningOperationFields maps read-path operation kinds from

--- a/internal/alter/settings_test.go
+++ b/internal/alter/settings_test.go
@@ -435,6 +435,36 @@ func TestProcessRepoSettingsTopicsNoChange(t *testing.T) {
 	}
 }
 
+func TestProcessRepoSettingsTopicsOrderIgnored(t *testing.T) {
+	ghfake.FakeRepo(t, "testowner", "testrepo")
+
+	live := repoJSON{Topics: []string{"cli", "go"}}
+	server := settingsServer(live, nil)
+	t.Cleanup(server.Close)
+	client := testutil.NewTestClient(t, server)
+
+	topics := []string{"go", "cli"}
+	cfg := &config.Config{
+		Repository: &model.RepositorySettings{
+			Topics: &topics,
+		},
+	}
+
+	results, err := alter.ProcessRepoSettings(cfg, alter.DryRun, repoTarget(client, "testowner", "testrepo", true))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Category != alter.RepoNoChange {
+		t.Errorf("category = %q, want %q", results[0].Category, alter.RepoNoChange)
+	}
+	if results[0].Value != "go, cli" {
+		t.Errorf("value = %q, want declared order %q", results[0].Value, "go, cli")
+	}
+}
+
 func TestProcessRepoSettingsTopicsWouldSet(t *testing.T) {
 	ghfake.FakeRepo(t, "testowner", "testrepo")
 
@@ -478,7 +508,7 @@ func TestProcessRepoSettingsTopicsEmptyVsNil(t *testing.T) {
 	client := testutil.NewTestClient(t, server)
 
 	// Declared: empty slice (clear all topics)
-	// slices.Equal treats nil and empty as equal, so this is no change
+	// The set comparison treats nil and empty as equal, so this is no change
 	topics := []string{}
 	cfg := &config.Config{
 		Repository: &model.RepositorySettings{

--- a/internal/alter/tokens_test.go
+++ b/internal/alter/tokens_test.go
@@ -58,9 +58,9 @@ func TestSubstituteSecurityMdWithoutRepoContext(t *testing.T) {
 
 func TestSubstituteConfigYmlWithRepoContext(t *testing.T) {
 	tc := &alter.TokenContext{Owner: "org", Name: "repo"}
-	input := []byte("url: {{SUPPORT_URL}}\n")
+	input := []byte("url: \"{{SUPPORT_URL}}\"\n")
 	got := tc.Substitute(input, ".github/ISSUE_TEMPLATE/config.yml")
-	want := []byte("url: https://github.com/org/repo/blob/HEAD/SUPPORT.md\n")
+	want := []byte("url: \"https://github.com/org/repo/blob/HEAD/SUPPORT.md\"\n")
 	if !bytes.Equal(got, want) {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -68,7 +68,7 @@ func TestSubstituteConfigYmlWithRepoContext(t *testing.T) {
 
 func TestSubstituteConfigYmlWithoutRepoContext(t *testing.T) {
 	tc := &alter.TokenContext{}
-	input := []byte("url: {{SUPPORT_URL}}\n")
+	input := []byte("url: \"{{SUPPORT_URL}}\"\n")
 	got := tc.Substitute(input, ".github/ISSUE_TEMPLATE/config.yml")
 	if !bytes.Equal(got, input) {
 		t.Errorf("expected no substitution, got %q", got)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/wimpysworld/tailor/internal/model"
 	"github.com/wimpysworld/tailor/internal/swatch"
@@ -187,7 +188,7 @@ func ValidateLabels(cfg *Config) error {
 		if l.Name == "" {
 			return fmt.Errorf("label[%d]: name must not be empty", i)
 		}
-		if len(l.Name) > 50 {
+		if utf8.RuneCountInString(l.Name) > 50 {
 			return fmt.Errorf("label[%d]: name %q exceeds 50 characters", i, l.Name)
 		}
 		if containsControl(l.Name) {
@@ -202,7 +203,7 @@ func ValidateLabels(cfg *Config) error {
 		if l.Description == "" {
 			return fmt.Errorf("label[%d]: description must not be empty", i)
 		}
-		if len(l.Description) > 100 {
+		if utf8.RuneCountInString(l.Description) > 100 {
 			return fmt.Errorf("label[%d]: description exceeds 100 characters", i)
 		}
 		if containsControl(l.Description) {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -132,12 +132,13 @@ func ValidateCompleteActions(cfg *Config) error {
 }
 
 // ValidateTopics checks that every topic, if set, starts with a lowercase
-// letter or number, contains only lowercase alphanumerics and hyphens, and
-// does not exceed 50 characters.
+// letter or number, contains only lowercase alphanumerics and hyphens, does
+// not exceed 50 characters, and appears only once.
 func ValidateTopics(cfg *Config) error {
 	if cfg.Repository == nil || cfg.Repository.Topics == nil {
 		return nil
 	}
+	seen := make(map[string]bool, len(*cfg.Repository.Topics))
 	for _, topic := range *cfg.Repository.Topics {
 		if len(topic) > 50 {
 			return fmt.Errorf("topic %q exceeds 50 characters", topic)
@@ -145,6 +146,10 @@ func ValidateTopics(cfg *Config) error {
 		if !topicRegexp.MatchString(topic) {
 			return fmt.Errorf("topic %q is invalid; must start with a lowercase letter or number and contain only lowercase alphanumerics and hyphens", topic)
 		}
+		if seen[topic] {
+			return fmt.Errorf("duplicate topic %q in config", topic)
+		}
+		seen[topic] = true
 	}
 	return nil
 }

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -267,6 +267,18 @@ func TestValidateTopicsRejectsStartingWithHyphen(t *testing.T) {
 	}
 }
 
+func TestValidateTopicsRejectsDuplicate(t *testing.T) {
+	topics := []string{"go", "cli", "go"}
+	cfg := &Config{Repository: &model.RepositorySettings{Topics: &topics}}
+	err := ValidateTopics(cfg)
+	if err == nil {
+		t.Fatal("ValidateTopics(duplicate) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `duplicate topic "go"`) {
+		t.Errorf("error = %q, want it to mention the duplicate topic", err)
+	}
+}
+
 func TestValidateTopicsRejectsTooLong(t *testing.T) {
 	topics := []string{strings.Repeat("a", 51)}
 	cfg := &Config{Repository: &model.RepositorySettings{Topics: &topics}}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -508,6 +508,51 @@ func TestValidateLabelsAcceptsMaxDescription(t *testing.T) {
 	}
 }
 
+func TestValidateLabelsMultibyteLimits(t *testing.T) {
+	tests := []struct {
+		name    string
+		label   model.LabelEntry
+		wantErr string
+	}{
+		{
+			name:  "multibyte name at limit",
+			label: model.LabelEntry{Name: strings.Repeat("é", 50), Color: "d73a4a", Description: "desc"},
+		},
+		{
+			name:    "multibyte name over limit",
+			label:   model.LabelEntry{Name: strings.Repeat("é", 51), Color: "d73a4a", Description: "desc"},
+			wantErr: "exceeds 50 characters",
+		},
+		{
+			name:  "multibyte description at limit",
+			label: model.LabelEntry{Name: "bug", Color: "d73a4a", Description: strings.Repeat("界", 100)},
+		},
+		{
+			name:    "multibyte description over limit",
+			label:   model.LabelEntry{Name: "bug", Color: "d73a4a", Description: strings.Repeat("界", 101)},
+			wantErr: "description exceeds 100 characters",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Labels: []model.LabelEntry{tt.label}}
+			err := ValidateLabels(cfg)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateLabels(%s): %v", tt.name, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateLabels(%s) expected error, got nil", tt.name)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateLabelsRejectsDuplicateNames(t *testing.T) {
 	cfg := &Config{
 		Labels: []model.LabelEntry{

--- a/internal/docket/docket.go
+++ b/internal/docket/docket.go
@@ -32,13 +32,17 @@ func Run(client *api.RESTClient) (*Result, error) {
 		r.Repository = repo.Owner + "/" + repo.Name
 	}
 
-	if err := gh.CheckAuth(repo.Host); err != nil {
+	// Resolve one effective host so the auth check and the REST client
+	// cannot disagree when no repository context exists.
+	host := gh.ResolveHost(repo.Host)
+
+	if err := gh.CheckAuth(host); err != nil {
 		return r, nil
 	}
 
 	if client == nil {
 		var err error
-		client, err = gh.NewRESTClient(repo.Host)
+		client, err = gh.NewRESTClient(host)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/docket/docket_test.go
+++ b/internal/docket/docket_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/cli/go-gh/v2/pkg/api"
+	"github.com/wimpysworld/tailor/internal/gh"
 	"github.com/wimpysworld/tailor/internal/ghfake"
 	"github.com/wimpysworld/tailor/internal/testutil"
 )
@@ -164,6 +165,45 @@ func TestRun(t *testing.T) {
 				t.Errorf("Auth = %q, want %q", result.Auth, tt.wantAuth)
 			}
 		})
+	}
+}
+
+func TestRunUsesOneHostForAuthAndClient(t *testing.T) {
+	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+	t.Setenv("GH_HOST", "ghe.example.com")
+	ghfake.FakeNoRepo(t)
+
+	var authHost string
+	restoreToken := gh.SetTokenForHostFunc(func(host string) (string, string) {
+		authHost = host
+		return "gho_test", "oauth_token"
+	})
+	t.Cleanup(restoreToken)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"login":"octocat"}`)
+	}))
+	t.Cleanup(server.Close)
+
+	var clientHost string
+	restoreClient := gh.SetNewRESTClientFunc(func(host string) (*api.RESTClient, error) {
+		clientHost = host
+		return testutil.NewTestClient(t, server), nil
+	})
+	t.Cleanup(restoreClient)
+
+	result, err := Run(nil)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.Auth != "authenticated" {
+		t.Errorf("Auth = %q, want %q", result.Auth, "authenticated")
+	}
+	if authHost != "ghe.example.com" {
+		t.Errorf("auth check host = %q, want %q", authHost, "ghe.example.com")
+	}
+	if clientHost != authHost {
+		t.Errorf("client host = %q, auth check host = %q, want equal hosts", clientHost, authHost)
 	}
 }
 

--- a/internal/gh/auth.go
+++ b/internal/gh/auth.go
@@ -2,6 +2,7 @@ package gh
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/cli/go-gh/v2/pkg/auth"
@@ -41,4 +42,25 @@ func CheckAuth(host string) error {
 // Callers must resolve an empty host with ResolveHost first.
 func NewRESTClient(host string) (*api.RESTClient, error) {
 	return newRESTClient(host)
+}
+
+// VerifyAuth checks that a token is present for the given host and verifies
+// it against the API with a single GET /user request. It returns the REST
+// client and the authenticated username so callers can reuse both without a
+// second request. An empty host falls back to the default host (see
+// ResolveHost).
+func VerifyAuth(host string) (*api.RESTClient, string, error) {
+	resolved := ResolveHost(host)
+	if err := CheckAuth(resolved); err != nil {
+		return nil, "", err
+	}
+	client, err := NewRESTClient(resolved)
+	if err != nil {
+		return nil, "", fmt.Errorf("creating GitHub API client: %w", err)
+	}
+	username, err := FetchUsername(client)
+	if err != nil {
+		return nil, "", fmt.Errorf("verifying GitHub authentication: %w", err)
+	}
+	return client, username, nil
 }

--- a/internal/gh/auth.go
+++ b/internal/gh/auth.go
@@ -10,14 +10,27 @@ import (
 // tokenForHost wraps auth.TokenForHost for testability.
 var tokenForHost = auth.TokenForHost
 
-// CheckAuth checks that a GitHub authentication token is present for the
-// given host. An empty host falls back to github.com. It does not validate
-// the token against the API.
-func CheckAuth(host string) error {
-	if host == "" {
-		host = "github.com"
+// newRESTClient wraps api.NewRESTClient for testability.
+var newRESTClient = func(host string) (*api.RESTClient, error) {
+	return api.NewRESTClient(api.ClientOptions{Host: host})
+}
+
+// ResolveHost returns the given host, or the go-gh default host when the
+// given host is empty. The default host honours GH_HOST and falls back to
+// github.com.
+func ResolveHost(host string) string {
+	if host != "" {
+		return host
 	}
-	token, _ := tokenForHost(host)
+	defaultHost, _ := auth.DefaultHost()
+	return defaultHost
+}
+
+// CheckAuth checks that a GitHub authentication token is present for the
+// given host. An empty host falls back to the default host (see
+// ResolveHost). It does not validate the token against the API.
+func CheckAuth(host string) error {
+	token, _ := tokenForHost(ResolveHost(host))
 	if token == "" {
 		return errors.New("tailor requires GitHub authentication. Set the GH_TOKEN or GITHUB_TOKEN environment variable, or run 'gh auth login'")
 	}
@@ -25,7 +38,7 @@ func CheckAuth(host string) error {
 }
 
 // NewRESTClient creates a GitHub REST client bound to the given host.
-// An empty host uses the go-gh default host resolution.
+// Callers must resolve an empty host with ResolveHost first.
 func NewRESTClient(host string) (*api.RESTClient, error) {
-	return api.NewRESTClient(api.ClientOptions{Host: host})
+	return newRESTClient(host)
 }

--- a/internal/gh/auth_test.go
+++ b/internal/gh/auth_test.go
@@ -1,6 +1,14 @@
 package gh
 
-import "testing"
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+)
 
 func TestResolveHost(t *testing.T) {
 	tests := []struct {
@@ -90,6 +98,86 @@ func TestCheckAuth(t *testing.T) {
 			}
 			if err.Error() != tt.wantErr {
 				t.Errorf("CheckAuth() error = %q, want %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestVerifyAuth(t *testing.T) {
+	tests := []struct {
+		name       string
+		token      string
+		userStatus int
+		wantUser   string
+		wantErr    string
+	}{
+		{
+			name:       "valid token returns client and username",
+			token:      "gho_test",
+			userStatus: http.StatusOK,
+			wantUser:   "octocat",
+		},
+		{
+			name:    "missing token fails before any request",
+			token:   "",
+			wantErr: "tailor requires GitHub authentication",
+		},
+		{
+			name:       "rejected token fails verification",
+			token:      "gho_invalid",
+			userStatus: http.StatusUnauthorized,
+			wantErr:    "verifying GitHub authentication",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GH_CONFIG_DIR", t.TempDir())
+			t.Setenv("GH_HOST", "")
+			restoreToken := SetTokenForHostFunc(func(string) (string, string) {
+				return tt.token, "oauth_token"
+			})
+			t.Cleanup(restoreToken)
+
+			var requests int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				if tt.userStatus != http.StatusOK {
+					w.WriteHeader(tt.userStatus)
+					fmt.Fprint(w, `{"message":"Bad credentials"}`)
+					return
+				}
+				fmt.Fprintf(w, `{"login":%q}`, tt.wantUser)
+			}))
+			t.Cleanup(server.Close)
+			client := newTestClient(t, server)
+			restoreClient := SetNewRESTClientFunc(func(string) (*api.RESTClient, error) {
+				return client, nil
+			})
+			t.Cleanup(restoreClient)
+
+			gotClient, username, err := VerifyAuth("github.com")
+
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("VerifyAuth() error = %v, want substring %q", err, tt.wantErr)
+				}
+				if tt.token == "" && requests != 0 {
+					t.Errorf("requests = %d, want 0 when no token is present", requests)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("VerifyAuth() error: %v", err)
+			}
+			if username != tt.wantUser {
+				t.Errorf("username = %q, want %q", username, tt.wantUser)
+			}
+			if gotClient != client {
+				t.Error("VerifyAuth() did not return the created client")
+			}
+			if requests != 1 {
+				t.Errorf("requests = %d, want 1", requests)
 			}
 		})
 	}

--- a/internal/gh/auth_test.go
+++ b/internal/gh/auth_test.go
@@ -2,6 +2,30 @@ package gh
 
 import "testing"
 
+func TestResolveHost(t *testing.T) {
+	tests := []struct {
+		name   string
+		host   string
+		ghHost string
+		want   string
+	}{
+		{name: "non-empty host passes through", host: "ghe.example.com", ghHost: "", want: "ghe.example.com"},
+		{name: "empty host falls back to github.com", host: "", ghHost: "", want: "github.com"},
+		{name: "empty host honours GH_HOST", host: "", ghHost: "ghe.example.com", want: "ghe.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GH_CONFIG_DIR", t.TempDir())
+			t.Setenv("GH_HOST", tt.ghHost)
+
+			if got := ResolveHost(tt.host); got != tt.want {
+				t.Errorf("ResolveHost(%q) = %q, want %q", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCheckAuth(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -39,6 +63,8 @@ func TestCheckAuth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GH_CONFIG_DIR", t.TempDir())
+			t.Setenv("GH_HOST", "")
 			var gotHost string
 			restore := SetTokenForHostFunc(func(host string) (string, string) {
 				gotHost = host

--- a/internal/gh/repo.go
+++ b/internal/gh/repo.go
@@ -56,7 +56,10 @@ func repositoryFromRemotes(dir string) (repository.Repository, error) {
 		return repository.Repository{}, err
 	}
 
-	knownHosts := auth.KnownHosts()
+	// Accept the default host and github.com even when no host is
+	// authenticated, so repository detection works without credentials.
+	defaultHost, _ := auth.DefaultHost()
+	acceptedHosts := append(auth.KnownHosts(), "github.com", defaultHost)
 	translator := ssh.NewTranslator()
 	bestPriority := -1
 	var best repository.Repository
@@ -78,7 +81,7 @@ func repositoryFromRemotes(dir string) (repository.Repository, error) {
 			remoteURL.Scheme = "ssh"
 		}
 		repo, parseErr := repository.Parse(translator.Translate(remoteURL).String())
-		if parseErr != nil || !isKnownHost(repo.Host, knownHosts) {
+		if parseErr != nil || !isKnownHost(repo.Host, acceptedHosts) {
 			continue
 		}
 		priority := remotePriority(fields[0])

--- a/internal/gh/repo_test.go
+++ b/internal/gh/repo_test.go
@@ -130,6 +130,23 @@ func TestRepoContextAtResolvesSSHAlias(t *testing.T) {
 	}
 }
 
+func TestRepoContextAtNoAuthenticatedHosts(t *testing.T) {
+	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+	t.Setenv("GH_HOST", "")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	dir := initGitRepository(t, "https://github.com/no-auth/project.git")
+
+	repo, ok, err := RepoContextAt(dir)
+	if err != nil {
+		t.Fatalf("RepoContextAt() error = %v", err)
+	}
+	want := Repo{Host: "github.com", Owner: "no-auth", Name: "project"}
+	if repo != want || !ok {
+		t.Errorf("RepoContextAt() = %+v, %v, want %+v, true", repo, ok, want)
+	}
+}
+
 func TestRepoContextAtNoRemote(t *testing.T) {
 	configureGitHubHost(t)
 	dir := initGitRepository(t, "")

--- a/internal/gh/testing.go
+++ b/internal/gh/testing.go
@@ -1,6 +1,9 @@
 package gh
 
-import "github.com/cli/go-gh/v2/pkg/repository"
+import (
+	"github.com/cli/go-gh/v2/pkg/api"
+	"github.com/cli/go-gh/v2/pkg/repository"
+)
 
 // SetTokenForHostFunc replaces the tokenForHost function for testing.
 // It returns a restore function for t.Cleanup.
@@ -8,6 +11,14 @@ func SetTokenForHostFunc(fn func(string) (string, string)) func() {
 	old := tokenForHost
 	tokenForHost = fn
 	return func() { tokenForHost = old }
+}
+
+// SetNewRESTClientFunc replaces REST client construction for testing.
+// It returns a restore function for t.Cleanup.
+func SetNewRESTClientFunc(fn func(string) (*api.RESTClient, error)) func() {
+	old := newRESTClient
+	newRESTClient = fn
+	return func() { newRESTClient = old }
 }
 
 // SetCurrentRepoFunc replaces repository discovery for testing.

--- a/internal/ghfake/ghfake.go
+++ b/internal/ghfake/ghfake.go
@@ -2,10 +2,16 @@ package ghfake
 
 import (
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/cli/go-gh/v2/pkg/repository"
 	"github.com/wimpysworld/tailor/internal/gh"
+	"github.com/wimpysworld/tailor/internal/testutil"
 )
 
 // FakeAuth installs a tokenForHost stub that returns the given token.
@@ -13,6 +19,31 @@ func FakeAuth(t *testing.T, token string) {
 	t.Helper()
 	restore := gh.SetTokenForHostFunc(func(string) (string, string) {
 		return token, "oauth_token"
+	})
+	t.Cleanup(restore)
+}
+
+// FakeUserAPI installs a REST client stub backed by a test server. GET /user
+// responds with the given status; on http.StatusOK it returns the login.
+func FakeUserAPI(t *testing.T, status int, login string) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/user") {
+			if status != http.StatusOK {
+				w.WriteHeader(status)
+				fmt.Fprint(w, `{"message":"error"}`)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"login":%q}`, login)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+	client := testutil.NewTestClient(t, server)
+	restore := gh.SetNewRESTClientFunc(func(string) (*api.RESTClient, error) {
+		return client, nil
 	})
 	t.Cleanup(restore)
 }

--- a/internal/measure/format.go
+++ b/internal/measure/format.go
@@ -3,6 +3,8 @@ package measure
 import (
 	"fmt"
 	"strings"
+
+	"github.com/wimpysworld/tailor/internal/termtext"
 )
 
 // labelWidth is the fixed column width for status labels in formatted output.
@@ -39,5 +41,7 @@ func writeResultLine(b *strings.Builder, label, path, detail string) {
 	if detail != "" {
 		path += " " + detail
 	}
-	fmt.Fprintf(b, "%-*s%s\n", labelWidth, label, path)
+	// Paths and details can carry values from .tailor.yml, so render
+	// control characters as visible escapes.
+	fmt.Fprintf(b, "%-*s%s\n", labelWidth, label, termtext.EscapeControlText(path))
 }

--- a/internal/measure/format_test.go
+++ b/internal/measure/format_test.go
@@ -74,6 +74,58 @@ func TestFormatOutputEmptyResults(t *testing.T) {
 	}
 }
 
+func TestFormatOutputEscapesControlCharacters(t *testing.T) {
+	tests := []struct {
+		name string
+		diff []DiffResult
+		want string
+	}{
+		{
+			name: "newline in swatch path",
+			diff: []DiffResult{{Path: "safe.yml\nmissing:        forged.yml", Category: ConfigOnly}},
+			want: "config-only:    safe.yml\\x0amissing:        forged.yml\n",
+		},
+		{
+			name: "carriage return in swatch path",
+			diff: []DiffResult{{Path: "safe.yml\rspoofed.yml", Category: ConfigOnly}},
+			want: "config-only:    safe.yml\\x0dspoofed.yml\n",
+		},
+		{
+			name: "ansi csi sequence in swatch path",
+			diff: []DiffResult{{Path: "\x1b[31mred.yml\x1b[0m", Category: ConfigOnly}},
+			want: "config-only:    \\x1b[31mred.yml\\x1b[0m\n",
+		},
+		{
+			name: "bare escape in swatch path",
+			diff: []DiffResult{{Path: "path\x1b.yml", Category: ConfigOnly}},
+			want: "config-only:    path\\x1b.yml\n",
+		},
+		{
+			name: "c1 control in swatch path",
+			diff: []DiffResult{{Path: "path\u009b.yml", Category: ConfigOnly}},
+			want: "config-only:    path\\u009b.yml\n",
+		},
+		{
+			name: "escape in detail",
+			diff: []DiffResult{{Path: "safe.yml", Category: ModeDiffers, Detail: "(config: \x1b[31mfirst-fit\x1b[0m, default: always)"}},
+			want: "mode-differs:   safe.yml (config: \\x1b[31mfirst-fit\\x1b[0m, default: always)\n",
+		},
+		{
+			name: "benign path unchanged",
+			diff: []DiffResult{{Path: ".github/dependabot.yml", Category: NotConfigured}},
+			want: "not-configured: .github/dependabot.yml\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatOutput(nil, tt.diff, true); got != tt.want {
+				t.Errorf("FormatOutput() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatOutputHealthOnlyWithConfig(t *testing.T) {
 	health := []HealthResult{
 		{Path: "LICENSE", Status: Present},

--- a/internal/measure/health.go
+++ b/internal/measure/health.go
@@ -111,6 +111,10 @@ const readmeFile = "README.md"
 // .tailor.yml limit in the config package.
 const maxLicenceSize = 1 << 20
 
+// errLicenceTooLarge marks a licence that exceeds maxLicenceSize, so the
+// health check can name the reason the file was not inspected.
+var errLicenceTooLarge = errors.New("licence exceeds maximum size of 1 MiB")
+
 // readLicence reads the licence file at path inside root for the
 // placeholder check. It returns an error when the file is not regular or
 // exceeds maxLicenceSize.
@@ -132,7 +136,7 @@ func readLicence(root *os.Root, path string) ([]byte, error) {
 		return nil, errors.New("licence is not a regular file")
 	}
 	if info.Size() > maxLicenceSize {
-		return nil, errors.New("licence exceeds maximum size of 1 MiB")
+		return nil, errLicenceTooLarge
 	}
 
 	data, err := io.ReadAll(io.LimitReader(file, maxLicenceSize+1))
@@ -140,7 +144,7 @@ func readLicence(root *os.Root, path string) ([]byte, error) {
 		return nil, fmt.Errorf("reading licence: %w", err)
 	}
 	if len(data) > maxLicenceSize {
-		return nil, errors.New("licence exceeds maximum size of 1 MiB")
+		return nil, errLicenceTooLarge
 	}
 	return data, nil
 }
@@ -160,7 +164,8 @@ func isRegularFile(root *os.Root, path string) bool {
 // README.md exist in dir as regular files; symlinks, paths whose parents
 // resolve outside dir, and other non-regular files count as absent. LICENSE
 // files containing unresolved placeholder tokens are reported as warnings
-// rather than present. A missing README.md is reported as a warning. Returns
+// rather than present, as are LICENSE files that exist but could not be
+// inspected. A missing README.md is reported as a warning. Returns
 // results sorted lexicographically by path within each status group
 // (missing, warning, present).
 func CheckHealth(dir string) []HealthResult {
@@ -187,7 +192,21 @@ func CheckHealth(dir string) []HealthResult {
 		}
 		if p == swatch.LicenseDestination {
 			data, err := readLicence(root, p)
-			if err == nil && hasUnresolvedPlaceholders(data) {
+			if err != nil {
+				// The licence exists but was not inspected, so present
+				// would overstate what the check verified. Warn instead.
+				detail := "(not inspected: read failed)"
+				if errors.Is(err, errLicenceTooLarge) {
+					detail = "(not inspected: exceeds 1 MiB)"
+				}
+				warning = append(warning, HealthResult{
+					Path:   p,
+					Status: Warning,
+					Detail: detail,
+				})
+				continue
+			}
+			if hasUnresolvedPlaceholders(data) {
 				warning = append(warning, HealthResult{
 					Path:   p,
 					Status: Warning,

--- a/internal/measure/health_test.go
+++ b/internal/measure/health_test.go
@@ -402,7 +402,7 @@ func TestCheckHealthLicenseHardening(t *testing.T) {
 			wantStatus: Missing,
 		},
 		{
-			name: "over-limit licence skips the placeholder check",
+			name: "over-limit licence warns as not inspected",
 			setup: func(t *testing.T, dir string) {
 				content := make([]byte, 1<<20+1)
 				copy(content, placeholderContent)
@@ -410,7 +410,8 @@ func TestCheckHealthLicenseHardening(t *testing.T) {
 					t.Fatalf("WriteFile: %v", err)
 				}
 			},
-			wantStatus: Present,
+			wantStatus: Warning,
+			wantDetail: "(not inspected: exceeds 1 MiB)",
 		},
 		{
 			name: "licence with placeholders warns",

--- a/internal/termtext/termtext.go
+++ b/internal/termtext/termtext.go
@@ -1,0 +1,32 @@
+// Package termtext renders untrusted text safely for terminal output.
+package termtext
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// EscapeControlText renders control characters as visible escapes so that
+// values from config or the GitHub API cannot inject terminal control
+// sequences into output. C0 controls and DEL render as \xNN; C1 and other
+// Unicode controls render as \uNNNN. Text without control characters passes
+// through unchanged.
+func EscapeControlText(input string) string {
+	if !strings.ContainsFunc(input, unicode.IsControl) {
+		return input
+	}
+	var b strings.Builder
+	b.Grow(len(input))
+	for _, r := range input {
+		switch {
+		case !unicode.IsControl(r):
+			b.WriteRune(r)
+		case r < 0x80:
+			fmt.Fprintf(&b, `\x%02x`, r)
+		default:
+			fmt.Fprintf(&b, `\u%04x`, r)
+		}
+	}
+	return b.String()
+}

--- a/internal/termtext/termtext_test.go
+++ b/internal/termtext/termtext_test.go
@@ -1,0 +1,60 @@
+package termtext
+
+import "testing"
+
+func TestEscapeControlText(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "benign text unchanged",
+			input: ".github/dependabot.yml",
+			want:  ".github/dependabot.yml",
+		},
+		{
+			name:  "newline",
+			input: "safe\ninjected",
+			want:  `safe\x0ainjected`,
+		},
+		{
+			name:  "carriage return",
+			input: "safe\rspoofed",
+			want:  `safe\x0dspoofed`,
+		},
+		{
+			name:  "ansi csi sequence",
+			input: "\x1b[31mred\x1b[0m",
+			want:  `\x1b[31mred\x1b[0m`,
+		},
+		{
+			name:  "bare escape",
+			input: "path\x1b",
+			want:  `path\x1b`,
+		},
+		{
+			name:  "delete",
+			input: "path\x7f",
+			want:  `path\x7f`,
+		},
+		{
+			name:  "c1 control",
+			input: "path\u009bspoofed",
+			want:  `path\u009bspoofed`,
+		},
+		{
+			name:  "non-control unicode unchanged",
+			input: "café",
+			want:  "café",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EscapeControlText(tt.input); got != tt.want {
+				t.Errorf("EscapeControlText(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/swatches/.github/ISSUE_TEMPLATE/config.yml
+++ b/swatches/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: 🛟 Support
-    url: {{SUPPORT_URL}}
+    url: "{{SUPPORT_URL}}"
     about: Check the support guide before opening an issue.
 #  - name: Code of Conduct Report
 #    url: https://yourproject.org/community-report/

--- a/swatches/.github/dependabot.yml
+++ b/swatches/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
         patterns:
           - "*"
 
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
   - package-ecosystem: "nix"
     directory: "/"
     schedule:


### PR DESCRIPTION
Fixes ten findings from a full-project code review. `gh.VerifyAuth` checks the token against the API before any local mutation runs. Repository detection works without local credentials and resolves one effective host per command. The Dependabot swatch gains the `gomod` ecosystem. The issue template swatch quotes `{{SUPPORT_URL}}` so the written file stays valid YAML. `measure` escapes terminal control characters in path and detail output through a new `internal/termtext` package. Label limits count runes rather than bytes. Topic comparison treats lists as unordered sets and rejects duplicates. `measure` warns on oversized or unreadable licence files instead of reporting them present. `runAlter` surfaces the underlying `config.Load` error. The `--recut` help text states its actual behaviour, and `docs/LINTING.md` matches the effective linter set.

Verified with `go test -count=1 ./...`, `go vet ./...`, and `golangci-lint run`; all pass with zero issues.
