### PR TITLE
refactor(test): retire AssertPtr in favour of AssertPtrEqual

### DIFF
--- a/internal/alter/alter_integration_test.go
+++ b/internal/alter/alter_integration_test.go
@@ -461,7 +461,7 @@ swatches:
 			}
 			if tt.wantWrite {
 				persisted := loadTestConfig(t, tc.Dir)
-				testutil.AssertPtr(t, persisted.Repository.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
+				testutil.AssertPtrEqual(t, persisted.Repository.VulnerabilityAlertsEnabled, new(true), "vulnerability_alerts_enabled")
 				if bytes.Equal(after, before) {
 					t.Error(".tailor.yml bytes did not change")
 				}
@@ -509,7 +509,7 @@ swatches:
 	requireContains(t, stderr, "warning: set vulnerability_alerts_enabled to true")
 
 	persisted := loadTestConfig(t, tc.Dir)
-	testutil.AssertPtr(t, persisted.Repository.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
+	testutil.AssertPtrEqual(t, persisted.Repository.VulnerabilityAlertsEnabled, new(true), "vulnerability_alerts_enabled")
 	for _, call := range tc.MutatingCalls() {
 		if strings.Contains(call.Path, "automated-security-fixes") {
 			t.Fatalf("automated security fixes API called after alert failure: %v", tc.MutatingCalls())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -98,22 +98,22 @@ func TestUnmarshalSpecYAML(t *testing.T) {
 	}
 
 	r := cfg.Repository
-	testutil.AssertPtr(t, r.HasWiki, false, false, "has_wiki")
-	testutil.AssertPtr(t, r.HasDiscussions, false, false, "has_discussions")
-	testutil.AssertPtr(t, r.HasProjects, false, false, "has_projects")
-	testutil.AssertPtr(t, r.HasIssues, false, true, "has_issues")
-	testutil.AssertPtr(t, r.AllowMergeCommit, false, false, "allow_merge_commit")
-	testutil.AssertPtr(t, r.AllowSquashMerge, false, true, "allow_squash_merge")
-	testutil.AssertPtr(t, r.AllowRebaseMerge, false, true, "allow_rebase_merge")
-	testutil.AssertPtr(t, r.SquashMergeCommitTitle, false, "PR_TITLE", "squash_merge_commit_title")
-	testutil.AssertPtr(t, r.SquashMergeCommitMessage, false, "PR_BODY", "squash_merge_commit_message")
-	testutil.AssertPtr(t, r.DeleteBranchOnMerge, false, true, "delete_branch_on_merge")
-	testutil.AssertPtr(t, r.AllowUpdateBranch, false, true, "allow_update_branch")
-	testutil.AssertPtr(t, r.AllowAutoMerge, false, false, "allow_auto_merge")
-	testutil.AssertPtr(t, r.WebCommitSignoffRequired, false, false, "web_commit_signoff_required")
-	testutil.AssertPtr(t, r.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertPtr(t, r.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertPtr(t, r.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
+	testutil.AssertPtrEqual(t, r.HasWiki, new(false), "has_wiki")
+	testutil.AssertPtrEqual(t, r.HasDiscussions, new(false), "has_discussions")
+	testutil.AssertPtrEqual(t, r.HasProjects, new(false), "has_projects")
+	testutil.AssertPtrEqual(t, r.HasIssues, new(true), "has_issues")
+	testutil.AssertPtrEqual(t, r.AllowMergeCommit, new(false), "allow_merge_commit")
+	testutil.AssertPtrEqual(t, r.AllowSquashMerge, new(true), "allow_squash_merge")
+	testutil.AssertPtrEqual(t, r.AllowRebaseMerge, new(true), "allow_rebase_merge")
+	testutil.AssertPtrEqual(t, r.SquashMergeCommitTitle, new("PR_TITLE"), "squash_merge_commit_title")
+	testutil.AssertPtrEqual(t, r.SquashMergeCommitMessage, new("PR_BODY"), "squash_merge_commit_message")
+	testutil.AssertPtrEqual(t, r.DeleteBranchOnMerge, new(true), "delete_branch_on_merge")
+	testutil.AssertPtrEqual(t, r.AllowUpdateBranch, new(true), "allow_update_branch")
+	testutil.AssertPtrEqual(t, r.AllowAutoMerge, new(false), "allow_auto_merge")
+	testutil.AssertPtrEqual(t, r.WebCommitSignoffRequired, new(false), "web_commit_signoff_required")
+	testutil.AssertPtrEqual(t, r.PrivateVulnerabilityReportEnabled, new(true), "private_vulnerability_reporting_enabled")
+	testutil.AssertPtrEqual(t, r.VulnerabilityAlertsEnabled, new(true), "vulnerability_alerts_enabled")
+	testutil.AssertPtrEqual(t, r.AutomatedSecurityFixesEnabled, new(true), "automated_security_fixes_enabled")
 
 	if len(cfg.Swatches) != 16 {
 		t.Fatalf("Swatches count = %d, want 16", len(cfg.Swatches))
@@ -185,9 +185,9 @@ func TestUnmarshalOptionalSecuritySettings(t *testing.T) {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
-	testutil.AssertPtr(t, cfg.Repository.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertPtr(t, cfg.Repository.VulnerabilityAlertsEnabled, false, false, "vulnerability_alerts_enabled")
-	testutil.AssertPtr(t, cfg.Repository.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
+	testutil.AssertPtrEqual(t, cfg.Repository.PrivateVulnerabilityReportEnabled, new(true), "private_vulnerability_reporting_enabled")
+	testutil.AssertPtrEqual(t, cfg.Repository.VulnerabilityAlertsEnabled, new(false), "vulnerability_alerts_enabled")
+	testutil.AssertPtrEqual(t, cfg.Repository.AutomatedSecurityFixesEnabled, new(true), "automated_security_fixes_enabled")
 }
 
 func TestRepositoryNilWhenAbsent(t *testing.T) {
@@ -265,8 +265,8 @@ swatches: []
 	}
 
 	r := cfg.Repository
-	testutil.AssertPtr(t, r.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
-	testutil.AssertPtr(t, r.CanApprovePullRequestReviews, false, false, "can_approve_pull_request_reviews")
+	testutil.AssertPtrEqual(t, r.DefaultWorkflowPermissions, new("read"), "default_workflow_permissions")
+	testutil.AssertPtrEqual(t, r.CanApprovePullRequestReviews, new(false), "can_approve_pull_request_reviews")
 
 	if r.Topics == nil {
 		t.Fatal("Topics is nil, want non-nil")
@@ -289,8 +289,8 @@ swatches: []
 	}
 
 	r := cfg.Repository
-	testutil.AssertPtr(t, r.DefaultWorkflowPermissions, true, "", "default_workflow_permissions")
-	testutil.AssertPtr(t, r.CanApprovePullRequestReviews, true, false, "can_approve_pull_request_reviews")
+	testutil.AssertPtrEqual(t, r.DefaultWorkflowPermissions, nil, "default_workflow_permissions")
+	testutil.AssertPtrEqual(t, r.CanApprovePullRequestReviews, nil, "can_approve_pull_request_reviews")
 
 	if r.Topics != nil {
 		t.Errorf("Topics = %v, want nil when omitted", *r.Topics)
@@ -342,8 +342,8 @@ func TestNewFieldsRoundTrip(t *testing.T) {
 	}
 
 	r := roundTripped.Repository
-	testutil.AssertPtr(t, r.DefaultWorkflowPermissions, false, "write", "default_workflow_permissions")
-	testutil.AssertPtr(t, r.CanApprovePullRequestReviews, false, true, "can_approve_pull_request_reviews")
+	testutil.AssertPtrEqual(t, r.DefaultWorkflowPermissions, new("write"), "default_workflow_permissions")
+	testutil.AssertPtrEqual(t, r.CanApprovePullRequestReviews, new(true), "can_approve_pull_request_reviews")
 
 	if r.Topics == nil {
 		t.Fatal("round-tripped Topics is nil")
@@ -511,8 +511,8 @@ swatches: []
 	}
 
 	r := cfg.Repository
-	testutil.AssertPtr(t, r.Description, false, "My project", "description")
-	testutil.AssertPtr(t, r.Homepage, false, "https://example.com", "homepage")
-	testutil.AssertPtr(t, r.MergeCommitTitle, false, "PR_TITLE", "merge_commit_title")
-	testutil.AssertPtr(t, r.MergeCommitMessage, false, "PR_BODY", "merge_commit_message")
+	testutil.AssertPtrEqual(t, r.Description, new("My project"), "description")
+	testutil.AssertPtrEqual(t, r.Homepage, new("https://example.com"), "homepage")
+	testutil.AssertPtrEqual(t, r.MergeCommitTitle, new("PR_TITLE"), "merge_commit_title")
+	testutil.AssertPtrEqual(t, r.MergeCommitMessage, new("PR_BODY"), "merge_commit_message")
 }

--- a/internal/config/generate_test.go
+++ b/internal/config/generate_test.go
@@ -37,32 +37,32 @@ func TestDefaultConfigMatchesEmbedded(t *testing.T) {
 	if got.Repository == nil {
 		t.Fatal("Repository is nil, want non-nil")
 	}
-	testutil.AssertPtr(t, got.Repository.HasWiki, false, false, "has_wiki")
-	testutil.AssertPtr(t, got.Repository.HasDiscussions, false, false, "has_discussions")
-	testutil.AssertPtr(t, got.Repository.HasProjects, false, false, "has_projects")
-	testutil.AssertPtr(t, got.Repository.HasIssues, false, true, "has_issues")
-	testutil.AssertPtr(t, got.Repository.AllowMergeCommit, false, false, "allow_merge_commit")
-	testutil.AssertPtr(t, got.Repository.AllowSquashMerge, false, true, "allow_squash_merge")
-	testutil.AssertPtr(t, got.Repository.AllowRebaseMerge, false, true, "allow_rebase_merge")
-	testutil.AssertPtr(t, got.Repository.SquashMergeCommitTitle, false, "PR_TITLE", "squash_merge_commit_title")
-	testutil.AssertPtr(t, got.Repository.SquashMergeCommitMessage, false, "PR_BODY", "squash_merge_commit_message")
-	testutil.AssertPtr(t, got.Repository.DeleteBranchOnMerge, false, true, "delete_branch_on_merge")
-	testutil.AssertPtr(t, got.Repository.AllowUpdateBranch, false, true, "allow_update_branch")
-	testutil.AssertPtr(t, got.Repository.AllowAutoMerge, false, true, "allow_auto_merge")
-	testutil.AssertPtr(t, got.Repository.WebCommitSignoffRequired, false, false, "web_commit_signoff_required")
-	testutil.AssertPtr(t, got.Repository.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertPtr(t, got.Repository.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertPtr(t, got.Repository.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
-	testutil.AssertPtr(t, got.Repository.DefaultWorkflowPermissions, false, "read", "default_workflow_permissions")
-	testutil.AssertPtr(t, got.Repository.CanApprovePullRequestReviews, false, false, "can_approve_pull_request_reviews")
+	testutil.AssertPtrEqual(t, got.Repository.HasWiki, new(false), "has_wiki")
+	testutil.AssertPtrEqual(t, got.Repository.HasDiscussions, new(false), "has_discussions")
+	testutil.AssertPtrEqual(t, got.Repository.HasProjects, new(false), "has_projects")
+	testutil.AssertPtrEqual(t, got.Repository.HasIssues, new(true), "has_issues")
+	testutil.AssertPtrEqual(t, got.Repository.AllowMergeCommit, new(false), "allow_merge_commit")
+	testutil.AssertPtrEqual(t, got.Repository.AllowSquashMerge, new(true), "allow_squash_merge")
+	testutil.AssertPtrEqual(t, got.Repository.AllowRebaseMerge, new(true), "allow_rebase_merge")
+	testutil.AssertPtrEqual(t, got.Repository.SquashMergeCommitTitle, new("PR_TITLE"), "squash_merge_commit_title")
+	testutil.AssertPtrEqual(t, got.Repository.SquashMergeCommitMessage, new("PR_BODY"), "squash_merge_commit_message")
+	testutil.AssertPtrEqual(t, got.Repository.DeleteBranchOnMerge, new(true), "delete_branch_on_merge")
+	testutil.AssertPtrEqual(t, got.Repository.AllowUpdateBranch, new(true), "allow_update_branch")
+	testutil.AssertPtrEqual(t, got.Repository.AllowAutoMerge, new(true), "allow_auto_merge")
+	testutil.AssertPtrEqual(t, got.Repository.WebCommitSignoffRequired, new(false), "web_commit_signoff_required")
+	testutil.AssertPtrEqual(t, got.Repository.PrivateVulnerabilityReportEnabled, new(true), "private_vulnerability_reporting_enabled")
+	testutil.AssertPtrEqual(t, got.Repository.VulnerabilityAlertsEnabled, new(true), "vulnerability_alerts_enabled")
+	testutil.AssertPtrEqual(t, got.Repository.AutomatedSecurityFixesEnabled, new(true), "automated_security_fixes_enabled")
+	testutil.AssertPtrEqual(t, got.Repository.DefaultWorkflowPermissions, new("read"), "default_workflow_permissions")
+	testutil.AssertPtrEqual(t, got.Repository.CanApprovePullRequestReviews, new(false), "can_approve_pull_request_reviews")
 	if got.Actions == nil {
 		t.Fatal("Actions is nil, want default policy")
 	}
-	testutil.AssertPtr(t, got.Actions.Enabled, false, true, "actions.enabled")
-	testutil.AssertPtr(t, got.Actions.AllowedActions, false, "selected", "actions.allowed_actions")
-	testutil.AssertPtr(t, got.Actions.SHAPinningRequired, false, false, "actions.sha_pinning_required")
-	testutil.AssertPtr(t, got.Actions.GitHubOwnedAllowed, false, true, "actions.github_owned_allowed")
-	testutil.AssertPtr(t, got.Actions.VerifiedAllowed, false, true, "actions.verified_allowed")
+	testutil.AssertPtrEqual(t, got.Actions.Enabled, new(true), "actions.enabled")
+	testutil.AssertPtrEqual(t, got.Actions.AllowedActions, new("selected"), "actions.allowed_actions")
+	testutil.AssertPtrEqual(t, got.Actions.SHAPinningRequired, new(false), "actions.sha_pinning_required")
+	testutil.AssertPtrEqual(t, got.Actions.GitHubOwnedAllowed, new(true), "actions.github_owned_allowed")
+	testutil.AssertPtrEqual(t, got.Actions.VerifiedAllowed, new(true), "actions.verified_allowed")
 	if got.Actions.PatternsAllowed == nil || !slices.Equal(*got.Actions.PatternsAllowed, approvedDefaultActionPatterns) {
 		t.Fatalf("actions.patterns_allowed = %v, want %v", got.Actions.PatternsAllowed, approvedDefaultActionPatterns)
 	}
@@ -250,23 +250,8 @@ func TestMergeRepoSettings(t *testing.T) {
 				t.Fatal("Repository was not replaced with live settings")
 			}
 
-			// Check Description.
-			if tt.wantDesc == nil {
-				if cfg.Repository.Description != nil {
-					t.Errorf("Description = %q, want nil", *cfg.Repository.Description)
-				}
-			} else {
-				testutil.AssertPtr(t, cfg.Repository.Description, false, *tt.wantDesc, "description")
-			}
-
-			// Check Homepage.
-			if tt.wantHome == nil {
-				if cfg.Repository.Homepage != nil {
-					t.Errorf("Homepage = %q, want nil", *cfg.Repository.Homepage)
-				}
-			} else {
-				testutil.AssertPtr(t, cfg.Repository.Homepage, false, *tt.wantHome, "homepage")
-			}
+			testutil.AssertPtrEqual(t, cfg.Repository.Description, tt.wantDesc, "description")
+			testutil.AssertPtrEqual(t, cfg.Repository.Homepage, tt.wantHome, "homepage")
 		})
 	}
 }
@@ -284,8 +269,8 @@ func TestMergeRepoSettingsPreservesMergeCommitFields(t *testing.T) {
 	cfg := &Config{License: "BlueOak-1.0.0"}
 	MergeRepoSettings(cfg, live, "")
 
-	testutil.AssertPtr(t, cfg.Repository.MergeCommitTitle, false, "PR_TITLE", "merge_commit_title")
-	testutil.AssertPtr(t, cfg.Repository.MergeCommitMessage, false, "PR_BODY", "merge_commit_message")
+	testutil.AssertPtrEqual(t, cfg.Repository.MergeCommitTitle, new("PR_TITLE"), "merge_commit_title")
+	testutil.AssertPtrEqual(t, cfg.Repository.MergeCommitMessage, new("PR_BODY"), "merge_commit_message")
 }
 
 func TestApplyRepoDefaults(t *testing.T) {

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -313,9 +313,9 @@ func TestMergeRepoSettingsAddsSecurityDefaults(t *testing.T) {
 		t.Fatal("expected changed=true for missing security settings")
 	}
 
-	testutil.AssertPtr(t, cfg.Repository.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertPtr(t, cfg.Repository.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertPtr(t, cfg.Repository.AutomatedSecurityFixesEnabled, false, true, "automated_security_fixes_enabled")
+	testutil.AssertPtrEqual(t, cfg.Repository.PrivateVulnerabilityReportEnabled, new(true), "private_vulnerability_reporting_enabled")
+	testutil.AssertPtrEqual(t, cfg.Repository.VulnerabilityAlertsEnabled, new(true), "vulnerability_alerts_enabled")
+	testutil.AssertPtrEqual(t, cfg.Repository.AutomatedSecurityFixesEnabled, new(true), "automated_security_fixes_enabled")
 }
 
 func TestMergeRepoSettingsPreservesExplicitFalseSecuritySettings(t *testing.T) {
@@ -329,9 +329,9 @@ func TestMergeRepoSettingsPreservesExplicitFalseSecuritySettings(t *testing.T) {
 		t.Fatal("expected changed=true for other missing repository settings")
 	}
 
-	testutil.AssertPtr(t, cfg.Repository.PrivateVulnerabilityReportEnabled, false, false, "private_vulnerability_reporting_enabled")
-	testutil.AssertPtr(t, cfg.Repository.VulnerabilityAlertsEnabled, false, false, "vulnerability_alerts_enabled")
-	testutil.AssertPtr(t, cfg.Repository.AutomatedSecurityFixesEnabled, false, false, "automated_security_fixes_enabled")
+	testutil.AssertPtrEqual(t, cfg.Repository.PrivateVulnerabilityReportEnabled, new(false), "private_vulnerability_reporting_enabled")
+	testutil.AssertPtrEqual(t, cfg.Repository.VulnerabilityAlertsEnabled, new(false), "vulnerability_alerts_enabled")
+	testutil.AssertPtrEqual(t, cfg.Repository.AutomatedSecurityFixesEnabled, new(false), "automated_security_fixes_enabled")
 }
 
 func TestMergeRepoSettingsFullRepository(t *testing.T) {
@@ -383,11 +383,11 @@ func TestMergeActionsNilActions(t *testing.T) {
 	}
 
 	// The default policy is "selected", so selected-only fields merge too.
-	testutil.AssertPtr(t, cfg.Actions.Enabled, false, true, "enabled")
-	testutil.AssertPtr(t, cfg.Actions.AllowedActions, false, "selected", "allowed_actions")
-	testutil.AssertPtr(t, cfg.Actions.SHAPinningRequired, false, false, "sha_pinning_required")
-	testutil.AssertPtr(t, cfg.Actions.GitHubOwnedAllowed, false, true, "github_owned_allowed")
-	testutil.AssertPtr(t, cfg.Actions.VerifiedAllowed, false, true, "verified_allowed")
+	testutil.AssertPtrEqual(t, cfg.Actions.Enabled, new(true), "enabled")
+	testutil.AssertPtrEqual(t, cfg.Actions.AllowedActions, new("selected"), "allowed_actions")
+	testutil.AssertPtrEqual(t, cfg.Actions.SHAPinningRequired, new(false), "sha_pinning_required")
+	testutil.AssertPtrEqual(t, cfg.Actions.GitHubOwnedAllowed, new(true), "github_owned_allowed")
+	testutil.AssertPtrEqual(t, cfg.Actions.VerifiedAllowed, new(true), "verified_allowed")
 	if cfg.Actions.PatternsAllowed == nil || len(*cfg.Actions.PatternsAllowed) == 0 {
 		t.Error("patterns_allowed should be set from defaults")
 	}
@@ -401,10 +401,10 @@ func TestMergeActionsSkipsSelectedFieldsForOtherPolicies(t *testing.T) {
 		t.Fatal("expected changed=true for missing non-selected fields")
 	}
 
-	testutil.AssertPtr(t, cfg.Actions.Enabled, false, true, "enabled")
-	testutil.AssertPtr(t, cfg.Actions.AllowedActions, false, "all", "allowed_actions")
-	testutil.AssertPtr(t, cfg.Actions.GitHubOwnedAllowed, true, false, "github_owned_allowed")
-	testutil.AssertPtr(t, cfg.Actions.VerifiedAllowed, true, false, "verified_allowed")
+	testutil.AssertPtrEqual(t, cfg.Actions.Enabled, new(true), "enabled")
+	testutil.AssertPtrEqual(t, cfg.Actions.AllowedActions, new("all"), "allowed_actions")
+	testutil.AssertPtrEqual(t, cfg.Actions.GitHubOwnedAllowed, nil, "github_owned_allowed")
+	testutil.AssertPtrEqual(t, cfg.Actions.VerifiedAllowed, nil, "verified_allowed")
 	if cfg.Actions.PatternsAllowed != nil {
 		t.Error("patterns_allowed should remain nil for non-selected policy")
 	}

--- a/internal/config/ruleset_test.go
+++ b/internal/config/ruleset_test.go
@@ -274,33 +274,33 @@ func TestLoadRejectsInvalidRuleset(t *testing.T) {
 
 func TestDefaultConfigRuleset(t *testing.T) {
 	r := defaultConfig(t).Ruleset
-	testutil.AssertPtr(t, r.Enforcement, false, "active", "enforcement")
+	testutil.AssertPtrEqual(t, r.Enforcement, new("active"), "enforcement")
 	if r.BypassActors == nil || len(*r.BypassActors) != 1 {
 		t.Fatalf("bypass_actors = %v, want one actor", r.BypassActors)
 	}
 	a := (*r.BypassActors)[0]
-	testutil.AssertPtr(t, a.ActorID, false, 5, "actor_id")
-	testutil.AssertPtr(t, a.ActorType, false, "RepositoryRole", "actor_type")
-	testutil.AssertPtr(t, a.BypassMode, false, "always", "bypass_mode")
+	testutil.AssertPtrEqual(t, a.ActorID, new(5), "actor_id")
+	testutil.AssertPtrEqual(t, a.ActorType, new("RepositoryRole"), "actor_type")
+	testutil.AssertPtrEqual(t, a.BypassMode, new("always"), "bypass_mode")
 	if r.Conditions == nil || r.Conditions.RefName == nil || r.Conditions.RefName.Include == nil || !reflect.DeepEqual(*r.Conditions.RefName.Include, []string{"~DEFAULT_BRANCH"}) {
 		t.Errorf("include = %v, want [~DEFAULT_BRANCH]", r.Conditions)
 	}
 	if r.Conditions.RefName.Exclude == nil || len(*r.Conditions.RefName.Exclude) != 0 {
 		t.Errorf("exclude = %v, want empty list", r.Conditions.RefName.Exclude)
 	}
-	testutil.AssertPtr(t, r.Rules.Deletion, false, true, "rules.deletion")
-	testutil.AssertPtr(t, r.Rules.NonFastForward, false, true, "rules.non_fast_forward")
-	testutil.AssertPtr(t, r.Rules.Creation, false, false, "rules.creation")
-	testutil.AssertPtr(t, r.Rules.PullRequest.Enabled, false, true, "rules.pull_request.enabled")
-	testutil.AssertPtr(t, r.Rules.PullRequest.Parameters.RequiredApprovingReviewCount, false, 1, "required_approving_review_count")
+	testutil.AssertPtrEqual(t, r.Rules.Deletion, new(true), "rules.deletion")
+	testutil.AssertPtrEqual(t, r.Rules.NonFastForward, new(true), "rules.non_fast_forward")
+	testutil.AssertPtrEqual(t, r.Rules.Creation, new(false), "rules.creation")
+	testutil.AssertPtrEqual(t, r.Rules.PullRequest.Enabled, new(true), "rules.pull_request.enabled")
+	testutil.AssertPtrEqual(t, r.Rules.PullRequest.Parameters.RequiredApprovingReviewCount, new(1), "required_approving_review_count")
 	if !reflect.DeepEqual(*r.Rules.PullRequest.Parameters.AllowedMergeMethods, []string{"squash", "rebase"}) {
 		t.Errorf("allowed_merge_methods = %v, want [squash rebase]", *r.Rules.PullRequest.Parameters.AllowedMergeMethods)
 	}
-	testutil.AssertPtr(t, r.Rules.RequiredStatusChecks.Enabled, false, false, "rules.required_status_checks.enabled")
+	testutil.AssertPtrEqual(t, r.Rules.RequiredStatusChecks.Enabled, new(false), "rules.required_status_checks.enabled")
 	if r.Rules.RequiredStatusChecks.Parameters.RequiredStatusChecks == nil || len(*r.Rules.RequiredStatusChecks.Parameters.RequiredStatusChecks) != 0 {
 		t.Errorf("required_status_checks = %v, want empty list", r.Rules.RequiredStatusChecks.Parameters.RequiredStatusChecks)
 	}
-	testutil.AssertPtr(t, r.Rules.CodeScanning.Enabled, false, false, "rules.code_scanning.enabled")
+	testutil.AssertPtrEqual(t, r.Rules.CodeScanning.Enabled, new(false), "rules.code_scanning.enabled")
 	if !reflect.DeepEqual(*r.Rules.CodeScanning.Parameters.CodeScanningTools, []model.RulesetCodeScanningTool{codeQLTool()}) {
 		t.Errorf("code_scanning_tools = %v, want [CodeQL errors high_or_higher]", *r.Rules.CodeScanning.Parameters.CodeScanningTools)
 	}
@@ -351,7 +351,7 @@ func TestMergeDefaultsFillsRulesetFields(t *testing.T) {
 		t.Fatalf("MergeDefaults() error: %v", err)
 	}
 	r := cfg.Ruleset
-	testutil.AssertPtr(t, r.Enforcement, false, "disabled", "enforcement")
+	testutil.AssertPtrEqual(t, r.Enforcement, new("disabled"), "enforcement")
 	if len(*r.BypassActors) != 0 {
 		t.Errorf("bypass_actors = %v, want the explicit empty list", *r.BypassActors)
 	}
@@ -361,16 +361,16 @@ func TestMergeDefaultsFillsRulesetFields(t *testing.T) {
 	if r.Conditions.RefName.Exclude == nil || len(*r.Conditions.RefName.Exclude) != 0 {
 		t.Errorf("exclude = %v, want the default empty list", r.Conditions.RefName.Exclude)
 	}
-	testutil.AssertPtr(t, r.Rules.Deletion, false, false, "rules.deletion")
-	testutil.AssertPtr(t, r.Rules.NonFastForward, false, true, "rules.non_fast_forward")
-	testutil.AssertPtr(t, r.Rules.PullRequest.Enabled, false, false, "rules.pull_request.enabled")
-	testutil.AssertPtr(t, r.Rules.PullRequest.Parameters.RequiredApprovingReviewCount, false, 1, "required_approving_review_count")
-	testutil.AssertPtr(t, r.Rules.RequiredStatusChecks.Enabled, false, true, "rules.required_status_checks.enabled")
-	testutil.AssertPtr(t, r.Rules.RequiredStatusChecks.Parameters.StrictRequiredStatusChecksPolicy, false, false, "strict_required_status_checks_policy")
+	testutil.AssertPtrEqual(t, r.Rules.Deletion, new(false), "rules.deletion")
+	testutil.AssertPtrEqual(t, r.Rules.NonFastForward, new(true), "rules.non_fast_forward")
+	testutil.AssertPtrEqual(t, r.Rules.PullRequest.Enabled, new(false), "rules.pull_request.enabled")
+	testutil.AssertPtrEqual(t, r.Rules.PullRequest.Parameters.RequiredApprovingReviewCount, new(1), "required_approving_review_count")
+	testutil.AssertPtrEqual(t, r.Rules.RequiredStatusChecks.Enabled, new(true), "rules.required_status_checks.enabled")
+	testutil.AssertPtrEqual(t, r.Rules.RequiredStatusChecks.Parameters.StrictRequiredStatusChecksPolicy, new(false), "strict_required_status_checks_policy")
 	if !reflect.DeepEqual(*r.Rules.RequiredStatusChecks.Parameters.RequiredStatusChecks, []model.RulesetStatusCheck{{Context: "lint"}}) {
 		t.Errorf("required_status_checks = %v, want the explicit list", *r.Rules.RequiredStatusChecks.Parameters.RequiredStatusChecks)
 	}
-	testutil.AssertPtr(t, r.Rules.CodeScanning.Enabled, false, false, "rules.code_scanning.enabled")
+	testutil.AssertPtrEqual(t, r.Rules.CodeScanning.Enabled, new(false), "rules.code_scanning.enabled")
 	if !reflect.DeepEqual(*r.Rules.CodeScanning.Parameters.CodeScanningTools, []model.RulesetCodeScanningTool{codeQLTool()}) {
 		t.Errorf("code_scanning_tools = %v, want the default list", *r.Rules.CodeScanning.Parameters.CodeScanningTools)
 	}
@@ -415,26 +415,26 @@ func TestMergeRulesetSetup(t *testing.T) {
 	}
 	MergeRulesetSetup(cfg, live)
 	r := cfg.Ruleset
-	testutil.AssertPtr(t, r.Enforcement, false, "disabled", "enforcement")
+	testutil.AssertPtrEqual(t, r.Enforcement, new("disabled"), "enforcement")
 	if len(*r.BypassActors) != 0 {
 		t.Errorf("bypass_actors = %v, want the live empty list", *r.BypassActors)
 	}
 	if !reflect.DeepEqual(*r.Conditions.RefName.Exclude, []string{"refs/heads/wip/*"}) {
 		t.Errorf("exclude = %v, want the live list", *r.Conditions.RefName.Exclude)
 	}
-	testutil.AssertPtr(t, r.Rules.Creation, false, true, "rules.creation")
-	testutil.AssertPtr(t, r.Rules.Deletion, false, false, "rules.deletion")
-	testutil.AssertPtr(t, r.Rules.NonFastForward, false, true, "rules.non_fast_forward")
-	testutil.AssertPtr(t, r.Rules.PullRequest.Enabled, false, false, "rules.pull_request.enabled")
+	testutil.AssertPtrEqual(t, r.Rules.Creation, new(true), "rules.creation")
+	testutil.AssertPtrEqual(t, r.Rules.Deletion, new(false), "rules.deletion")
+	testutil.AssertPtrEqual(t, r.Rules.NonFastForward, new(true), "rules.non_fast_forward")
+	testutil.AssertPtrEqual(t, r.Rules.PullRequest.Enabled, new(false), "rules.pull_request.enabled")
 	// The live ruleset carries no pull request rule, so the built-in
 	// parameters stay in the config for the day the rule is enabled.
-	testutil.AssertPtr(t, r.Rules.PullRequest.Parameters.RequiredApprovingReviewCount, false, 1, "required_approving_review_count")
-	testutil.AssertPtr(t, r.Rules.RequiredStatusChecks.Enabled, false, true, "rules.required_status_checks.enabled")
-	testutil.AssertPtr(t, r.Rules.RequiredStatusChecks.Parameters.StrictRequiredStatusChecksPolicy, false, true, "strict_required_status_checks_policy")
+	testutil.AssertPtrEqual(t, r.Rules.PullRequest.Parameters.RequiredApprovingReviewCount, new(1), "required_approving_review_count")
+	testutil.AssertPtrEqual(t, r.Rules.RequiredStatusChecks.Enabled, new(true), "rules.required_status_checks.enabled")
+	testutil.AssertPtrEqual(t, r.Rules.RequiredStatusChecks.Parameters.StrictRequiredStatusChecksPolicy, new(true), "strict_required_status_checks_policy")
 	if !reflect.DeepEqual(*r.Rules.RequiredStatusChecks.Parameters.RequiredStatusChecks, []model.RulesetStatusCheck{{Context: "lint", IntegrationID: new(15368)}}) {
 		t.Errorf("required_status_checks = %v, want the live list", *r.Rules.RequiredStatusChecks.Parameters.RequiredStatusChecks)
 	}
-	testutil.AssertPtr(t, r.Rules.CodeScanning.Enabled, false, true, "rules.code_scanning.enabled")
+	testutil.AssertPtrEqual(t, r.Rules.CodeScanning.Enabled, new(true), "rules.code_scanning.enabled")
 	wantTools := []model.RulesetCodeScanningTool{{Tool: "CodeQL", AlertsThreshold: "all", SecurityAlertsThreshold: "critical"}}
 	if !reflect.DeepEqual(*r.Rules.CodeScanning.Parameters.CodeScanningTools, wantTools) {
 		t.Errorf("code_scanning_tools = %v, want the live list", *r.Rules.CodeScanning.Parameters.CodeScanningTools)
@@ -448,7 +448,7 @@ func TestMergeRulesetSetupKeepsBuiltInCodeScanningTools(t *testing.T) {
 	// list stays in the config for the day the rule is enabled.
 	cfg := &Config{Ruleset: defaultConfig(t).Ruleset}
 	MergeRulesetSetup(cfg, &model.RulesetSettings{Rules: &model.RulesetRules{CodeScanning: &model.RulesetCodeScanning{Enabled: new(false)}}})
-	testutil.AssertPtr(t, cfg.Ruleset.Rules.CodeScanning.Enabled, false, false, "rules.code_scanning.enabled")
+	testutil.AssertPtrEqual(t, cfg.Ruleset.Rules.CodeScanning.Enabled, new(false), "rules.code_scanning.enabled")
 	if !reflect.DeepEqual(*cfg.Ruleset.Rules.CodeScanning.Parameters.CodeScanningTools, []model.RulesetCodeScanningTool{codeQLTool()}) {
 		t.Errorf("code_scanning_tools = %v, want the built-in list", *cfg.Ruleset.Rules.CodeScanning.Parameters.CodeScanningTools)
 	}
@@ -460,9 +460,9 @@ func TestMergeRulesetSetupSkipsUnmanagedEnforcement(t *testing.T) {
 	if !MergeRulesetSetup(cfg, live) {
 		t.Error("MergeRulesetSetup() = false, want true for an evaluate enforcement")
 	}
-	testutil.AssertPtr(t, cfg.Ruleset.Enforcement, false, "active", "enforcement")
-	testutil.AssertPtr(t, cfg.Ruleset.Rules.Creation, false, true, "rules.creation")
-	testutil.AssertPtr(t, live.Enforcement, false, "evaluate", "live enforcement")
+	testutil.AssertPtrEqual(t, cfg.Ruleset.Enforcement, new("active"), "enforcement")
+	testutil.AssertPtrEqual(t, cfg.Ruleset.Rules.Creation, new(true), "rules.creation")
+	testutil.AssertPtrEqual(t, live.Enforcement, new("evaluate"), "live enforcement")
 	if err := ValidateRuleset(cfg); err != nil {
 		t.Errorf("ValidateRuleset() error after merge: %v", err)
 	}
@@ -470,7 +470,7 @@ func TestMergeRulesetSetupSkipsUnmanagedEnforcement(t *testing.T) {
 	if MergeRulesetSetup(cfg, &model.RulesetSettings{Enforcement: new("disabled")}) {
 		t.Error("MergeRulesetSetup() = true, want false for a disabled enforcement")
 	}
-	testutil.AssertPtr(t, cfg.Ruleset.Enforcement, false, "disabled", "enforcement")
+	testutil.AssertPtrEqual(t, cfg.Ruleset.Enforcement, new("disabled"), "enforcement")
 }
 
 func TestWriteRulesetSection(t *testing.T) {

--- a/internal/config/setup_test.go
+++ b/internal/config/setup_test.go
@@ -173,19 +173,19 @@ func TestDefaultConfigSetupSections(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultConfig() error: %v", err)
 	}
-	testutil.AssertPtr(t, got.Repository.SecretScanning, false, "enabled", "secret_scanning")
-	testutil.AssertPtr(t, got.Repository.SecretScanningPushProtection, false, "enabled", "secret_scanning_push_protection")
-	testutil.AssertPtr(t, got.Repository.SecretScanningNonProviderPatterns, false, "enabled", "secret_scanning_non_provider_patterns")
+	testutil.AssertPtrEqual(t, got.Repository.SecretScanning, new("enabled"), "secret_scanning")
+	testutil.AssertPtrEqual(t, got.Repository.SecretScanningPushProtection, new("enabled"), "secret_scanning_push_protection")
+	testutil.AssertPtrEqual(t, got.Repository.SecretScanningNonProviderPatterns, new("enabled"), "secret_scanning_non_provider_patterns")
 	if got.CodeScanning == nil || got.CodeQuality == nil {
 		t.Fatal("default code_scanning or code_quality section is nil")
 	}
-	testutil.AssertPtr(t, got.CodeScanning.State, false, "configured", "code_scanning.state")
-	testutil.AssertPtr(t, got.CodeScanning.QuerySuite, false, "default", "code_scanning.query_suite")
-	testutil.AssertPtr(t, got.CodeScanning.ThreatModel, false, "remote", "code_scanning.threat_model")
+	testutil.AssertPtrEqual(t, got.CodeScanning.State, new("configured"), "code_scanning.state")
+	testutil.AssertPtrEqual(t, got.CodeScanning.QuerySuite, new("default"), "code_scanning.query_suite")
+	testutil.AssertPtrEqual(t, got.CodeScanning.ThreatModel, new("remote"), "code_scanning.threat_model")
 	if got.CodeScanning.Languages == nil || len(*got.CodeScanning.Languages) != 0 {
 		t.Errorf("code_scanning.languages = %v, want empty list", got.CodeScanning.Languages)
 	}
-	testutil.AssertPtr(t, got.CodeQuality.State, false, "not-configured", "code_quality.state")
+	testutil.AssertPtrEqual(t, got.CodeQuality.State, new("not-configured"), "code_quality.state")
 	if got.CodeQuality.Languages == nil || len(*got.CodeQuality.Languages) != 0 {
 		t.Errorf("code_quality.languages = %v, want empty list", got.CodeQuality.Languages)
 	}
@@ -200,19 +200,19 @@ func TestMergeDefaultsAddsSetupSections(t *testing.T) {
 	if !changed {
 		t.Fatal("expected changed=true for an empty config")
 	}
-	testutil.AssertPtr(t, cfg.Repository.SecretScanning, false, "enabled", "secret_scanning")
-	testutil.AssertPtr(t, cfg.Repository.SecretScanningPushProtection, false, "enabled", "secret_scanning_push_protection")
-	testutil.AssertPtr(t, cfg.Repository.SecretScanningNonProviderPatterns, false, "enabled", "secret_scanning_non_provider_patterns")
+	testutil.AssertPtrEqual(t, cfg.Repository.SecretScanning, new("enabled"), "secret_scanning")
+	testutil.AssertPtrEqual(t, cfg.Repository.SecretScanningPushProtection, new("enabled"), "secret_scanning_push_protection")
+	testutil.AssertPtrEqual(t, cfg.Repository.SecretScanningNonProviderPatterns, new("enabled"), "secret_scanning_non_provider_patterns")
 	if cfg.CodeScanning == nil || cfg.CodeQuality == nil {
 		t.Fatal("merged config is missing a setup section")
 	}
-	testutil.AssertPtr(t, cfg.CodeScanning.State, false, "configured", "code_scanning.state")
-	testutil.AssertPtr(t, cfg.CodeScanning.QuerySuite, false, "default", "code_scanning.query_suite")
-	testutil.AssertPtr(t, cfg.CodeScanning.ThreatModel, false, "remote", "code_scanning.threat_model")
+	testutil.AssertPtrEqual(t, cfg.CodeScanning.State, new("configured"), "code_scanning.state")
+	testutil.AssertPtrEqual(t, cfg.CodeScanning.QuerySuite, new("default"), "code_scanning.query_suite")
+	testutil.AssertPtrEqual(t, cfg.CodeScanning.ThreatModel, new("remote"), "code_scanning.threat_model")
 	if cfg.CodeScanning.Languages == nil || len(*cfg.CodeScanning.Languages) != 0 {
 		t.Errorf("code_scanning.languages = %v, want empty list", cfg.CodeScanning.Languages)
 	}
-	testutil.AssertPtr(t, cfg.CodeQuality.State, false, "not-configured", "code_quality.state")
+	testutil.AssertPtrEqual(t, cfg.CodeQuality.State, new("not-configured"), "code_quality.state")
 	if cfg.CodeQuality.Languages == nil || len(*cfg.CodeQuality.Languages) != 0 {
 		t.Errorf("code_quality.languages = %v, want empty list", cfg.CodeQuality.Languages)
 	}
@@ -227,12 +227,12 @@ func TestMergeDefaultsKeepsExistingSetupEntries(t *testing.T) {
 	if _, err := MergeDefaults(cfg); err != nil {
 		t.Fatalf("MergeDefaults() error: %v", err)
 	}
-	testutil.AssertPtr(t, cfg.CodeScanning.State, false, "not-configured", "code_scanning.state")
-	testutil.AssertPtr(t, cfg.CodeScanning.QuerySuite, false, "default", "code_scanning.query_suite")
+	testutil.AssertPtrEqual(t, cfg.CodeScanning.State, new("not-configured"), "code_scanning.state")
+	testutil.AssertPtrEqual(t, cfg.CodeScanning.QuerySuite, new("default"), "code_scanning.query_suite")
 	if cfg.CodeScanning.Languages == nil || len(*cfg.CodeScanning.Languages) != 1 {
 		t.Errorf("code_scanning.languages = %v, want [go]", cfg.CodeScanning.Languages)
 	}
-	testutil.AssertPtr(t, cfg.CodeQuality.State, false, "configured", "code_quality.state")
+	testutil.AssertPtrEqual(t, cfg.CodeQuality.State, new("configured"), "code_quality.state")
 	if cfg.CodeQuality.Languages == nil || len(*cfg.CodeQuality.Languages) != 0 {
 		t.Errorf("code_quality.languages = %v, want empty list", cfg.CodeQuality.Languages)
 	}
@@ -319,7 +319,7 @@ func TestWriteSetupSectionsRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}
-	testutil.AssertPtr(t, loaded.CodeScanning.QuerySuite, false, "extended", "code_scanning.query_suite")
+	testutil.AssertPtrEqual(t, loaded.CodeScanning.QuerySuite, new("extended"), "code_scanning.query_suite")
 	if loaded.CodeScanning.Languages == nil || len(*loaded.CodeScanning.Languages) != 1 || (*loaded.CodeScanning.Languages)[0] != "go" {
 		t.Errorf("code_scanning.languages = %v, want [go]", loaded.CodeScanning.Languages)
 	}
@@ -336,13 +336,13 @@ func TestMergeSetupWritesEmptyLanguages(t *testing.T) {
 	})
 	MergeCodeQualitySetup(cfg, &model.CodeQualitySettings{State: new("configured"), Languages: &[]string{"go"}})
 
-	testutil.AssertPtr(t, cfg.CodeScanning.State, false, "configured", "code_scanning.state")
-	testutil.AssertPtr(t, cfg.CodeScanning.QuerySuite, false, "extended", "code_scanning.query_suite")
-	testutil.AssertPtr(t, cfg.CodeScanning.ThreatModel, false, "remote_and_local", "code_scanning.threat_model")
+	testutil.AssertPtrEqual(t, cfg.CodeScanning.State, new("configured"), "code_scanning.state")
+	testutil.AssertPtrEqual(t, cfg.CodeScanning.QuerySuite, new("extended"), "code_scanning.query_suite")
+	testutil.AssertPtrEqual(t, cfg.CodeScanning.ThreatModel, new("remote_and_local"), "code_scanning.threat_model")
 	if cfg.CodeScanning.Languages == nil || len(*cfg.CodeScanning.Languages) != 0 {
 		t.Errorf("code_scanning.languages = %v, want empty list", cfg.CodeScanning.Languages)
 	}
-	testutil.AssertPtr(t, cfg.CodeQuality.State, false, "configured", "code_quality.state")
+	testutil.AssertPtrEqual(t, cfg.CodeQuality.State, new("configured"), "code_quality.state")
 	if cfg.CodeQuality.Languages == nil || len(*cfg.CodeQuality.Languages) != 0 {
 		t.Errorf("code_quality.languages = %v, want empty list", cfg.CodeQuality.Languages)
 	}

--- a/internal/gh/codequality_test.go
+++ b/internal/gh/codequality_test.go
@@ -32,7 +32,7 @@ func TestReadCodeQualitySetup(t *testing.T) {
 			if err != nil {
 				return
 			}
-			testutil.AssertPtr(t, got.State, false, "not-configured", "state")
+			testutil.AssertPtrEqual(t, got.State, new("not-configured"), "state")
 			if got.Languages == nil || len(*got.Languages) != 1 || (*got.Languages)[0] != "go" {
 				t.Fatalf("languages = %v, want [go]", got.Languages)
 			}

--- a/internal/gh/codescanning_test.go
+++ b/internal/gh/codescanning_test.go
@@ -61,9 +61,9 @@ func TestReadCodeScanningSetup(t *testing.T) {
 			if err != nil {
 				return
 			}
-			testutil.AssertPtr(t, got.State, false, "not-configured", "state")
-			testutil.AssertPtr(t, got.QuerySuite, false, "default", "query_suite")
-			testutil.AssertPtr(t, got.ThreatModel, false, "remote", "threat_model")
+			testutil.AssertPtrEqual(t, got.State, new("not-configured"), "state")
+			testutil.AssertPtrEqual(t, got.QuerySuite, new("default"), "query_suite")
+			testutil.AssertPtrEqual(t, got.ThreatModel, new("remote"), "threat_model")
 			if got.Languages == nil || len(*got.Languages) != 2 {
 				t.Fatalf("languages = %v, want [actions go]", got.Languages)
 			}
@@ -125,16 +125,16 @@ func TestReadSetupLeavesEmptyFieldsNil(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadCodeScanningSetup() error: %v", err)
 	}
-	testutil.AssertPtr(t, scanning.State, false, "not-configured", "state")
-	testutil.AssertPtr(t, scanning.QuerySuite, true, "", "query_suite")
-	testutil.AssertPtr(t, scanning.ThreatModel, true, "", "threat_model")
+	testutil.AssertPtrEqual(t, scanning.State, new("not-configured"), "state")
+	testutil.AssertPtrEqual(t, scanning.QuerySuite, nil, "query_suite")
+	testutil.AssertPtrEqual(t, scanning.ThreatModel, nil, "threat_model")
 
 	qualityServer := setupServer(t, "/repos/acme/widget/code-quality/setup", http.StatusOK, `{"languages":[]}`, nil)
 	quality, err := ReadCodeQualitySetup(testutil.NewTestClient(t, qualityServer), "acme", "widget")
 	if err != nil {
 		t.Fatalf("ReadCodeQualitySetup() error: %v", err)
 	}
-	testutil.AssertPtr(t, quality.State, true, "", "state")
+	testutil.AssertPtrEqual(t, quality.State, nil, "state")
 }
 
 func TestApplyCodeScanningSetupSendsNothingWhenEmpty(t *testing.T) {

--- a/internal/gh/ruleset_test.go
+++ b/internal/gh/ruleset_test.go
@@ -119,7 +119,7 @@ func TestReadTailorRuleset(t *testing.T) {
 			if stub.ReadQuery != "includes_parents=false" {
 				t.Errorf("read query = %q, want parents excluded", stub.ReadQuery)
 			}
-			testutil.AssertPtr(t, live.Enforcement, false, "disabled", "enforcement")
+			testutil.AssertPtrEqual(t, live.Enforcement, new("disabled"), "enforcement")
 			wantActors := []model.RulesetBypassActor{
 				{ActorID: new(5), ActorType: new("RepositoryRole"), BypassMode: new("always")},
 				{ActorType: new("DeployKey"), BypassMode: new("exempt")},
@@ -131,29 +131,29 @@ func TestReadTailorRuleset(t *testing.T) {
 				t.Errorf("conditions = %+v", *live.Conditions.RefName)
 			}
 			rules := live.Rules
-			testutil.AssertPtr(t, rules.Creation, false, false, "rules.creation")
-			testutil.AssertPtr(t, rules.Deletion, false, true, "rules.deletion")
-			testutil.AssertPtr(t, rules.NonFastForward, false, true, "rules.non_fast_forward")
-			testutil.AssertPtr(t, rules.PullRequest.Enabled, false, true, "rules.pull_request.enabled")
+			testutil.AssertPtrEqual(t, rules.Creation, new(false), "rules.creation")
+			testutil.AssertPtrEqual(t, rules.Deletion, new(true), "rules.deletion")
+			testutil.AssertPtrEqual(t, rules.NonFastForward, new(true), "rules.non_fast_forward")
+			testutil.AssertPtrEqual(t, rules.PullRequest.Enabled, new(true), "rules.pull_request.enabled")
 			p := rules.PullRequest.Parameters
-			testutil.AssertPtr(t, p.RequiredApprovingReviewCount, false, 1, "required_approving_review_count")
-			testutil.AssertPtr(t, p.DismissStaleReviewsOnPush, false, true, "dismiss_stale_reviews_on_push")
-			testutil.AssertPtr(t, p.RequireCodeOwnerReview, false, false, "require_code_owner_review")
-			testutil.AssertPtr(t, p.RequireLastPushApproval, false, false, "require_last_push_approval")
-			testutil.AssertPtr(t, p.RequiredReviewThreadResolution, false, true, "required_review_thread_resolution")
-			testutil.AssertPtr(t, p.RequireExtraApprovalForUnattributedChanges, false, true, "require_extra_approval_for_unattributed_changes")
+			testutil.AssertPtrEqual(t, p.RequiredApprovingReviewCount, new(1), "required_approving_review_count")
+			testutil.AssertPtrEqual(t, p.DismissStaleReviewsOnPush, new(true), "dismiss_stale_reviews_on_push")
+			testutil.AssertPtrEqual(t, p.RequireCodeOwnerReview, new(false), "require_code_owner_review")
+			testutil.AssertPtrEqual(t, p.RequireLastPushApproval, new(false), "require_last_push_approval")
+			testutil.AssertPtrEqual(t, p.RequiredReviewThreadResolution, new(true), "required_review_thread_resolution")
+			testutil.AssertPtrEqual(t, p.RequireExtraApprovalForUnattributedChanges, new(true), "require_extra_approval_for_unattributed_changes")
 			if !reflect.DeepEqual(*p.AllowedMergeMethods, []string{"squash", "rebase"}) {
 				t.Errorf("allowed_merge_methods = %v", *p.AllowedMergeMethods)
 			}
-			testutil.AssertPtr(t, rules.RequiredStatusChecks.Enabled, false, true, "rules.required_status_checks.enabled")
+			testutil.AssertPtrEqual(t, rules.RequiredStatusChecks.Enabled, new(true), "rules.required_status_checks.enabled")
 			checks := rules.RequiredStatusChecks.Parameters
-			testutil.AssertPtr(t, checks.StrictRequiredStatusChecksPolicy, false, true, "strict_required_status_checks_policy")
-			testutil.AssertPtr(t, checks.DoNotEnforceOnCreate, false, false, "do_not_enforce_on_create")
+			testutil.AssertPtrEqual(t, checks.StrictRequiredStatusChecksPolicy, new(true), "strict_required_status_checks_policy")
+			testutil.AssertPtrEqual(t, checks.DoNotEnforceOnCreate, new(false), "do_not_enforce_on_create")
 			wantChecks := []model.RulesetStatusCheck{{Context: "Sentinel 👁️"}, {Context: "lint", IntegrationID: new(15368)}}
 			if !reflect.DeepEqual(*checks.RequiredStatusChecks, wantChecks) {
 				t.Errorf("required_status_checks = %+v, want %+v", *checks.RequiredStatusChecks, wantChecks)
 			}
-			testutil.AssertPtr(t, rules.CodeScanning.Enabled, false, true, "rules.code_scanning.enabled")
+			testutil.AssertPtrEqual(t, rules.CodeScanning.Enabled, new(true), "rules.code_scanning.enabled")
 			wantTools := []model.RulesetCodeScanningTool{{Tool: "CodeQL", AlertsThreshold: "errors", SecurityAlertsThreshold: "high_or_higher"}}
 			if !reflect.DeepEqual(*rules.CodeScanning.Parameters.CodeScanningTools, wantTools) {
 				t.Errorf("code_scanning_tools = %+v, want %+v", *rules.CodeScanning.Parameters.CodeScanningTools, wantTools)
@@ -180,7 +180,7 @@ func TestReadTailorRulesetAbsentRulesAreDisabled(t *testing.T) {
 		"required_status_checks":  live.Rules.RequiredStatusChecks.Enabled,
 		"code_scanning":           live.Rules.CodeScanning.Enabled,
 	} {
-		testutil.AssertPtr(t, value, false, false, name)
+		testutil.AssertPtrEqual(t, value, new(false), name)
 	}
 	if live.Rules.PullRequest.Parameters != nil || live.Rules.RequiredStatusChecks.Parameters != nil || live.Rules.CodeScanning.Parameters != nil {
 		t.Error("absent rules carry parameters")
@@ -198,7 +198,7 @@ func TestCodeScanningFromJSONWithoutParameters(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			rule := codeScanningFromJSON(raw)
-			testutil.AssertPtr(t, rule.Enabled, false, true, "enabled")
+			testutil.AssertPtrEqual(t, rule.Enabled, new(true), "enabled")
 			if rule.Parameters != nil {
 				t.Errorf("parameters = %+v, want nil", rule.Parameters)
 			}

--- a/internal/gh/settings_test.go
+++ b/internal/gh/settings_test.go
@@ -53,10 +53,8 @@ func TestReadRepoSettings(t *testing.T) {
 		repoJSON    string
 		wfPermsJSON string
 		// expected field checks
-		wantDesc       string
-		wantDescNil    bool
-		wantHome       string
-		wantHomeNil    bool
+		wantDesc       *string
+		wantHome       *string
 		wantWiki       bool
 		wantDisc       bool
 		wantProj       bool
@@ -80,8 +78,8 @@ func TestReadRepoSettings(t *testing.T) {
 			name:           "all fields populated",
 			repoJSON:       fullRepoJSON,
 			wfPermsJSON:    wfPermsWriteJSON,
-			wantDesc:       "A tailor for your repos",
-			wantHome:       "https://tailor.dev",
+			wantDesc:       new("A tailor for your repos"),
+			wantHome:       new("https://tailor.dev"),
 			wantWiki:       false,
 			wantDisc:       true,
 			wantProj:       false,
@@ -123,8 +121,8 @@ func TestReadRepoSettings(t *testing.T) {
 				"web_commit_signoff_required": true
 			}`,
 			wfPermsJSON:    wfPermsReadJSON,
-			wantDesc:       "",
-			wantHome:       "",
+			wantDesc:       new(""),
+			wantHome:       new(""),
 			wantWiki:       true,
 			wantDisc:       false,
 			wantProj:       true,
@@ -167,29 +165,29 @@ func TestReadRepoSettings(t *testing.T) {
 			}
 
 			// description and homepage
-			testutil.AssertPtr(t, settings.Description, tt.wantDescNil, tt.wantDesc, "description")
-			testutil.AssertPtr(t, settings.Homepage, tt.wantHomeNil, tt.wantHome, "homepage")
+			testutil.AssertPtrEqual(t, settings.Description, tt.wantDesc, "description")
+			testutil.AssertPtrEqual(t, settings.Homepage, tt.wantHome, "homepage")
 
 			// bool fields
-			testutil.AssertPtr(t, settings.HasWiki, false, tt.wantWiki, "has_wiki")
-			testutil.AssertPtr(t, settings.HasDiscussions, false, tt.wantDisc, "has_discussions")
-			testutil.AssertPtr(t, settings.HasProjects, false, tt.wantProj, "has_projects")
-			testutil.AssertPtr(t, settings.HasIssues, false, tt.wantIssues, "has_issues")
-			testutil.AssertPtr(t, settings.AllowMergeCommit, false, tt.wantMerge, "allow_merge_commit")
-			testutil.AssertPtr(t, settings.AllowSquashMerge, false, tt.wantSquash, "allow_squash_merge")
-			testutil.AssertPtr(t, settings.AllowRebaseMerge, false, tt.wantRebase, "allow_rebase_merge")
-			testutil.AssertPtr(t, settings.DeleteBranchOnMerge, false, tt.wantDelete, "delete_branch_on_merge")
-			testutil.AssertPtr(t, settings.AllowUpdateBranch, false, tt.wantUpdate, "allow_update_branch")
-			testutil.AssertPtr(t, settings.AllowAutoMerge, false, tt.wantAuto, "allow_auto_merge")
-			testutil.AssertPtr(t, settings.WebCommitSignoffRequired, false, tt.wantSignoff, "web_commit_signoff_required")
-			testutil.AssertPtr(t, settings.CanApprovePullRequestReviews, false, tt.wantCanApprove, "can_approve_pull_request_reviews")
+			testutil.AssertPtrEqual(t, settings.HasWiki, new(tt.wantWiki), "has_wiki")
+			testutil.AssertPtrEqual(t, settings.HasDiscussions, new(tt.wantDisc), "has_discussions")
+			testutil.AssertPtrEqual(t, settings.HasProjects, new(tt.wantProj), "has_projects")
+			testutil.AssertPtrEqual(t, settings.HasIssues, new(tt.wantIssues), "has_issues")
+			testutil.AssertPtrEqual(t, settings.AllowMergeCommit, new(tt.wantMerge), "allow_merge_commit")
+			testutil.AssertPtrEqual(t, settings.AllowSquashMerge, new(tt.wantSquash), "allow_squash_merge")
+			testutil.AssertPtrEqual(t, settings.AllowRebaseMerge, new(tt.wantRebase), "allow_rebase_merge")
+			testutil.AssertPtrEqual(t, settings.DeleteBranchOnMerge, new(tt.wantDelete), "delete_branch_on_merge")
+			testutil.AssertPtrEqual(t, settings.AllowUpdateBranch, new(tt.wantUpdate), "allow_update_branch")
+			testutil.AssertPtrEqual(t, settings.AllowAutoMerge, new(tt.wantAuto), "allow_auto_merge")
+			testutil.AssertPtrEqual(t, settings.WebCommitSignoffRequired, new(tt.wantSignoff), "web_commit_signoff_required")
+			testutil.AssertPtrEqual(t, settings.CanApprovePullRequestReviews, new(tt.wantCanApprove), "can_approve_pull_request_reviews")
 
 			// string fields (always non-nil)
-			testutil.AssertPtr(t, settings.DefaultWorkflowPermissions, false, tt.wantWfPerms, "default_workflow_permissions")
-			testutil.AssertPtr(t, settings.SquashMergeCommitTitle, false, tt.wantSqTitle, "squash_merge_commit_title")
-			testutil.AssertPtr(t, settings.SquashMergeCommitMessage, false, tt.wantSqMsg, "squash_merge_commit_message")
-			testutil.AssertPtr(t, settings.MergeCommitTitle, false, tt.wantMcTitle, "merge_commit_title")
-			testutil.AssertPtr(t, settings.MergeCommitMessage, false, tt.wantMcMsg, "merge_commit_message")
+			testutil.AssertPtrEqual(t, settings.DefaultWorkflowPermissions, new(tt.wantWfPerms), "default_workflow_permissions")
+			testutil.AssertPtrEqual(t, settings.SquashMergeCommitTitle, new(tt.wantSqTitle), "squash_merge_commit_title")
+			testutil.AssertPtrEqual(t, settings.SquashMergeCommitMessage, new(tt.wantSqMsg), "squash_merge_commit_message")
+			testutil.AssertPtrEqual(t, settings.MergeCommitTitle, new(tt.wantMcTitle), "merge_commit_title")
+			testutil.AssertPtrEqual(t, settings.MergeCommitMessage, new(tt.wantMcMsg), "merge_commit_message")
 
 			// topics
 			if tt.wantTopics == nil {
@@ -247,13 +245,13 @@ func TestReadRepoSettingsIgnoresGitHubActionsEnvironment(t *testing.T) {
 		t.Errorf("ReadRepoSettings() warnings = %v, want none", warnings)
 	}
 
-	testutil.AssertPtr(t, settings.AllowAutoMerge, false, false, "allow_auto_merge")
-	testutil.AssertPtr(t, settings.AllowRebaseMerge, false, false, "allow_rebase_merge")
-	testutil.AssertPtr(t, settings.AllowSquashMerge, false, false, "allow_squash_merge")
-	testutil.AssertPtr(t, settings.AllowUpdateBranch, false, false, "allow_update_branch")
-	testutil.AssertPtr(t, settings.DeleteBranchOnMerge, false, false, "delete_branch_on_merge")
-	testutil.AssertPtr(t, settings.SquashMergeCommitMessage, false, "", "squash_merge_commit_message")
-	testutil.AssertPtr(t, settings.SquashMergeCommitTitle, false, "", "squash_merge_commit_title")
+	testutil.AssertPtrEqual(t, settings.AllowAutoMerge, new(false), "allow_auto_merge")
+	testutil.AssertPtrEqual(t, settings.AllowRebaseMerge, new(false), "allow_rebase_merge")
+	testutil.AssertPtrEqual(t, settings.AllowSquashMerge, new(false), "allow_squash_merge")
+	testutil.AssertPtrEqual(t, settings.AllowUpdateBranch, new(false), "allow_update_branch")
+	testutil.AssertPtrEqual(t, settings.DeleteBranchOnMerge, new(false), "delete_branch_on_merge")
+	testutil.AssertPtrEqual(t, settings.SquashMergeCommitMessage, new(""), "squash_merge_commit_message")
+	testutil.AssertPtrEqual(t, settings.SquashMergeCommitTitle, new(""), "squash_merge_commit_title")
 }
 
 func TestReadRepoSettingsRepoAPIError(t *testing.T) {
@@ -294,7 +292,7 @@ func TestReadRepoSettingsWFPerms403GracefulDegradation(t *testing.T) {
 		t.Errorf("CanApprovePullRequestReviews = %v, want nil", *settings.CanApprovePullRequestReviews)
 	}
 	// Other fields should be populated.
-	testutil.AssertPtr(t, settings.Description, false, "A tailor for your repos", "description")
+	testutil.AssertPtrEqual(t, settings.Description, new("A tailor for your repos"), "description")
 }
 
 func TestReadRepoSettingsAll403GracefulDegradation(t *testing.T) {
@@ -330,8 +328,8 @@ func TestReadRepoSettingsAll403GracefulDegradation(t *testing.T) {
 		t.Errorf("expected 4 warnings, got %d", len(warnings))
 	}
 	// Core repo fields should still be populated.
-	testutil.AssertPtr(t, settings.Description, false, "A tailor for your repos", "description")
-	testutil.AssertPtr(t, settings.HasWiki, false, false, "has_wiki")
+	testutil.AssertPtrEqual(t, settings.Description, new("A tailor for your repos"), "description")
+	testutil.AssertPtrEqual(t, settings.HasWiki, new(false), "has_wiki")
 }
 
 func TestReadRepoSettingsNon403StillFails(t *testing.T) {
@@ -381,9 +379,9 @@ func TestReadRepoSettingsSecurityFeatures(t *testing.T) {
 	if len(warnings) != 0 {
 		t.Fatalf("warnings = %v, want none", warnings)
 	}
-	testutil.AssertPtr(t, settings.PrivateVulnerabilityReportEnabled, false, true, "private_vulnerability_reporting_enabled")
-	testutil.AssertPtr(t, settings.VulnerabilityAlertsEnabled, false, true, "vulnerability_alerts_enabled")
-	testutil.AssertPtr(t, settings.AutomatedSecurityFixesEnabled, false, false, "automated_security_fixes_enabled")
+	testutil.AssertPtrEqual(t, settings.PrivateVulnerabilityReportEnabled, new(true), "private_vulnerability_reporting_enabled")
+	testutil.AssertPtrEqual(t, settings.VulnerabilityAlertsEnabled, new(true), "vulnerability_alerts_enabled")
+	testutil.AssertPtrEqual(t, settings.AutomatedSecurityFixesEnabled, new(false), "automated_security_fixes_enabled")
 }
 
 func TestReadRepoSettingsSecurityFeature404HandlingForAdmin(t *testing.T) {
@@ -407,9 +405,9 @@ func TestReadRepoSettingsSecurityFeature404HandlingForAdmin(t *testing.T) {
 	if len(warnings) != 1 {
 		t.Fatalf("warnings = %v, want private reporting access warning", warnings)
 	}
-	testutil.AssertPtr(t, settings.PrivateVulnerabilityReportEnabled, true, false, "private_vulnerability_reporting_enabled")
-	testutil.AssertPtr(t, settings.VulnerabilityAlertsEnabled, false, false, "vulnerability_alerts_enabled")
-	testutil.AssertPtr(t, settings.AutomatedSecurityFixesEnabled, false, false, "automated_security_fixes_enabled")
+	testutil.AssertPtrEqual(t, settings.PrivateVulnerabilityReportEnabled, nil, "private_vulnerability_reporting_enabled")
+	testutil.AssertPtrEqual(t, settings.VulnerabilityAlertsEnabled, new(false), "vulnerability_alerts_enabled")
+	testutil.AssertPtrEqual(t, settings.AutomatedSecurityFixesEnabled, new(false), "automated_security_fixes_enabled")
 }
 
 func TestReadRepoSettingsSecurityFeature404UnknownWithoutConfirmedAdminAccess(t *testing.T) {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -76,25 +76,6 @@ func WriteConfig(t *testing.T, dir, content string) {
 	WriteFile(t, dir, ".tailor.yml", content)
 }
 
-// AssertPtr checks a pointer field. When wantNil is true, it expects got to
-// be nil. Otherwise it expects got to be non-nil with value wantVal.
-func AssertPtr[T comparable](t *testing.T, got *T, wantNil bool, wantVal T, field string) {
-	t.Helper()
-	if wantNil {
-		if got != nil {
-			t.Errorf("%s = %#v, want nil", field, *got)
-		}
-		return
-	}
-	if got == nil {
-		t.Errorf("%s is nil, want %#v", field, wantVal)
-		return
-	}
-	if *got != wantVal {
-		t.Errorf("%s = %#v, want %#v", field, *got, wantVal)
-	}
-}
-
 // AssertPtrEqual checks a pointer field against a pointer expectation. When
 // want is nil, it expects got to be nil. Otherwise it expects got to be
 // non-nil with the value that want points to.

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -140,22 +140,12 @@ func TestWriteConfigCreatesFile(t *testing.T) {
 	}
 }
 
-func TestAssertPtrBool(t *testing.T) {
-	val := true
-	AssertPtr(t, &val, false, true, "bool_field")
-	AssertPtr(t, nil, true, false, "bool_field")
-}
-
-func TestAssertPtrString(t *testing.T) {
-	val := "read"
-	AssertPtr(t, &val, false, "read", "string_field")
-	AssertPtr(t, nil, true, "", "string_field")
-}
-
 func TestAssertPtrEqual(t *testing.T) {
 	val := "read"
 	AssertPtrEqual(t, &val, &val, "string_field")
+	AssertPtrEqual(t, &val, new("read"), "string_field")
 	AssertPtrEqual[string](t, nil, nil, "string_field")
 	flag := true
 	AssertPtrEqual(t, &flag, new(true), "bool_field")
+	AssertPtrEqual[bool](t, nil, nil, "bool_field")
 }


### PR DESCRIPTION
AssertPtr took a nil flag and a value for one optional expectation, and AssertPtrEqual already expressed the same check with one pointer. The 188 call sites now pass new(value) or nil, and the paired wantDescNil and wantHomeNil table fields in settings_test.go fold into pointer fields. The two if/else blocks in generate_test.go become one call each.