### PR TITLE
fix(gh): prefer origin over upstream for repository discovery

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -227,6 +227,8 @@ A `license` key is included in `.tailor.yml` by default (`license: BlueOak-1.0.0
 
 **Repository settings resolution at `fit` time**: `fit` detects repository context by querying GitHub remotes in `<path>`. If a GitHub remote exists, the project has repository context. If no remote is found, no repository context exists. Repository context detection reads git remotes (via `go-gh`), so `git` must be present when a GitHub remote exists - which is always the case in practice, since the remote implies a git repository.
 
+When several remotes exist, Tailor prefers `origin`, then `github`, then `upstream`, then any other remote. This deliberately reverses the gh CLI order: Tailor manages the repository the user administers and pushes to, so in a fork clone the fork (`origin`) wins over the parent (`upstream`). A default repository recorded by `gh repo set-default` (the `remote.<name>.gh-resolved` git config) overrides this priority. This selection applies to every command that uses repository context (`fit`, `alter`, `baste`, `docket`).
+
 When repository context exists, `fit` queries the live repository configuration via `GET /repos/{owner}/{repo}` and the separate endpoints for security features and Actions workflow permissions. The live values populate the `repository` section. This prevents Tailor from changing features that the repository already configures. The `--description` flag takes precedence over the value from GitHub. `description` and `homepage` are omitted if empty. When no repository context exists, the built-in defaults from the embedded swatch are used. `DefaultConfig` normalises `description` and `homepage` to nil, so the generated config omits them.
 
 ```bash

--- a/internal/gh/repo.go
+++ b/internal/gh/repo.go
@@ -95,7 +95,7 @@ func repositoryFromRemotes(dir string) (repository.Repository, error) {
 	if bestPriority < 0 {
 		return repository.Repository{}, errors.New("unable to determine current repository")
 	}
-	if resolved, ok := resolvedRepository(dir, remotes); ok {
+	if resolved, ok := resolvedRepository(dir, remotes, acceptedHosts); ok {
 		return resolved, nil
 	}
 	return best, nil
@@ -104,7 +104,7 @@ func repositoryFromRemotes(dir string) (repository.Repository, error) {
 // resolvedRepository honours the remote resolution that `gh repo set-default`
 // stores in git config as remote.<name>.gh-resolved. A value of "base" selects
 // the remote's own repository; any other value names a repository directly.
-func resolvedRepository(dir string, remotes map[string]repository.Repository) (repository.Repository, bool) {
+func resolvedRepository(dir string, remotes map[string]repository.Repository, acceptedHosts []string) (repository.Repository, bool) {
 	output, err := exec.CommandContext(context.Background(), "git", "-C", dir,
 		"config", "--get-regexp", `^remote\..+\.gh-resolved$`).Output()
 	if err != nil {
@@ -127,7 +127,7 @@ func resolvedRepository(dir string, remotes map[string]repository.Repository) (r
 			repo = remote
 		} else {
 			parsed, parseErr := repository.Parse(value)
-			if parseErr != nil {
+			if parseErr != nil || !isKnownHost(parsed.Host, acceptedHosts) {
 				continue
 			}
 			repo = parsed

--- a/internal/gh/repo.go
+++ b/internal/gh/repo.go
@@ -61,6 +61,7 @@ func repositoryFromRemotes(dir string) (repository.Repository, error) {
 	defaultHost, _ := auth.DefaultHost()
 	acceptedHosts := append(auth.KnownHosts(), "github.com", defaultHost)
 	translator := ssh.NewTranslator()
+	remotes := map[string]repository.Repository{}
 	bestPriority := -1
 	var best repository.Repository
 	for line := range strings.Lines(string(output)) {
@@ -84,6 +85,7 @@ func repositoryFromRemotes(dir string) (repository.Repository, error) {
 		if parseErr != nil || !isKnownHost(repo.Host, acceptedHosts) {
 			continue
 		}
+		remotes[fields[0]] = repo
 		priority := remotePriority(fields[0])
 		if priority > bestPriority {
 			best = repo
@@ -93,7 +95,49 @@ func repositoryFromRemotes(dir string) (repository.Repository, error) {
 	if bestPriority < 0 {
 		return repository.Repository{}, errors.New("unable to determine current repository")
 	}
+	if resolved, ok := resolvedRepository(dir, remotes); ok {
+		return resolved, nil
+	}
 	return best, nil
+}
+
+// resolvedRepository honours the remote resolution that `gh repo set-default`
+// stores in git config as remote.<name>.gh-resolved. A value of "base" selects
+// the remote's own repository; any other value names a repository directly.
+func resolvedRepository(dir string, remotes map[string]repository.Repository) (repository.Repository, bool) {
+	output, err := exec.CommandContext(context.Background(), "git", "-C", dir,
+		"config", "--get-regexp", `^remote\..+\.gh-resolved$`).Output()
+	if err != nil {
+		return repository.Repository{}, false
+	}
+	bestPriority := -1
+	var best repository.Repository
+	for line := range strings.Lines(string(output)) {
+		key, value, found := strings.Cut(strings.TrimSpace(line), " ")
+		if !found {
+			continue
+		}
+		name := strings.TrimSuffix(strings.TrimPrefix(key, "remote."), ".gh-resolved")
+		var repo repository.Repository
+		if value == "base" {
+			remote, known := remotes[name]
+			if !known {
+				continue
+			}
+			repo = remote
+		} else {
+			parsed, parseErr := repository.Parse(value)
+			if parseErr != nil {
+				continue
+			}
+			repo = parsed
+		}
+		if priority := remotePriority(name); priority > bestPriority {
+			best = repo
+			bestPriority = priority
+		}
+	}
+	return best, bestPriority >= 0
 }
 
 func isKnownHost(host string, knownHosts []string) bool {
@@ -105,13 +149,16 @@ func isKnownHost(host string, knownHosts []string) bool {
 	return false
 }
 
+// remotePriority ranks origin above upstream: tailor manages the repository
+// the user administers and pushes to, so in a fork clone the fork wins over
+// the parent repository. This inverts the gh CLI ordering deliberately.
 func remotePriority(name string) int {
 	switch strings.ToLower(name) {
-	case "upstream":
+	case "origin":
 		return 3
 	case "github":
 		return 2
-	case "origin":
+	case "upstream":
 		return 1
 	default:
 		return 0

--- a/internal/gh/repo_test.go
+++ b/internal/gh/repo_test.go
@@ -150,6 +150,52 @@ func TestRepoContextAtNoAuthenticatedHosts(t *testing.T) {
 	}
 }
 
+func TestRepoContextAtPrefersOriginOverUpstream(t *testing.T) {
+	configureGitHubHost(t)
+	dir := initGitRepository(t, "https://github.com/wimpysworld/vecdecor.git")
+	runGit(t, dir, "remote", "add", "upstream", "https://github.com/soreau/pixdecor.git")
+
+	repo, ok, err := RepoContextAt(dir)
+	if err != nil {
+		t.Fatalf("RepoContextAt() error = %v", err)
+	}
+	want := Repo{Host: "github.com", Owner: "wimpysworld", Name: "vecdecor"}
+	if repo != want || !ok {
+		t.Errorf("RepoContextAt() = %+v, %v, want %+v, true", repo, ok, want)
+	}
+}
+
+func TestRepoContextAtHonoursSetDefaultBase(t *testing.T) {
+	configureGitHubHost(t)
+	dir := initGitRepository(t, "https://github.com/wimpysworld/vecdecor.git")
+	runGit(t, dir, "remote", "add", "upstream", "https://github.com/soreau/pixdecor.git")
+	runGit(t, dir, "config", "remote.upstream.gh-resolved", "base")
+
+	repo, ok, err := RepoContextAt(dir)
+	if err != nil {
+		t.Fatalf("RepoContextAt() error = %v", err)
+	}
+	want := Repo{Host: "github.com", Owner: "soreau", Name: "pixdecor"}
+	if repo != want || !ok {
+		t.Errorf("RepoContextAt() = %+v, %v, want %+v, true", repo, ok, want)
+	}
+}
+
+func TestRepoContextAtHonoursSetDefaultNamed(t *testing.T) {
+	configureGitHubHost(t)
+	dir := initGitRepository(t, "https://github.com/wimpysworld/vecdecor.git")
+	runGit(t, dir, "config", "remote.origin.gh-resolved", "another/project")
+
+	repo, ok, err := RepoContextAt(dir)
+	if err != nil {
+		t.Fatalf("RepoContextAt() error = %v", err)
+	}
+	want := Repo{Host: "github.com", Owner: "another", Name: "project"}
+	if repo != want || !ok {
+		t.Errorf("RepoContextAt() = %+v, %v, want %+v, true", repo, ok, want)
+	}
+}
+
 func TestRepoContextAtNoRemote(t *testing.T) {
 	configureGitHubHost(t)
 	dir := initGitRepository(t, "")

--- a/internal/gh/repo_test.go
+++ b/internal/gh/repo_test.go
@@ -196,6 +196,21 @@ func TestRepoContextAtHonoursSetDefaultNamed(t *testing.T) {
 	}
 }
 
+func TestRepoContextAtIgnoresSetDefaultUnacceptedHost(t *testing.T) {
+	configureGitHubHost(t)
+	dir := initGitRepository(t, "https://github.com/wimpysworld/vecdecor.git")
+	runGit(t, dir, "config", "remote.origin.gh-resolved", "evil.example.com/owner/name")
+
+	repo, ok, err := RepoContextAt(dir)
+	if err != nil {
+		t.Fatalf("RepoContextAt() error = %v", err)
+	}
+	want := Repo{Host: "github.com", Owner: "wimpysworld", Name: "vecdecor"}
+	if repo != want || !ok {
+		t.Errorf("RepoContextAt() = %+v, %v, want %+v, true", repo, ok, want)
+	}
+}
+
 func TestRepoContextAtNoRemote(t *testing.T) {
 	configureGitHubHost(t)
 	dir := initGitRepository(t, "")


### PR DESCRIPTION
In a fork clone, remotePriority ranked upstream above origin, so tailor targeted the parent repository instead of the user's fork. fit then hit 403/404 on admin-only settings endpoints and emitted misleading scope warnings.

Rank origin above github above upstream, reversing the gh CLI order: tailor manages the repository the user administers and pushes to. Add resolvedRepository to honour the remote.<name>.gh-resolved git config that gh repo set-default writes; "base" selects the remote's own repository, any other value is parsed as a repository reference. Document the priority order and the gh-resolved override in the fit repository-settings section of the specification.